### PR TITLE
runtime: real Graph writes for retire-inactive-devices (gated, default OFF)

### DIFF
--- a/agents/retire-inactive-devices/src/agent.ts
+++ b/agents/retire-inactive-devices/src/agent.ts
@@ -90,30 +90,75 @@ const agent: WriteAgentModule = {
   },
 
   async apply(ctx: RunContext, plan: WritePlan): Promise<AgentRunResult> {
+    const realWrites = ctx.realWrites;
     const retiredDeviceIds: string[] = [];
+    const simulatedDeviceIds: string[] = [];
+    const failed: Array<{ id: string; name: string; error: string }> = [];
+
+    if (!realWrites) {
+      ctx.log(
+        "warn",
+        "Real Graph writes are disabled (no tenant connected or the toggle in Settings is OFF). The apply phase will emit a simulated trace instead of calling Microsoft Graph.",
+      );
+    }
 
     for (const action of plan.actions) {
       const deviceId = readString(action.metadata, "deviceId");
       const deviceName = readString(action.metadata, "deviceName") ?? deviceId ?? action.id;
 
-      await ctx.step(
-        action.label,
-        action.description,
-        async () => {
-          if (!deviceId) {
-            throw new Error(`Action ${action.id} is missing deviceId metadata.`);
+      if (!deviceId) {
+        failed.push({
+          id: action.id,
+          name: deviceName,
+          error: "Action is missing deviceId metadata.",
+        });
+        ctx.log("error", `Skipping ${action.label}: missing deviceId.`);
+        continue;
+      }
+
+      // Per-device errors must not abort the run -- catch around the
+      // step so one Graph 404 / 403 / throttle doesn't strand the other
+      // approved devices. Aggregate into `failed` and report in summary.
+      try {
+        await ctx.step(action.label, action.description, async () => {
+          if (realWrites) {
+            await ctx.graph.retireManagedDevice(deviceId);
+            ctx.log("info", `Retired ${deviceName} (${deviceId}) via Graph.`);
+            retiredDeviceIds.push(deviceId);
+          } else {
+            ctx.log(
+              "info",
+              `[simulated] would retire ${deviceName} (${deviceId}); real writes disabled.`,
+            );
+            simulatedDeviceIds.push(deviceId);
           }
-          ctx.log("info", `Retired ${deviceName} (${deviceId}).`);
-          retiredDeviceIds.push(deviceId);
-        },
-      );
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        failed.push({ id: deviceId, name: deviceName, error: message });
+        ctx.log(
+          "error",
+          `Failed to retire ${deviceName} (${deviceId}): ${message}`,
+        );
+      }
     }
 
+    const successCount = realWrites ? retiredDeviceIds.length : simulatedDeviceIds.length;
+    const total = plan.actions.length;
+    const verb = realWrites ? "Retired" : "Simulated retire of";
+    const failureSuffix = failed.length > 0 ? ` ${failed.length} failed.` : "";
+    const summary = `${verb} ${successCount} of ${total} devices.${failureSuffix}`;
+
     return {
-      summary: `Retired ${retiredDeviceIds.length} devices.`,
+      summary,
       result: {
+        mode: realWrites ? "real" : "simulated",
         retiredDeviceIds,
-        count: retiredDeviceIds.length,
+        simulatedDeviceIds,
+        failed,
+        successCount,
+        failureCount: failed.length,
+        total,
       },
     };
   },

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -123,6 +123,10 @@ function registerIpcHandlers() {
   ipcMain.handle("openagents:disconnect-tenant", (_event, id: string) =>
     store.disconnectTenant(id),
   );
+  ipcMain.handle(
+    "openagents:set-real-writes-enabled",
+    (_event, enabled: boolean) => store.setRealWritesEnabled(enabled),
+  );
 }
 
 const gotLock = app.requestSingleInstanceLock();

--- a/apps/desktop/electron/preload.mts
+++ b/apps/desktop/electron/preload.mts
@@ -28,6 +28,8 @@ const api: OpenAgentsApi = {
     ipcRenderer.invoke("openagents:set-active-tenant", id),
   disconnectTenant: (id: string) =>
     ipcRenderer.invoke("openagents:disconnect-tenant", id),
+  setRealWritesEnabled: (enabled: boolean) =>
+    ipcRenderer.invoke("openagents:set-real-writes-enabled", enabled),
 };
 
 contextBridge.exposeInMainWorld("openAgents", api);

--- a/apps/desktop/electron/state.ts
+++ b/apps/desktop/electron/state.ts
@@ -45,6 +45,7 @@ interface PersistedState {
   runs: RunRecord[];
   tenants: TenantRecord[];
   activeTenantId?: string;
+  realWritesEnabled: boolean;
 }
 
 interface OllamaTagsResponse {
@@ -58,6 +59,7 @@ const defaultState: PersistedState = {
   installedAgents: [],
   runs: [],
   tenants: [],
+  realWritesEnabled: false,
 };
 
 const providerIds = new Set<ProviderId>(
@@ -124,11 +126,26 @@ export class AppStateStore {
       runs: persisted.runs,
       trust: deriveTrustState({ provider: activeProvider, activeTenant }),
       tenants: persisted.tenants,
+      realWritesEnabled: persisted.realWritesEnabled,
     };
     if (persisted.activeTenantId) {
       state.activeTenantId = persisted.activeTenantId;
     }
     return state;
+  }
+
+  async setRealWritesEnabled(enabled: boolean): Promise<AppState> {
+    if (typeof enabled !== "boolean") {
+      throw new Error(`setRealWritesEnabled requires a boolean, got ${typeof enabled}.`);
+    }
+    await this.serialize(async () => {
+      const persisted = await this.read();
+      await this.write({
+        ...persisted,
+        realWritesEnabled: enabled,
+      });
+    });
+    return this.getAppState();
   }
 
   listRegistryAgents(): RegistryAgentSummary[] {
@@ -519,6 +536,17 @@ export class AppStateStore {
     return next;
   }
 
+  // Real writes are only permitted when: (a) the run resolved to a real
+  // tenant Graph adapter (dataSource === "graph") AND (b) the user has
+  // explicitly toggled the global "Enable real Graph writes" setting.
+  // Synthetic runs never pass real writes through, regardless of the
+  // toggle, because there's no tenant to write against.
+  private async resolveRealWrites(selection: { dataSource: RunDataSource }): Promise<boolean> {
+    if (selection.dataSource !== "graph") return false;
+    const persisted = await this.read();
+    return persisted.realWritesEnabled === true;
+  }
+
   private async driveRun(input: {
     run: RunRecord;
     agent: AgentSummary;
@@ -529,6 +557,7 @@ export class AppStateStore {
       const driver = input.agent.mode === "write" ? executePlan : executeRun;
       const llm = await this.buildLlm(input.providerId, input.model);
       const selection = await this.buildGraph(input.run.tenantId);
+      const realWrites = await this.resolveRealWrites(selection);
       const stampedRun = this.stampDataSource(input.run, selection);
       await this.persistRunSnapshot(stampedRun);
       await driver({
@@ -538,6 +567,7 @@ export class AppStateStore {
         model: input.model,
         llm,
         graph: selection.graph,
+        realWrites,
         onProgress: (next) =>
           this.persistRunSnapshot(this.stampDataSource(next, selection)),
       });
@@ -556,6 +586,7 @@ export class AppStateStore {
     try {
       const llm = await this.buildLlm(input.providerId, input.model);
       const selection = await this.buildGraph(input.run.tenantId);
+      const realWrites = await this.resolveRealWrites(selection);
       await executeApply({
         run: input.run,
         agent: input.agent,
@@ -564,6 +595,7 @@ export class AppStateStore {
         plan: input.plan,
         llm,
         graph: selection.graph,
+        realWrites,
         onProgress: (next) =>
           this.persistRunSnapshot(this.stampDataSource(next, selection)),
       });
@@ -620,6 +652,12 @@ export class AppStateStore {
           : defaultState.installedAgents,
         runs: Array.isArray(parsed.runs) ? parsed.runs : defaultState.runs,
         tenants,
+        // Default to false for older state files written before real-writes
+        // existed; the user must explicitly opt in via Settings.
+        realWritesEnabled:
+          typeof parsed.realWritesEnabled === "boolean"
+            ? parsed.realWritesEnabled
+            : defaultState.realWritesEnabled,
       };
       if (activeTenantId) {
         state.activeTenantId = activeTenantId;

--- a/apps/desktop/src/pages/RunResult.tsx
+++ b/apps/desktop/src/pages/RunResult.tsx
@@ -14,6 +14,7 @@ import {
   IconLock,
   IconPlay,
   IconShare,
+  IconShield,
   IconWarning,
 } from "../components/icons";
 import { useAppState } from "../state";
@@ -204,6 +205,14 @@ export default function RunResult() {
             plan={run.plan}
             onConfirm={confirmRun}
             onReject={rejectRun}
+            writesAreReal={
+              run.dataSource === "graph" && state.realWritesEnabled === true
+            }
+            tenantDisplayName={
+              run.tenantId
+                ? state.tenants.find((tenant) => tenant.id === run.tenantId)?.displayName
+                : undefined
+            }
           />
         )}
 
@@ -306,11 +315,15 @@ function DiffConfirmPanel({
   plan,
   onConfirm,
   onReject,
+  writesAreReal,
+  tenantDisplayName,
 }: {
   runId: string;
   plan: WritePlan;
   onConfirm: (runId: string, phrase: string) => Promise<RunRecord>;
   onReject: (runId: string) => Promise<RunRecord>;
+  writesAreReal: boolean;
+  tenantDisplayName: string | undefined;
 }) {
   const [typed, setTyped] = useState("");
   const [busy, setBusy] = useState(false);
@@ -353,6 +366,32 @@ function DiffConfirmPanel({
           Write operation paused for confirmation. Open Agents will not proceed until the exact phrase is typed.
         </div>
       </div>
+
+      {writesAreReal ? (
+        <div className="border-b border-[var(--color-danger)]/35 bg-[var(--color-danger-soft)] px-6 py-3">
+          <div className="flex items-start gap-3 text-[12.5px] text-[var(--color-danger)]">
+            <IconWarning size={14} className="mt-0.5 shrink-0" />
+            <span>
+              <span className="font-semibold">Approving will call Microsoft Graph.</span>{" "}
+              {plan.actions.length} {plan.actions.length === 1 ? "device" : "devices"} in{" "}
+              <span className="font-mono">{tenantDisplayName ?? "the active tenant"}</span>{" "}
+              will be retired. There is no undo at the Graph level.
+            </span>
+          </div>
+        </div>
+      ) : (
+        <div className="border-b border-[var(--color-info)]/25 bg-[var(--color-info-soft)] px-6 py-3">
+          <div className="flex items-start gap-3 text-[12.5px] text-[var(--color-info)]">
+            <IconShield size={14} className="mt-0.5 shrink-0" />
+            <span>
+              <span className="font-semibold">Apply will be simulated.</span>{" "}
+              No Graph writes. The agent will emit a trace of what it would have
+              retired. Flip "Enable real Graph writes" in Settings → Privacy to
+              perform real changes against a connected tenant.
+            </span>
+          </div>
+        </div>
+      )}
 
       <div className="p-6">
         <div className="mb-5 flex items-start justify-between gap-6">

--- a/apps/desktop/src/pages/Settings.tsx
+++ b/apps/desktop/src/pages/Settings.tsx
@@ -38,6 +38,7 @@ export default function Settings() {
     connectTenant,
     setActiveTenant,
     disconnectTenant,
+    setRealWritesEnabled,
   } = useAppState();
   const [tenantBusy, setTenantBusy] = useState(false);
   const [tenantError, setTenantError] = useState<string | null>(null);
@@ -93,7 +94,13 @@ export default function Settings() {
             />
           )}
           {section === "general" && <GeneralSection />}
-          {section === "privacy" && <PrivacySection trust={state.trust} />}
+          {section === "privacy" && (
+            <PrivacySection
+              trust={state.trust}
+              realWritesEnabled={state.realWritesEnabled}
+              onRealWritesChange={setRealWritesEnabled}
+            />
+          )}
           {section === "about" && <AboutSection />}
         </PageBody>
       </div>
@@ -421,7 +428,26 @@ function GeneralSection() {
   );
 }
 
-function PrivacySection({ trust }: { trust: TrustState }) {
+function PrivacySection({
+  trust,
+  realWritesEnabled,
+  onRealWritesChange,
+}: {
+  trust: TrustState;
+  realWritesEnabled: boolean;
+  onRealWritesChange: (enabled: boolean) => Promise<void>;
+}) {
+  const [busy, setBusy] = useState(false);
+  const handleToggle = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await onRealWritesChange(!realWritesEnabled);
+    } finally {
+      setBusy(false);
+    }
+  };
+
   return (
     <div className="max-w-[720px]">
       <SectionTitle
@@ -446,6 +472,30 @@ function PrivacySection({ trust }: { trust: TrustState }) {
             <Pill tone={trust.isLocal ? "success" : "warning"}>
               <IconHardDrive size={10} /> {trust.label}
             </Pill>
+          }
+        />
+        <SettingRow
+          label="Enable real Graph writes"
+          description="Off by default. When ON, approved write agents call Microsoft Graph and make real changes after typed diff confirmation. When OFF, the apply phase emits a simulated trace -- no Graph mutating calls. The diff prompt itself is mandatory in either mode and cannot be disabled."
+          control={
+            <button
+              onClick={() => void handleToggle()}
+              disabled={busy}
+              className={`inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-[11.5px] font-medium ring-1 transition-colors ${
+                realWritesEnabled
+                  ? "bg-[var(--color-warning-soft)] text-[var(--color-warning)] ring-[var(--color-warning)]/35"
+                  : "bg-[var(--color-bg-raised)] text-[var(--color-text-soft)] ring-[var(--color-border)]"
+              } ${busy ? "opacity-50" : ""}`}
+            >
+              <span
+                className={`inline-block h-1.5 w-1.5 rounded-full ${
+                  realWritesEnabled
+                    ? "bg-[var(--color-warning)]"
+                    : "bg-[var(--color-text-muted)]"
+                }`}
+              />
+              {realWritesEnabled ? "On — writes will hit Graph" : "Off — simulated"}
+            </button>
           }
         />
         <SettingRow

--- a/apps/desktop/src/state/AppStateContext.tsx
+++ b/apps/desktop/src/state/AppStateContext.tsx
@@ -35,6 +35,7 @@ interface AppStateContextValue {
   connectTenant: () => Promise<TenantRecord | undefined>;
   setActiveTenant: (id: string) => Promise<void>;
   disconnectTenant: (id: string) => Promise<void>;
+  setRealWritesEnabled: (enabled: boolean) => Promise<void>;
 }
 
 interface AppStateProviderProps {
@@ -55,6 +56,7 @@ function createFallbackState(activeProviderId: ProviderId): AppState {
     runs: [],
     trust: deriveTrustState(activeProvider),
     tenants: [],
+    realWritesEnabled: false,
   };
 }
 
@@ -269,6 +271,21 @@ export function AppStateProvider({ children }: AppStateProviderProps) {
     }
   }, []);
 
+  const setRealWritesEnabled = useCallback(async (enabled: boolean) => {
+    const api = getOpenAgentsApi();
+    if (!api) return;
+    setError(null);
+    try {
+      const nextState = await api.setRealWritesEnabled(enabled);
+      setState(nextState);
+      setRegistryAgents(nextState.registryAgents);
+    } catch (caughtError) {
+      const settingError = toError(caughtError);
+      setError(settingError);
+      throw settingError;
+    }
+  }, []);
+
   const rejectRun = useCallback(async (runId: string) => {
     const api = getOpenAgentsApi();
     if (!api) {
@@ -324,12 +341,14 @@ export function AppStateProvider({ children }: AppStateProviderProps) {
       connectTenant,
       setActiveTenant,
       disconnectTenant,
+      setRealWritesEnabled,
     }),
     [
       confirmRun,
       connectTenant,
       disconnectTenant,
       error,
+      setRealWritesEnabled,
       installAgent,
       loading,
       refresh,

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -168,6 +168,14 @@ export interface AppState {
   trust: TrustState;
   tenants: TenantRecord[];
   activeTenantId?: string;
+  /**
+   * Global toggle that gates whether write-mode agents may call real
+   * Microsoft Graph mutating endpoints. Default `false`. Even when `true`,
+   * every write run still pauses for typed diff confirmation; this toggle
+   * only controls whether the approved `apply` phase actually hits Graph
+   * or emits a simulated trace.
+   */
+  realWritesEnabled: boolean;
 }
 
 export interface OpenAgentsApi {
@@ -186,6 +194,7 @@ export interface OpenAgentsApi {
   connectTenant(): Promise<AppState>;
   setActiveTenant(id: string): Promise<AppState>;
   disconnectTenant(id: string): Promise<AppState>;
+  setRealWritesEnabled(enabled: boolean): Promise<AppState>;
 }
 
 export type AgentDefinition = AgentContract &
@@ -204,6 +213,14 @@ export interface ManagedDeviceRecord {
 
 export interface RunGraphApi {
   listManagedDevices(): Promise<ManagedDeviceRecord[]>;
+  /**
+   * Calls `POST /deviceManagement/managedDevices/{managedDevice-id}/retire`.
+   * Destructive — only invoke after the user has approved a `WritePlan`
+   * via typed diff confirmation. The runtime's policy gating (tenant
+   * connected + real-writes toggle ON) is surfaced via `RunContext.realWrites`;
+   * agents should branch on that flag before calling this method.
+   */
+  retireManagedDevice(deviceId: string): Promise<void>;
 }
 
 export interface LlmOptions {
@@ -249,6 +266,21 @@ export interface RunContext {
   model?: string;
   graph: RunGraphApi;
   llm: RunLlmApi;
+  /**
+   * Whether write actions invoked via `ctx.graph.*` will hit real Graph.
+   *
+   * `true`  — a tenant is connected AND the user has flipped the global
+   *           "Enable real Graph writes" toggle ON. Destructive operations
+   *           in `apply` should call the real Graph methods.
+   * `false` — no tenant connected, OR the toggle is OFF. `apply` should
+   *           emit a log line describing what *would* have happened and
+   *           skip the destructive call so the synthetic / blocked mode
+   *           remains honest about not touching the tenant.
+   *
+   * Read-only operations (`listManagedDevices`) ignore this flag and
+   * always reflect the active data source.
+   */
+  realWrites: boolean;
   log(level: RunLogLevel, message: string, metadata?: Record<string, unknown>): void;
   step<T>(
     label: string,

--- a/packages/runtime/src/graph-adapter.ts
+++ b/packages/runtime/src/graph-adapter.ts
@@ -53,6 +53,7 @@ export function createGraphAdapter(options: GraphAdapterOptions): RunGraphApi {
         const payload: GraphListResponse<ManagedDeviceResponseItem> = await graphRequest<
           GraphListResponse<ManagedDeviceResponseItem>
         >({
+          method: "GET",
           url: nextLink,
           tokenProvider: options.tokenProvider,
           fetchImpl,
@@ -67,18 +68,40 @@ export function createGraphAdapter(options: GraphAdapterOptions): RunGraphApi {
 
       return records;
     },
+
+    async retireManagedDevice(deviceId: string): Promise<void> {
+      if (!deviceId || typeof deviceId !== "string") {
+        throw new Error("retireManagedDevice requires a non-empty deviceId.");
+      }
+      // Action endpoint. Body is empty per Microsoft Graph docs.
+      const url = `${baseUrl}/deviceManagement/managedDevices/${encodeURIComponent(
+        deviceId,
+      )}/retire`;
+      await graphRequest<void>({
+        method: "POST",
+        url,
+        tokenProvider: options.tokenProvider,
+        fetchImpl,
+        maxRetries,
+        timeoutMs,
+        expectJson: false,
+      });
+    },
   };
 }
 
 interface GraphRequestInput {
+  method: "GET" | "POST";
   url: string;
   tokenProvider: () => Promise<string>;
   fetchImpl: typeof fetch;
   maxRetries: number;
   timeoutMs: number;
+  expectJson?: boolean;
 }
 
 async function graphRequest<T>(input: GraphRequestInput): Promise<T> {
+  const expectJson = input.expectJson ?? true;
   let attempt = 0;
   while (true) {
     attempt += 1;
@@ -86,14 +109,18 @@ async function graphRequest<T>(input: GraphRequestInput): Promise<T> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), input.timeoutMs);
 
+    const headers: Record<string, string> = {
+      authorization: `Bearer ${token}`,
+    };
+    if (expectJson) {
+      headers.accept = "application/json";
+    }
+
     let response: Response;
     try {
       response = await input.fetchImpl(input.url, {
-        method: "GET",
-        headers: {
-          authorization: `Bearer ${token}`,
-          accept: "application/json",
-        },
+        method: input.method,
+        headers,
         signal: controller.signal,
       });
     } catch (error) {
@@ -106,6 +133,11 @@ async function graphRequest<T>(input: GraphRequestInput): Promise<T> {
     clearTimeout(timer);
 
     if (response.ok) {
+      if (!expectJson) {
+        // Consume the body so the underlying connection can be reused.
+        await response.text().catch(() => "");
+        return undefined as T;
+      }
       return (await response.json()) as T;
     }
 

--- a/packages/runtime/src/graph-fixtures.ts
+++ b/packages/runtime/src/graph-fixtures.ts
@@ -63,6 +63,15 @@ export function createSyntheticGraph(): RunGraphApi {
     async listManagedDevices(): Promise<ManagedDeviceRecord[]> {
       return buildInventory(Date.now());
     },
+    async retireManagedDevice(_deviceId: string): Promise<void> {
+      // Synthetic graph is read-only by design — the device list is
+      // regenerated each call from a fixed spec. The runtime gates real
+      // writes via RunContext.realWrites, and agents branch on that
+      // flag before calling this method, so a synthetic call here is
+      // unexpected. Return successfully but make this a no-op rather
+      // than throwing — it makes accidental calls during tests harmless.
+      return;
+    },
   };
 }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -117,6 +117,14 @@ export interface ExecuteRunInput {
   model?: string;
   llm?: RunLlmApi;
   graph?: RunGraphApi;
+  /**
+   * Whether the agent is allowed to call destructive Graph methods
+   * during this run. The host computes this from
+   * `tenant !== null && realWritesEnabled === true`. Defaults to
+   * `false` so unconfigured callers cannot accidentally perform real
+   * writes.
+   */
+  realWrites?: boolean;
   onProgress(run: RunRecord): void | Promise<void>;
 }
 
@@ -171,6 +179,7 @@ async function createPhaseHandle(
     model: input.model,
     graph: input.graph ?? createSyntheticGraph(),
     llm,
+    realWrites: input.realWrites ?? false,
     log: (level, message, metadata) => {
       working = appendLog(working, level, message, currentStepId, metadata);
       void input.onProgress(working);


### PR DESCRIPTION
Closes the last "synthetic-but-pretends" gap. The \`retire-inactive-devices\` agent can now actually call Microsoft Graph to retire devices after typed diff confirmation, **but only when both conditions hold**:
1. A real tenant is connected (\`dataSource === "graph"\`)
2. The user has flipped a new global toggle in Settings → Privacy → **"Enable real Graph writes"** to ON

Default is OFF — apply emits a simulated trace and never touches Graph.

## Layered safety

| Layer | When | Can be bypassed? |
| --- | --- | --- |
| 1. Diff confirmation with typed phrase (\`RETIRE N DEVICES\`) | Always, every run | **Never.** Hard-coded by the SPEC. |
| 2. Real tenant connected | Per-run, stamped at queue time | Synthetic runs always simulate, regardless of toggle. |
| 3. Global toggle ON | Persistent user setting in \`state.json\` | Default OFF; users opt in explicitly. |

Even with (3) ON, every individual run still pauses at (1) before any Graph call is made.

## Per-device error handling

A 404 / 403 / throttle on one device records the failure into \`result.failed[]\` and the agent keeps processing the rest. Final summary reports successes + failures. The run completes (not fails) even if some devices errored.

## API surface

- **\`@openagents/agent-sdk\`**
  - \`RunGraphApi.retireManagedDevice(deviceId)\`
  - \`RunContext.realWrites: boolean\` — agents branch their apply on this
  - \`AppState.realWritesEnabled: boolean\`
  - \`OpenAgentsApi.setRealWritesEnabled(enabled)\`
- **\`@openagents/runtime\`**
  - Real graph adapter \`POST /deviceManagement/managedDevices/{id}/retire\`, empty body, reuses 429/5xx retry. \`graphRequest\` now supports POST + non-JSON responses.
  - Synthetic graph \`retireManagedDevice\` is a no-op safety net.
- **Electron state**
  - \`PersistedState.realWritesEnabled\` with backward-compatible loader defaulting.
  - \`resolveRealWrites()\` = \`dataSource === "graph" && toggle ON\`.
- **Renderer**
  - Settings → Privacy: new toggle row with honest copy.
  - \`/runs/:id\` diff-confirm panel: contextual red banner when armed for real, blue banner when simulated.

## QA gate

No change required — the retire-inactive-devices manifest already declared the retire endpoint. \`npm run qa\` stays at 12 pass / 1 warn / 0 fail.

## Test plan

- [x] \`npm run typecheck\` + \`npm run qa\` + \`npm run build\` green.
- [ ] CI green.
- [ ] Manual: with toggle OFF and a real tenant connected, run retire-inactive-devices → diff panel shows blue banner → confirm → run completes with \`result.mode === "simulated"\`, \`result.simulatedDeviceIds\` populated, logs contain \`[simulated] would retire …\`. **No outgoing POST.**
- [ ] Manual: with toggle ON and tenant connected, run retire-inactive-devices → diff panel shows red banner → confirm → run completes with \`result.mode === "real"\`, real Graph POSTs fire per device.
- [ ] Manual: with toggle ON but synthetic mode (no tenant), run retire-inactive-devices → diff panel still shows blue banner (no tenant to write to) → confirm → simulated mode.

## Note on testing

The "toggle ON + real tenant" path will actually retire real devices in the test tenant. Recommend testing against a non-production tenant or a tenant where the affected devices are throwaway.