### PR TITLE
desktop: canonicalize logo mark + fix traffic-light overlap

### DIFF
--- a/apps/desktop/public/favicon.svg
+++ b/apps/desktop/public/favicon.svg
@@ -1,1 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="7" fill="#1c1917"/><path d="M10 11 L16 8 L22 11 L22 21 L16 24 L10 21 Z" fill="none" stroke="#e8a87c" stroke-width="1.6" stroke-linejoin="round"/><circle cx="16" cy="16" r="2.2" fill="#e8a87c"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#1c1917"/>
+  <circle cx="16" cy="16" r="9" fill="none" stroke="#e8a87c" stroke-width="2"/>
+  <circle cx="16" cy="16" r="3" fill="#e8a87c"/>
+</svg>

--- a/apps/desktop/src/components/AppShell.tsx
+++ b/apps/desktop/src/components/AppShell.tsx
@@ -1,6 +1,25 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
 import { Sidebar } from "./Sidebar";
 import { CommandPalette } from "./CommandPalette";
+
+// Reserve space at the top of the window for the macOS traffic-light buttons
+// (titleBarStyle: "hiddenInset" leaves them floating over the renderer) and
+// make that strip draggable so users can move the window from the top edge.
+// Harmless on Windows/Linux: just a thin extra header band.
+const TITLE_BAR_HEIGHT = 32;
+const dragStyle: CSSProperties = {
+  WebkitAppRegion: "drag",
+} as CSSProperties;
+
+export function TitleBarInset() {
+  return (
+    <div
+      aria-hidden
+      className="shrink-0 bg-[var(--color-bg)]"
+      style={{ ...dragStyle, height: TITLE_BAR_HEIGHT }}
+    />
+  );
+}
 
 export function AppShell({ children }: { children: ReactNode }) {
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -17,11 +36,14 @@ export function AppShell({ children }: { children: ReactNode }) {
   }, []);
 
   return (
-    <div className="flex h-full w-full overflow-hidden bg-[var(--color-bg)] text-[var(--color-text)]">
-      <Sidebar onOpenPalette={() => setPaletteOpen(true)} />
-      <main className="flex h-full min-w-0 flex-1 flex-col overflow-hidden">
-        {children}
-      </main>
+    <div className="flex h-full w-full flex-col overflow-hidden bg-[var(--color-bg)] text-[var(--color-text)]">
+      <TitleBarInset />
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <Sidebar onOpenPalette={() => setPaletteOpen(true)} />
+        <main className="flex h-full min-w-0 flex-1 flex-col overflow-hidden">
+          {children}
+        </main>
+      </div>
       <CommandPalette
         open={paletteOpen}
         onClose={() => setPaletteOpen(false)}

--- a/apps/desktop/src/components/AppShell.tsx
+++ b/apps/desktop/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { Sidebar } from "./Sidebar";
 import { CommandPalette } from "./CommandPalette";
 
@@ -7,16 +7,13 @@ import { CommandPalette } from "./CommandPalette";
 // make that strip draggable so users can move the window from the top edge.
 // Harmless on Windows/Linux: just a thin extra header band.
 const TITLE_BAR_HEIGHT = 32;
-const dragStyle: CSSProperties = {
-  WebkitAppRegion: "drag",
-} as CSSProperties;
 
 export function TitleBarInset() {
   return (
     <div
       aria-hidden
-      className="shrink-0 bg-[var(--color-bg)]"
-      style={{ ...dragStyle, height: TITLE_BAR_HEIGHT }}
+      className="app-region-drag shrink-0 bg-[var(--color-bg)]"
+      style={{ height: TITLE_BAR_HEIGHT }}
     />
   );
 }

--- a/apps/desktop/src/components/icons.tsx
+++ b/apps/desktop/src/components/icons.tsx
@@ -140,8 +140,8 @@ export const IconSparkle = ({ size = 14, ...p }: IconProps) => (
 
 export const IconLogo = ({ size = 22, ...p }: IconProps) => (
   <svg {...base(size, p)}>
-    <path d="M12 3 L20 7.5 V16.5 L12 21 L4 16.5 V7.5 Z" stroke="currentColor" />
-    <circle cx="12" cy="12" r="2.6" fill="currentColor" stroke="none" />
+    <circle cx="12" cy="12" r="7" stroke="currentColor" strokeWidth={1.6} />
+    <circle cx="12" cy="12" r="2.25" fill="currentColor" stroke="none" />
   </svg>
 );
 

--- a/apps/desktop/src/pages/Onboarding.tsx
+++ b/apps/desktop/src/pages/Onboarding.tsx
@@ -13,6 +13,7 @@ import {
   IconPlay,
   IconShield,
 } from "../components/icons";
+import { TitleBarInset } from "../components/AppShell";
 import { useAppState } from "../state";
 import type {
   ProviderId,
@@ -98,6 +99,7 @@ export default function Onboarding() {
 
   return (
     <div className="flex h-full flex-col bg-[var(--color-bg)]">
+      <TitleBarInset />
       {/* Top bar */}
       <header className="flex shrink-0 items-center justify-between border-b border-[var(--color-border-soft)] px-10 py-4">
         <div className="flex items-center gap-2.5">

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -153,3 +153,21 @@ button:disabled {
 .animate-fade-in-scale {
   animation: fade-in-scale 0.18s ease-out;
 }
+
+/* Electron window drag regions. Tailwind has no utility for the
+ * non-standard -webkit-app-region property, and React's CSS-in-JS
+ * doesn't reliably emit it from the camelCase `WebkitAppRegion` prop.
+ * Plain class rules guarantee the property reaches the DOM.
+ *
+ * Use .app-region-drag on areas that should drag the OS window
+ * (e.g. the title-bar strip above the sidebar). Use .app-region-no-drag
+ * on interactive children (buttons, links, inputs) so clicks still
+ * register inside a drag region.
+ */
+.app-region-drag {
+  -webkit-app-region: drag;
+}
+
+.app-region-no-drag {
+  -webkit-app-region: no-drag;
+}


### PR DESCRIPTION
Visual polish to the desktop chrome — two related fixes.

## 1. Canonicalize the website's logo mark

The repo had three different "logo" marks: the website's intentional concentric-circles favicon, plus an older hexagon mark inside the desktop app (used by \`apps/desktop/public/favicon.svg\` and the inline \`<IconLogo>\` in the sidebar / onboarding header). Retire the hexagon.

- **\`apps/desktop/public/favicon.svg\`** — same circle+dot shape as \`web/src/app/icon.svg\`, rendered in the existing peach accent (\`#e8a87c\`) on the dark rounded-rect container so the renderer favicon matches the app theme tokens.
- **\`apps/desktop/src/components/icons.tsx\` \`IconLogo\`** — replaces the hexagon path with the matching circle+dot, keeps \`currentColor\` so sidebar / onboarding callers continue to inherit their own color.

## 2. Reserve a draggable title-bar inset on macOS

\`titleBarStyle: "hiddenInset"\` keeps the macOS traffic-light buttons floating over the renderer at the top-left corner. The sidebar's "Open Agents" brand row was rendering at y=0 underneath them and getting clobbered.

- New \`<TitleBarInset>\` component (32px tall, \`-webkit-app-region: drag\`) at the top of the window.
- \`<AppShell>\` renders it once; \`<Onboarding>\` (which bypasses AppShell) also mounts it above its own header.
- Harmless on Windows / Linux — just a thin extra header band, since the system chrome is drawn above the renderer there.

## Out of scope (separate follow-up)

- **Electron app-bundle icon** (\`.icns\` for macOS / \`.ico\` for Windows / Linux PNG set). The Dock / Cmd-Tab icon is still the default Electron one until we generate raster assets from a 1024px source PNG and wire them into \`electron-builder\`. Next slice.

## Test plan

- [x] \`npm run typecheck\` + \`npm run qa\` + \`npm run build\` green.
- [ ] CI green.
- [ ] Manual: traffic lights no longer overlap the sidebar header; sidebar starts ~32px below the top of the window. Mark in the sidebar header is the new circle+dot in peach.