### PR TITLE
ci: skip desktop pipeline when only web/ changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,11 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'web/**'
   pull_request:
+    paths-ignore:
+      - 'web/**'
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
The marketing site at \`/web\` is deployed by Vercel from a separate project and is not part of the desktop workspace. Today the desktop CI workflow still runs on every push / PR, including ones that only touch \`web/\` — ~90s of wasted runner time per such change.

Adds \`paths-ignore: ['web/**']\` to both the push and pull_request triggers so the desktop pipeline only fires when desktop or shared monorepo content actually changes.

Vercel's own "Skip deployments when no changes to root directory" toggle already handles the inverse (no marketing rebuilds when only desktop changes), so the two systems are cleanly partitioned:

| Change                 | Desktop CI | Vercel build |
| ---------------------- | ---------- | ------------ |
| only desktop / agents  | runs       | skipped      |
| only \`web/\`            | skipped    | runs         |
| both                   | runs       | runs         |

## Test plan

- [ ] This PR's CI run still triggers (it modifies \`.github/workflows/ci.yml\`, which is outside \`web/\`).
- [ ] After merge, a follow-up commit that only touches \`web/\` should show no Actions run on \`main\`; Vercel deploys it.
- [ ] A commit that touches only desktop should still trigger desktop CI and be skipped by Vercel.