### PR TITLE
Multi-tenant UX: switcher dropdown, run pinning, activity filter

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -102,8 +102,10 @@ function registerIpcHandlers() {
   ipcMain.handle("openagents:set-active-provider", (_event, id: ProviderId) =>
     store.setActiveProvider(id),
   );
-  ipcMain.handle("openagents:start-run", (_event, agentSlug: string) =>
-    store.startRun(agentSlug),
+  ipcMain.handle(
+    "openagents:start-run",
+    (_event, agentSlug: string, options?: { tenantId?: string | null }) =>
+      store.startRun(agentSlug, options),
   );
   ipcMain.handle("openagents:get-run", (_event, id: string) => store.getRun(id));
   ipcMain.handle(

--- a/apps/desktop/electron/preload.mts
+++ b/apps/desktop/electron/preload.mts
@@ -1,5 +1,9 @@
 import { contextBridge, ipcRenderer } from "electron";
-import type { OpenAgentsApi, ProviderId } from "@openagents/agent-sdk";
+import type {
+  OpenAgentsApi,
+  ProviderId,
+  StartRunOptions,
+} from "@openagents/agent-sdk";
 
 const api: OpenAgentsApi = {
   getAppState: () => ipcRenderer.invoke("openagents:get-app-state"),
@@ -12,8 +16,8 @@ const api: OpenAgentsApi = {
     ipcRenderer.invoke("openagents:install-agent", agentId),
   setActiveProvider: (id: ProviderId) =>
     ipcRenderer.invoke("openagents:set-active-provider", id),
-  startRun: (agentSlug: string) =>
-    ipcRenderer.invoke("openagents:start-run", agentSlug),
+  startRun: (agentSlug: string, options?: StartRunOptions) =>
+    ipcRenderer.invoke("openagents:start-run", agentSlug, options),
   getRun: (id: string) => ipcRenderer.invoke("openagents:get-run", id),
   confirmRun: (runId: string, phrase: string) =>
     ipcRenderer.invoke("openagents:confirm-run", runId, phrase),

--- a/apps/desktop/electron/state.ts
+++ b/apps/desktop/electron/state.ts
@@ -22,6 +22,7 @@ import type {
   RunDataSource,
   RunGraphApi,
   RunLlmApi,
+  StartRunOptions,
   TenantRecord,
 } from "@openagents/agent-sdk";
 import {
@@ -293,7 +294,10 @@ export class AppStateStore {
     return this.getAppState();
   }
 
-  async startRun(agentSlug: string): Promise<RunRecord> {
+  async startRun(
+    agentSlug: string,
+    options: StartRunOptions = {},
+  ): Promise<RunRecord> {
     const queued = await this.serialize(async () => {
       const persisted = await this.read();
       const agent = persisted.installedAgents.find(
@@ -310,7 +314,31 @@ export class AppStateStore {
         providers[0];
       const providerId = activeProvider?.id ?? persisted.activeProviderId;
       const model = activeProvider?.defaultModel;
+
+      // Resolve the effective tenant at queue time:
+      //   - explicit null  -> synthetic for this run regardless of active tenant
+      //   - explicit id    -> validate it exists and pin it
+      //   - omitted        -> default to currently-active tenant (if any)
+      let pinnedTenantId: string | null;
+      if (options.tenantId === null) {
+        pinnedTenantId = null;
+      } else if (typeof options.tenantId === "string") {
+        const exists = persisted.tenants.some((tenant) => tenant.id === options.tenantId);
+        if (!exists) {
+          throw new Error(`Tenant not connected: ${options.tenantId}`);
+        }
+        pinnedTenantId = options.tenantId;
+      } else {
+        pinnedTenantId = persisted.activeTenantId ?? null;
+      }
+
       const queuedRun = createQueuedRun({ agent, providerId, model });
+      if (pinnedTenantId) {
+        queuedRun.tenantId = pinnedTenantId;
+        queuedRun.dataSource = "graph";
+      } else {
+        queuedRun.dataSource = "synthetic";
+      }
 
       await this.write({
         ...persisted,
@@ -449,13 +477,13 @@ export class AppStateStore {
     return createOllamaLlm(options);
   }
 
-  private async buildGraph(): Promise<{
+  private async buildGraph(pinnedTenantId?: string): Promise<{
     graph: RunGraphApi;
     dataSource: RunDataSource;
     tenantId?: string;
   }> {
     const persisted = await this.read();
-    const tenantId = persisted.activeTenantId;
+    const tenantId = pinnedTenantId ?? persisted.activeTenantId;
     const tenant = tenantId
       ? persisted.tenants.find((t) => t.id === tenantId)
       : undefined;
@@ -500,7 +528,7 @@ export class AppStateStore {
     try {
       const driver = input.agent.mode === "write" ? executePlan : executeRun;
       const llm = await this.buildLlm(input.providerId, input.model);
-      const selection = await this.buildGraph();
+      const selection = await this.buildGraph(input.run.tenantId);
       const stampedRun = this.stampDataSource(input.run, selection);
       await this.persistRunSnapshot(stampedRun);
       await driver({
@@ -527,7 +555,7 @@ export class AppStateStore {
   }): Promise<void> {
     try {
       const llm = await this.buildLlm(input.providerId, input.model);
-      const selection = await this.buildGraph();
+      const selection = await this.buildGraph(input.run.tenantId);
       await executeApply({
         run: input.run,
         agent: input.agent,

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { NavLink, useNavigate } from "react-router";
+import { NavLink } from "react-router";
 import type { ReactNode } from "react";
 import {
   IconAgents,
@@ -8,12 +8,12 @@ import {
   IconLogo,
   IconHardDrive,
   IconCommand,
-  IconChevronUpDown,
   IconChevronDown,
 } from "./icons";
 import { StatusDot } from "./Pill";
 import { Avatar } from "./Avatar";
 import { Sparkline } from "./Sparkline";
+import { TenantSwitcher } from "./TenantSwitcher";
 import { useAppState } from "../state";
 
 interface NavItem {
@@ -71,11 +71,7 @@ function NavRow({ item }: { item: NavItem }) {
 
 export function Sidebar({ onOpenPalette }: { onOpenPalette?: () => void }) {
   const { state } = useAppState();
-  const navigate = useNavigate();
   const active = state.providers.find((p) => p.id === state.activeProviderId);
-  const activeTenant = state.activeTenantId
-    ? state.tenants.find((tenant) => tenant.id === state.activeTenantId)
-    : undefined;
   const mainNav: NavItem[] = [
     {
       to: "/",
@@ -116,27 +112,8 @@ export function Sidebar({ onOpenPalette }: { onOpenPalette?: () => void }) {
         <span className="ml-auto inline-flex h-1.5 w-1.5 animate-pulse-soft rounded-full bg-[var(--color-success)]" />
       </div>
 
-      {/* Tenant switcher card */}
-      <button
-        onClick={() => navigate("/settings")}
-        className="mx-2.5 mt-1 flex items-center gap-2.5 rounded-xl bg-[var(--color-surface)] px-2.5 py-2 text-left ring-1 ring-[var(--color-border-soft)] transition-colors hover:bg-[var(--color-surface-hover)]"
-      >
-        <Avatar name={activeTenant?.displayName ?? "Synthetic"} size={28} />
-        <div className="min-w-0 flex-1 leading-tight">
-          <div className="truncate text-[12.5px] font-semibold text-[var(--color-text)]">
-            {activeTenant?.displayName ?? "Synthetic data"}
-          </div>
-          <div className="mt-0.5 flex items-center gap-1 text-[10px] text-[var(--color-text-muted)]">
-            <StatusDot tone={activeTenant ? "success" : "muted"} />
-            <span>
-              {activeTenant
-                ? activeTenant.username
-                : "Manage tenants in Settings"}
-            </span>
-          </div>
-        </div>
-        <IconChevronUpDown size={12} className="text-[var(--color-text-muted)]" />
-      </button>
+      {/* Tenant switcher */}
+      <TenantSwitcher />
 
       {/* Command palette */}
       <button

--- a/apps/desktop/src/components/TenantSwitcher.tsx
+++ b/apps/desktop/src/components/TenantSwitcher.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router";
+import { Avatar } from "./Avatar";
+import { StatusDot } from "./Pill";
+import {
+  IconCheck,
+  IconChevronUpDown,
+  IconCloud,
+  IconHardDrive,
+  IconPlus,
+} from "./icons";
+import { useAppState } from "../state";
+
+export function TenantSwitcher() {
+  const navigate = useNavigate();
+  const { state, setActiveTenant, connectTenant } = useAppState();
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+
+  const activeTenant = state.activeTenantId
+    ? state.tenants.find((tenant) => tenant.id === state.activeTenantId)
+    : undefined;
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (event: MouseEvent) => {
+      if (!wrapperRef.current) return;
+      if (!wrapperRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("mousedown", handleClick);
+    window.addEventListener("keydown", handleKey);
+    return () => {
+      window.removeEventListener("mousedown", handleClick);
+      window.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  const handlePickSynthetic = async () => {
+    if (!activeTenant) {
+      setOpen(false);
+      return;
+    }
+    // Setting active is per-tenant; "Synthetic data" can't be set as a tenant.
+    // Route to Settings → Tenants where the user can disconnect or manage.
+    navigate("/settings");
+    setOpen(false);
+  };
+
+  const handlePickTenant = async (tenantId: string) => {
+    if (tenantId === activeTenant?.id) {
+      setOpen(false);
+      return;
+    }
+    setBusy(true);
+    try {
+      await setActiveTenant(tenantId);
+      setOpen(false);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleConnect = async () => {
+    setBusy(true);
+    try {
+      await connectTenant();
+      setOpen(false);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div ref={wrapperRef} className="relative mx-2.5 mt-1">
+      <button
+        onClick={() => setOpen((value) => !value)}
+        className="flex w-full items-center gap-2.5 rounded-xl bg-[var(--color-surface)] px-2.5 py-2 text-left ring-1 ring-[var(--color-border-soft)] transition-colors hover:bg-[var(--color-surface-hover)]"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <Avatar name={activeTenant?.displayName ?? "Synthetic"} size={28} />
+        <div className="min-w-0 flex-1 leading-tight">
+          <div className="truncate text-[12.5px] font-semibold text-[var(--color-text)]">
+            {activeTenant?.displayName ?? "Synthetic data"}
+          </div>
+          <div className="mt-0.5 flex items-center gap-1 text-[10px] text-[var(--color-text-muted)]">
+            <StatusDot tone={activeTenant ? "success" : "muted"} />
+            <span className="truncate">
+              {activeTenant ? activeTenant.username : "No tenant connected"}
+            </span>
+          </div>
+        </div>
+        <IconChevronUpDown size={12} className="text-[var(--color-text-muted)]" />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute left-0 right-0 top-[calc(100%+6px)] z-50 overflow-hidden rounded-xl bg-[var(--color-bg-elevated)] shadow-[var(--shadow-modal)] ring-1 ring-[var(--color-border-strong)] animate-fade-in"
+        >
+          <div className="px-2 py-1.5 text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+            Tenants
+          </div>
+          {state.tenants.length === 0 ? (
+            <div className="px-3 pb-2 pt-1 text-[12px] text-[var(--color-text-muted)]">
+              No tenants connected.
+            </div>
+          ) : (
+            <div className="flex flex-col">
+              {state.tenants.map((tenant) => {
+                const isActive = tenant.id === activeTenant?.id;
+                return (
+                  <button
+                    key={tenant.id}
+                    onClick={() => void handlePickTenant(tenant.id)}
+                    disabled={busy}
+                    role="menuitem"
+                    className={`flex items-center gap-2.5 px-3 py-2 text-left transition-colors hover:bg-[var(--color-surface-hover)] ${
+                      isActive ? "bg-[var(--color-surface)]" : ""
+                    }`}
+                  >
+                    <Avatar name={tenant.displayName} size={22} />
+                    <div className="min-w-0 flex-1 leading-tight">
+                      <div className="truncate text-[12.5px] font-medium text-[var(--color-text)]">
+                        {tenant.displayName}
+                      </div>
+                      <div className="mt-0.5 truncate text-[10px] text-[var(--color-text-muted)]">
+                        {tenant.username}
+                      </div>
+                    </div>
+                    {isActive && (
+                      <IconCheck size={12} className="text-[var(--color-accent)]" />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          <button
+            onClick={() => void handlePickSynthetic()}
+            disabled={busy}
+            role="menuitem"
+            className={`flex w-full items-center gap-2.5 border-t border-[var(--color-border-soft)] px-3 py-2 text-left transition-colors hover:bg-[var(--color-surface-hover)] ${
+              !activeTenant ? "bg-[var(--color-surface)]" : ""
+            }`}
+          >
+            <span className="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full bg-[var(--color-bg-raised)] text-[var(--color-text-muted)] ring-1 ring-[var(--color-border)]">
+              <IconHardDrive size={11} />
+            </span>
+            <div className="min-w-0 flex-1 leading-tight">
+              <div className="truncate text-[12.5px] font-medium text-[var(--color-text)]">
+                Synthetic data
+              </div>
+              <div className="mt-0.5 truncate text-[10px] text-[var(--color-text-muted)]">
+                Built-in fixture; no Microsoft Graph call
+              </div>
+            </div>
+            {!activeTenant && (
+              <IconCheck size={12} className="text-[var(--color-accent)]" />
+            )}
+          </button>
+
+          <div className="flex items-center gap-1 border-t border-[var(--color-border-soft)] bg-[var(--color-surface)] p-1.5">
+            <button
+              onClick={() => void handleConnect()}
+              disabled={busy}
+              className="flex flex-1 items-center justify-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px] font-medium text-[var(--color-text)] transition-colors hover:bg-[var(--color-surface-hover)]"
+            >
+              <IconPlus size={11} />
+              {busy ? "Waiting for sign-in…" : "Connect tenant"}
+            </button>
+            <button
+              onClick={() => {
+                navigate("/settings");
+                setOpen(false);
+              }}
+              className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px] text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+            >
+              <IconCloud size={11} /> Manage
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/pages/Activity.tsx
+++ b/apps/desktop/src/pages/Activity.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { PageBody, PageHeader } from "../components/AppShell";
 import { Card } from "../components/Card";
@@ -5,9 +6,34 @@ import { Pill } from "../components/Pill";
 import { useAppState } from "../state";
 import type { RunRecord, RunStatus } from "../shared/openAgents";
 
+type Filter = { kind: "all" } | { kind: "synthetic" } | { kind: "tenant"; tenantId: string };
+
 export default function Activity() {
   const navigate = useNavigate();
   const { state } = useAppState();
+  const [filter, setFilter] = useState<Filter>({ kind: "all" });
+
+  const counts = useMemo(() => {
+    const total = state.runs.length;
+    const synthetic = state.runs.filter((run) => run.dataSource === "synthetic").length;
+    const byTenant = new Map<string, number>();
+    for (const run of state.runs) {
+      if (run.tenantId) {
+        byTenant.set(run.tenantId, (byTenant.get(run.tenantId) ?? 0) + 1);
+      }
+    }
+    return { total, synthetic, byTenant };
+  }, [state.runs]);
+
+  const filteredRuns = useMemo(() => {
+    if (filter.kind === "all") return state.runs;
+    if (filter.kind === "synthetic") {
+      return state.runs.filter((run) => run.dataSource === "synthetic");
+    }
+    return state.runs.filter((run) => run.tenantId === filter.tenantId);
+  }, [filter, state.runs]);
+
+  const showFilters = state.tenants.length > 0 || counts.synthetic > 0;
 
   return (
     <>
@@ -16,6 +42,32 @@ export default function Activity() {
         subtitle="A local, append-only history of every agent run on this device."
       />
       <PageBody>
+        {showFilters && (
+          <div className="mb-4 flex flex-wrap items-center gap-1.5">
+            <FilterChip
+              label="All tenants"
+              count={counts.total}
+              active={filter.kind === "all"}
+              onClick={() => setFilter({ kind: "all" })}
+            />
+            <FilterChip
+              label="Synthetic"
+              count={counts.synthetic}
+              active={filter.kind === "synthetic"}
+              onClick={() => setFilter({ kind: "synthetic" })}
+            />
+            {state.tenants.map((tenant) => (
+              <FilterChip
+                key={tenant.id}
+                label={tenant.displayName}
+                count={counts.byTenant.get(tenant.id) ?? 0}
+                active={filter.kind === "tenant" && filter.tenantId === tenant.id}
+                onClick={() => setFilter({ kind: "tenant", tenantId: tenant.id })}
+              />
+            ))}
+          </div>
+        )}
+
         <Card>
           <div className="divide-y divide-[var(--color-border-soft)]">
             <div className="grid grid-cols-[1.6fr_1fr_1fr_auto_auto_auto] items-center gap-4 px-5 py-3 text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
@@ -26,12 +78,14 @@ export default function Activity() {
               <span>Cost</span>
               <span>Status</span>
             </div>
-            {state.runs.length === 0 ? (
+            {filteredRuns.length === 0 ? (
               <div className="px-5 py-10 text-center text-[13px] text-[var(--color-text-muted)]">
-                No runs recorded yet.
+                {state.runs.length === 0
+                  ? "No runs recorded yet."
+                  : "No runs match this filter."}
               </div>
             ) : (
-              state.runs.map((run) => (
+              filteredRuns.map((run) => (
                 <button
                   key={run.id}
                   onClick={() => navigate(`/runs/${run.id}`)}
@@ -41,8 +95,12 @@ export default function Activity() {
                     <div className="truncate font-medium text-[var(--color-text)]">
                       {agentNameForRun(run, state.installedAgents)}
                     </div>
-                    <div className="mt-0.5 truncate text-[11px] text-[var(--color-text-muted)]">
-                      {run.summary ?? run.id}
+                    <div className="mt-0.5 flex items-center gap-2 text-[11px] text-[var(--color-text-muted)]">
+                      <span className="truncate">{run.summary ?? run.id}</span>
+                      <span className="opacity-50">·</span>
+                      <span className="shrink-0">
+                        {tenantLabel(run, state.tenants)}
+                      </span>
                     </div>
                   </div>
                   <span className="text-[var(--color-text-soft)]">
@@ -68,11 +126,53 @@ export default function Activity() {
   );
 }
 
+function FilterChip({
+  label,
+  count,
+  active,
+  onClick,
+}: {
+  label: string;
+  count: number;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[11.5px] font-medium transition-colors ${
+        active
+          ? "bg-[var(--color-accent-soft)] text-[var(--color-accent)] ring-1 ring-[var(--color-accent)]/30"
+          : "bg-[var(--color-surface)] text-[var(--color-text-soft)] ring-1 ring-[var(--color-border-soft)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+      }`}
+    >
+      <span>{label}</span>
+      <span
+        className={`font-mono text-[10.5px] tabular-nums ${
+          active ? "opacity-80" : "text-[var(--color-text-muted)]"
+        }`}
+      >
+        {count}
+      </span>
+    </button>
+  );
+}
+
 function agentNameForRun(
   run: RunRecord,
   agents: { slug: string; name: string }[],
 ) {
   return agents.find((agent) => agent.slug === run.agentSlug)?.name ?? run.agentSlug;
+}
+
+function tenantLabel(
+  run: RunRecord,
+  tenants: { id: string; displayName: string }[],
+): string {
+  if (run.dataSource === "graph" && run.tenantId) {
+    return tenants.find((tenant) => tenant.id === run.tenantId)?.displayName ?? "real tenant";
+  }
+  return "synthetic";
 }
 
 function formatDate(value: string) {

--- a/apps/desktop/src/pages/RunResult.tsx
+++ b/apps/desktop/src/pages/RunResult.tsx
@@ -21,6 +21,7 @@ import type {
   RunRecord,
   RunStatus,
   RunStepRecord,
+  TenantRecord,
   WriteAction,
   WritePlan,
 } from "../shared/openAgents";
@@ -206,6 +207,12 @@ export default function RunResult() {
           />
         )}
 
+        <TenantDriftNote
+          runTenantId={run.tenantId}
+          activeTenantId={state.activeTenantId}
+          tenants={state.tenants}
+        />
+
         <Card className="mb-6">
           <div className="p-6">
             <SectionLabel>Steps</SectionLabel>
@@ -258,6 +265,39 @@ export default function RunResult() {
         </div>
       </PageBody>
     </>
+  );
+}
+
+function TenantDriftNote({
+  runTenantId,
+  activeTenantId,
+  tenants,
+}: {
+  runTenantId: string | undefined;
+  activeTenantId: string | undefined;
+  tenants: TenantRecord[];
+}) {
+  if (!runTenantId) return null;
+  if (runTenantId === activeTenantId) return null;
+  const runTenant = tenants.find((tenant) => tenant.id === runTenantId);
+  const activeTenant = activeTenantId
+    ? tenants.find((tenant) => tenant.id === activeTenantId)
+    : undefined;
+  return (
+    <div className="mb-6 flex items-start gap-3 rounded-lg bg-[var(--color-info-soft)] px-4 py-3 ring-1 ring-[var(--color-info)]/25">
+      <span className="mt-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--color-info)]" />
+      <div className="text-[12.5px] leading-relaxed text-[var(--color-text-soft)]">
+        This run executed against{" "}
+        <span className="font-medium text-[var(--color-text)]">
+          {runTenant?.displayName ?? `tenant ${runTenantId}`}
+        </span>
+        . The active tenant is now{" "}
+        <span className="font-medium text-[var(--color-text)]">
+          {activeTenant?.displayName ?? "Synthetic data"}
+        </span>
+        , so results below reflect the original tenant, not the current one.
+      </div>
+    </div>
   );
 }
 

--- a/apps/desktop/src/state/AppStateContext.tsx
+++ b/apps/desktop/src/state/AppStateContext.tsx
@@ -16,6 +16,7 @@ import {
   type ProviderId,
   type RegistryAgentSummary,
   type RunRecord,
+  type StartRunOptions,
   type TenantRecord,
 } from "../shared/openAgents";
 
@@ -28,7 +29,7 @@ interface AppStateContextValue {
   refreshRegistry: () => Promise<void>;
   installAgent: (agentId: string) => Promise<void>;
   setActiveProvider: (id: ProviderId) => Promise<void>;
-  startRun: (agentSlug: string) => Promise<RunRecord>;
+  startRun: (agentSlug: string, options?: StartRunOptions) => Promise<RunRecord>;
   confirmRun: (runId: string, phrase: string) => Promise<RunRecord>;
   rejectRun: (runId: string) => Promise<RunRecord>;
   connectTenant: () => Promise<TenantRecord | undefined>;
@@ -162,32 +163,35 @@ export function AppStateProvider({ children }: AppStateProviderProps) {
     }
   }, []);
 
-  const startRun = useCallback(async (agentSlug: string) => {
-    const api = getOpenAgentsApi();
+  const startRun = useCallback(
+    async (agentSlug: string, options?: StartRunOptions) => {
+      const api = getOpenAgentsApi();
 
-    if (!api) {
-      const fallbackError = new Error("Agent runs are unavailable in browser development.");
-      setError(fallbackError);
-      throw fallbackError;
-    }
+      if (!api) {
+        const fallbackError = new Error("Agent runs are unavailable in browser development.");
+        setError(fallbackError);
+        throw fallbackError;
+      }
 
-    setLoading(true);
-    setError(null);
+      setLoading(true);
+      setError(null);
 
-    try {
-      const run = await api.startRun(agentSlug);
-      const nextState = await api.getAppState();
-      setState(nextState);
-      setRegistryAgents(nextState.registryAgents);
-      return run;
-    } catch (caughtError) {
-      const runError = toError(caughtError);
-      setError(runError);
-      throw runError;
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+      try {
+        const run = await api.startRun(agentSlug, options);
+        const nextState = await api.getAppState();
+        setState(nextState);
+        setRegistryAgents(nextState.registryAgents);
+        return run;
+      } catch (caughtError) {
+        const runError = toError(caughtError);
+        setError(runError);
+        throw runError;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [],
+  );
 
   const confirmRun = useCallback(async (runId: string, phrase: string) => {
     const api = getOpenAgentsApi();

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -81,6 +81,15 @@ export type RunStatus =
 
 export type RunDataSource = "graph" | "synthetic";
 
+export interface StartRunOptions {
+  /**
+   * Pin the run to a specific tenant id at queue time. Pass `null` to force
+   * synthetic mode regardless of the currently-active tenant. Omit to default
+   * to whichever tenant is active when the run is queued.
+   */
+  tenantId?: string | null;
+}
+
 export interface TenantRecord {
   id: string;
   displayName: string;
@@ -169,7 +178,7 @@ export interface OpenAgentsApi {
   listProviders(): Promise<ProviderSummary[]>;
   installAgent(agentId: string): Promise<AppState>;
   setActiveProvider(id: ProviderId): Promise<AppState>;
-  startRun(agentSlug: string): Promise<RunRecord>;
+  startRun(agentSlug: string, options?: StartRunOptions): Promise<RunRecord>;
   getRun(id: string): Promise<RunRecord | undefined>;
   confirmRun(runId: string, phrase: string): Promise<RunRecord>;
   rejectRun(runId: string): Promise<RunRecord>;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,76 +1,36 @@
-# MSAL interactive auth + real Graph adapter (read path)
+# Multi-tenant UX
 
-**Goal:** Replace the synthetic Graph fixture with real Microsoft Graph against a real tenant when the user has connected one. Authentication via `@azure/msal-node` `acquireTokenInteractive` against the public Microsoft Graph CLI client id (`14d82eec-204b-4c2f-b7e8-296a70dab67e`) — opens the system browser to `login.microsoftonline.com`, uses a loopback redirect, and never has the user copy a code anywhere. Token cache encrypted with Electron `safeStorage`. Synthetic mode remains the default when no tenant is connected so the showcase demo keeps working.
+**Goal:** Polish the multi-tenant experience now that the MSAL read path is live. Users should be able to switch tenants from the sidebar in one click, pin a run to a specific tenant at start time, filter Activity by tenant, and notice when they're viewing a past run that executed against a different tenant than the one currently active.
 
-**Status:** Implemented (build green; manual sign-in verified against my tenant).
+**Status:** In progress.
 
 ---
 
 ## Scope for this pass
 
-- [x] Add `@azure/msal-node` to `@openagents/runtime`. No `keytar`; we use Electron's `safeStorage` (built into Electron, no native binding to maintain).
-- [x] `@openagents/agent-sdk` adds `TenantRecord`, `RunDataSource = "graph" | "synthetic"`. IPC additions on `OpenAgentsApi`: `listTenants`, `connectTenant`, `setActiveTenant`, `disconnectTenant`. `AppState` gains `tenants: TenantRecord[]` and `activeTenantId?: string`. `RunRecord` gains `dataSource: RunDataSource` and `tenantId?: string`. `TrustState` gains `dataSource` and `tenantDisplayName?`.
-- [x] `@openagents/runtime` ships:
-  - A `createMsalClient({ storage })` factory wrapping `PublicClientApplication` with the well-known Microsoft Graph CLI client id and a `TokenCacheStorage`-backed cache plugin.
-  - A `runInteractiveFlow({ client, openBrowser })` helper invoking `acquireTokenInteractive` with the system browser via the injected `openBrowser` callback and branded success/error templates.
-  - `acquireTokenSilent` mapping `InteractionRequiredAuthError` to a clear "reconnect the tenant" message.
-  - A `createGraphAdapter({ tokenProvider })` implementing `RunGraphApi.listManagedDevices` via raw `fetch`, with `@odata.nextLink` paging and 429 / 5xx retry honoring `Retry-After`.
-- [x] Electron main:
-  - `tokens.bin` file storing the `safeStorage`-encrypted MSAL serialized cache. Loaded on app start, written after each MSAL cache mutation.
-  - `AppStateStore` gains tenant methods (`listTenants`, `connectTenant`, `setActiveTenant`, `disconnectTenant`), all serialized through the existing write chain. `connectTenant` invokes the interactive flow with `shell.openExternal` injected as the `openBrowser` callback.
-  - `driveRun`/`driveApply` construct `ctx.graph` per run: real Graph adapter when `activeTenantId` is set and a token is available; otherwise `createSyntheticGraph()`. The chosen mode is stamped onto `RunRecord.dataSource`.
-- [x] Renderer:
-  - New "Tenants" section in Settings: list connected tenants, add (interactive sign-in), set active, disconnect. The connect button shows "Waiting for sign-in…" while the browser handles consent.
-  - Status strip / sidebar shows the active tenant or "Synthetic data".
-  - `/runs/:id` header pill labels the run as real-tenant or synthetic.
-- [x] Trust messaging update: `deriveTrustState` factors in tenant context. Four valid states: local-LLM + synthetic, local-LLM + real-tenant, hosted-LLM + synthetic, hosted-LLM + real-tenant.
-- [x] Renamed `electron/preload.ts` to `electron/preload.mts` so tsc emits `preload.mjs`. Electron 28+ accepts ESM preloads via the `.mjs` extension; the previous `preload.js` failed to load with `ERR_REQUIRE_ESM` and silently broke renderer IPC.
-- [x] QA gate continues to pass; CI continues to pass.
+- [ ] **Sidebar tenant switcher dropdown.** Replace the sidebar tenant card's navigation-to-Settings behavior with a dropdown menu listing all connected tenants. Each row sets active inline. Includes a "Synthetic data" option (clears active), a footer "Manage tenants…" link routing to Settings → Tenants, and an empty-state "Connect tenant" CTA when none are connected. Closes on outside-click and Escape.
+- [ ] **Per-run tenant pinning.** `startRun(slug, opts?: { tenantId?: string | null })` accepts an optional tenant override. The queued `RunRecord` is stamped with the chosen tenant id at queue time, and `driveRun` / `driveApply` read tenant from `run.tenantId` (passing `null` selects synthetic mode for this run regardless of active tenant). Closes the mid-run-switch race we had before.
+- [ ] **Activity tenant filter.** A small chip row above the run table: "All tenants" / "Synthetic" / per connected tenant. Local component state; filters `state.runs` by stamped `tenantId` / `dataSource`. Count badge per chip.
+- [ ] **`/runs/:id` drift label.** When the run's stamped `tenantId` doesn't match the current `activeTenantId`, surface a small inline note explaining the discrepancy.
+- [ ] Typecheck, QA, and build stay green; CI passes.
 
 ## Out of scope for this pass
 
-- Real Graph **writes** — `retire-inactive-devices` apply phase keeps emitting synthetic steps. Real `POST /retire` is a follow-up slice with its own burn-in.
-- Per-user custom Entra app registration UI.
-- Conditional Access compliance handling.
-- Multi-account-per-tenant.
-- Background inventory sync.
-- Onboarding tenant step (Settings is enough for v0.1; onboarding integration is a follow-up).
-- Sidebar dropdown tenant switcher, per-run tenant pinning, and Activity filtering — see follow-up slice.
+- Re-running a past run against a different tenant from `/runs/:id`.
+- Run-against-all-connected-tenants scheduler.
+- Tenant-scoped run history retention.
+- Renaming / aliasing tenants in the UI.
+- Tenant-aware sorting / grouping in the home page.
 
 ## Acceptance criteria
 
-- [x] `npm install`, `npm run typecheck`, `npm run qa`, `npm run build` all stay green.
-- [x] Manual verification: completing the interactive sign-in persists a tenant record. Running `find-inactive-devices` afterward produces a `RunRecord` with `dataSource: "graph"` and real device IDs / names from the connected tenant.
-- [x] Manual verification: with no tenant connected, `find-inactive-devices` still completes with `dataSource: "synthetic"` and the existing fixture results.
-- [x] `retire-inactive-devices` apply path emits steps without making any Graph write calls.
-- [x] Disconnecting a tenant removes its entries from the MSAL cache.
-- [x] 401 from Graph triggers silent token refresh via MSAL; if refresh fails, the run lands `failed` with an actionable message including "reconnect the tenant".
-- [x] 429 from Graph is retried up to 3 times respecting `Retry-After`.
-- [x] Status strip / `/runs/:id` pill correctly reflect tenant context across all four trust combinations.
-- [x] No secrets committed; `tokens.bin` is gitignored; client id is the public well-known CLI value.
+- [ ] `npm run typecheck`, `npm run qa`, `npm run build` all green; CI passes.
+- [ ] Connect two tenants. Clicking the sidebar tenant card opens a dropdown with both tenants + Synthetic option. Selecting another tenant updates the active tenant inline (no Settings round-trip).
+- [ ] After connecting a tenant, running `find-inactive-devices` stamps the run with that tenant id. If the user switches active tenants while the run is in-flight, the run still completes against the originally-pinned tenant (verified by the stamped `tenantId` not drifting and by inspecting the resulting `result` containing the original tenant's device IDs).
+- [ ] Activity page shows a filter chip row. Selecting one tenant filters the table to that tenant's runs; counts on each chip update correctly. Synthetic-only filter shows only runs with `dataSource: "synthetic"`.
+- [ ] On `/runs/:id`, viewing a past run whose `tenantId` differs from the current active tenant displays an inline "Active tenant differs from the one this run executed against" note (worded clearly, not alarming).
+- [ ] No secrets committed.
 
 ## Review
 
-- `@openagents/agent-sdk` gained `TenantRecord` and `RunDataSource`, plus new fields on `AppState` (`tenants`, `activeTenantId?`), `RunRecord` (`dataSource?`, `tenantId?`), and `TrustState` (`dataSource`, `tenantDisplayName?`). `OpenAgentsApi` exposes `listTenants`, `connectTenant`, `setActiveTenant`, `disconnectTenant`. `deriveTrustState` now factors in tenant context so the four quadrants (local-LLM × synthetic-or-real-tenant) all produce honest labels.
-- `@openagents/runtime` ships:
-  - `msal.ts` wrapping `@azure/msal-node` `PublicClientApplication` with the well-known Microsoft Graph CLI client id (`14d82eec-204b-4c2f-b7e8-296a70dab67e`). Exposes `createMsalClient`, `runInteractiveFlow`, `acquireTokenSilent`, `removeAccount`, plus a `TokenCacheStorage` interface and a `createCachePlugin` adapter. `runInteractiveFlow` invokes `acquireTokenInteractive` with the system browser via the injected `openBrowser` callback and renders branded success/error templates.
-  - `graph-adapter.ts` implementing `RunGraphApi.listManagedDevices` via raw `fetch` with `@odata.nextLink` paging, 30 s per-request `AbortController` timeout, 429 / 5xx retry with `Retry-After` respect, and 401 mapped to a "tenant needs reconnect" error.
-  - `ExecuteRunInput.graph?` so the host injects either the real adapter or the synthetic fixture.
-- Electron:
-  - New `secret-store.ts` wrapping `safeStorage` + a per-file ciphertext blob (mode 0o600). Replaces the `keytar` plan from SPEC; no native binding to rebuild per Electron version.
-  - `AppStateStore` gained tenant state and methods serialized through the existing write chain. `buildGraph` returns the real adapter when an `activeTenantId` is set and a cached token is available, otherwise `createSyntheticGraph()`. Each run is stamped with `dataSource` and (when graph-backed) `tenantId` before progress events fire, so the renderer's polling sees the labeling for free.
-  - `main.ts` constructs the secret store under `userData`/`tokens.bin`, passes `shell.openExternal` as the MSAL `openBrowser` callback, and registers the four new IPC handlers.
-  - `preload.mts` (renamed from `preload.ts`) exposes the new methods. The `.mjs` output is what Electron 28+ requires for an ESM preload; the previous `preload.js` failed silently with `ERR_REQUIRE_ESM` and broke renderer IPC in dev.
-- Renderer:
-  - New Settings → Tenants section with connect / set-active / disconnect, error surface, and a helper line clarifying the sign-in opens in the system browser.
-  - Sidebar tenant card swapped from hardcoded "No tenant connected" to the active tenant pulled from state (clicking routes into Settings).
-  - `/runs/:id` header now shows a "Tenant: …" pill when `run.dataSource === "graph"` and a "Synthetic data" pill otherwise.
-- Trust messaging: `deriveTrustState` now returns labels like "Local Ollama · synthetic data" and "Hosted OpenAI · real tenant contoso.onmicrosoft.com". `TrustState.tenantDisplayName` is set when a tenant is active.
-- Verified: `npm install`, `npm run typecheck`, `npm run qa`, `npm run build` all stay green; QA still 12 pass / 1 warn / 0 fail. Manual sign-in confirmed end-to-end.
-
-## Known follow-ups
-
-- Real Graph **writes** (`POST /retire`) — apply phase still emits synthetic steps; needs its own burn-in slice with a feature flag.
-- Onboarding "Connect tenant" step — Settings is enough for v0.1 but the onboarding flow could surface this earlier.
-- Multi-tenant UX polish: sidebar dropdown switcher, per-run tenant pinning at `startRun`, Activity-page tenant filter chip.
-- Multi-account-per-tenant and tenant-scoped run-history filtering.
+(to fill in after implementation)


### PR DESCRIPTION
Polish pass on top of the MSAL read path.

## Summary

- **Sidebar tenant switcher dropdown.** Click the sidebar tenant card to switch in one tap. Lists every connected tenant + a "Synthetic data" option + a "Connect tenant" CTA + a "Manage" link to Settings. Closes on outside-click and Escape.
- **Per-run tenant pinning.** \`startRun(slug, options?)\` accepts \`{ tenantId?: string | null }\`:
  - \`tenantId: "<id>"\` → pin this run to that tenant.
  - \`tenantId: null\` → force synthetic for this run.
  - omitted → default to whichever tenant is active at queue time.
  The queued \`RunRecord\` is stamped immediately; \`buildGraph\` reads from the run, not from a live \`activeTenantId\` re-read. Closes the mid-run-switch race we had.
- **Activity tenant filter.** Chip row above the run table: All / Synthetic / per connected tenant, with counts. Each row also shows the run's tenant inline.
- **\`/runs/:id\` drift label.** Inline note when the run's stamped tenant differs from the currently active tenant.

## Test plan

- [x] \`npm run typecheck\`, \`npm run qa\`, \`npm run build\` green (12 pass / 1 warn / 0 fail).
- [ ] CI green.
- [ ] Manual: connect a second tenant, swap via sidebar dropdown, run \`find-inactive-devices\`, switch tenants mid-run, confirm the result reflects the originally-pinned tenant. Then visit the past run and see the drift note.