### PR TITLE
desktop: agent detail manifest preview + Install → Add rename

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -127,6 +127,9 @@ function registerIpcHandlers() {
     "openagents:set-real-writes-enabled",
     (_event, enabled: boolean) => store.setRealWritesEnabled(enabled),
   );
+  ipcMain.handle("openagents:get-agent-manifest", (_event, slug: string) =>
+    store.getAgentManifest(slug),
+  );
 }
 
 const gotLock = app.requestSingleInstanceLock();

--- a/apps/desktop/electron/preload.mts
+++ b/apps/desktop/electron/preload.mts
@@ -30,6 +30,8 @@ const api: OpenAgentsApi = {
     ipcRenderer.invoke("openagents:disconnect-tenant", id),
   setRealWritesEnabled: (enabled: boolean) =>
     ipcRenderer.invoke("openagents:set-real-writes-enabled", enabled),
+  getAgentManifest: (slug: string) =>
+    ipcRenderer.invoke("openagents:get-agent-manifest", slug),
 };
 
 contextBridge.exposeInMainWorld("openAgents", api);

--- a/apps/desktop/electron/state.ts
+++ b/apps/desktop/electron/state.ts
@@ -12,6 +12,7 @@ import {
   executeRun,
   findRegistryAgentById,
   listBuiltInRegistryAgents,
+  loadAgentManifestPreview,
   noopLlm,
   removeAccount,
   runInteractiveFlow,
@@ -19,6 +20,7 @@ import {
   type TokenCacheStorage,
 } from "@openagents/runtime";
 import type {
+  AgentManifestPreview,
   RunDataSource,
   RunGraphApi,
   RunLlmApi,
@@ -150,6 +152,24 @@ export class AppStateStore {
 
   listRegistryAgents(): RegistryAgentSummary[] {
     return listBuiltInRegistryAgents();
+  }
+
+  async getAgentManifest(slug: string): Promise<AgentManifestPreview | undefined> {
+    // Prefer the on-disk metadata from the registry (it has the correct
+    // registryPath) so the preview can label the source location.
+    const registryAgent = this.listRegistryAgents().find(
+      (agent) => agent.slug === slug || agent.id === slug,
+    );
+    if (registryAgent) {
+      return loadAgentManifestPreview(registryAgent);
+    }
+    // Fall back to an installed agent for the rare case where it's no
+    // longer in the registry but still in user state.
+    const persisted = await this.read();
+    const installed = persisted.installedAgents.find(
+      (agent) => agent.slug === slug || agent.id === slug,
+    );
+    return installed ? loadAgentManifestPreview(installed) : undefined;
   }
 
   async listAgents(): Promise<AgentSummary[]> {

--- a/apps/desktop/src/components/CommandPalette.tsx
+++ b/apps/desktop/src/components/CommandPalette.tsx
@@ -96,8 +96,8 @@ export function CommandPalette({
         label: "Start first run",
         hint:
           state.installedAgents.length > 0
-            ? "Queue the first installed agent"
-            : "Install an agent before running",
+            ? "Queue the first added agent"
+            : "Add an agent before running",
         group: "Actions",
         icon: <IconPlay size={13} className="text-[var(--color-accent)]" />,
         action: async () => {

--- a/apps/desktop/src/components/ManifestPreview.tsx
+++ b/apps/desktop/src/components/ManifestPreview.tsx
@@ -150,12 +150,12 @@ function PipelineCard({ steps }: { steps: TemplateStep[] }) {
 function StepRow({ step, index }: { step: TemplateStep; index: number }) {
   const tone = formatTone(step.format);
   return (
-    <div className="rounded-lg bg-[var(--color-bg-raised)] p-4 ring-1 ring-[var(--color-border-soft)]">
-      <div className="flex items-start gap-3">
+    <div className="min-w-0 rounded-lg bg-[var(--color-bg-raised)] p-4 ring-1 ring-[var(--color-border-soft)]">
+      <div className="flex min-w-0 items-start gap-3">
         <span className="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--color-surface)] font-mono text-[11px] text-[var(--color-text-muted)] ring-1 ring-[var(--color-border-soft)]">
           {index + 1}
         </span>
-        <div className="min-w-0 flex-1">
+        <div className="min-w-0 flex-1 overflow-hidden">
           <div className="flex items-center gap-2">
             <span className="text-[13.5px] font-medium text-[var(--color-text)]">
               {step.label}
@@ -196,12 +196,12 @@ function StepDetail({ step }: { step: TemplateStep }) {
 
 function GraphDetail({ step }: { step: GraphStep }) {
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex items-center gap-2 font-mono text-[11.5px]">
-        <span className="rounded bg-[var(--color-success-soft)] px-1.5 py-0.5 text-[10.5px] font-semibold uppercase tracking-wider text-[var(--color-success)]">
+    <div className="flex min-w-0 flex-col gap-2">
+      <div className="flex min-w-0 items-center gap-2 font-mono text-[11.5px]">
+        <span className="shrink-0 rounded bg-[var(--color-success-soft)] px-1.5 py-0.5 text-[10.5px] font-semibold uppercase tracking-wider text-[var(--color-success)]">
           {step.settings.method}
         </span>
-        <span className="truncate text-[var(--color-text)]">{step.settings.path}</span>
+        <span className="min-w-0 truncate text-[var(--color-text)]">{step.settings.path}</span>
       </div>
       {step.settings.select && step.settings.select.length > 0 && (
         <div className="flex flex-wrap items-center gap-1.5">

--- a/apps/desktop/src/components/ManifestPreview.tsx
+++ b/apps/desktop/src/components/ManifestPreview.tsx
@@ -1,0 +1,517 @@
+import { useState } from "react";
+import { Card } from "./Card";
+import { Pill } from "./Pill";
+import {
+  IconBolt,
+  IconChevronDown,
+  IconCloud,
+  IconLock,
+  IconShield,
+  IconSparkle,
+} from "./icons";
+import type {
+  AgentManifestPreview,
+  AgentTemplate,
+  GraphStep,
+  LlmStep,
+  TemplateStep,
+  TransformStep,
+} from "../shared/openAgents";
+
+/**
+ * Renders an agent's manifest as readable cards so users can audit what an
+ * agent does before installing or running it. Two render paths:
+ *   - `agent-template` — declarative YAML pipeline (`<TemplateBody>`)
+ *   - `code-based`     — TypeScript module with metadata only
+ *                        (`<CodeBasedBody>`)
+ *
+ * Both flavours include a "View raw" affordance at the bottom for users who
+ * want to read the exact source the runtime sees.
+ */
+export function ManifestPreview({ preview }: { preview: AgentManifestPreview }) {
+  if (preview.kind === "agent-template") {
+    return <TemplateBody preview={preview} />;
+  }
+  return <CodeBasedBody preview={preview} />;
+}
+
+function TemplateBody({
+  preview,
+}: {
+  preview: Extract<AgentManifestPreview, { kind: "agent-template" }>;
+}) {
+  const { manifest, sourceText, registryPath } = preview;
+  const scopes = collectScopesFromManifest(manifest);
+  return (
+    <div className="flex flex-col gap-6">
+      <ScopesCard scopes={scopes} />
+      <PipelineCard steps={manifest.skills} />
+      <SettingsCard manifest={manifest} />
+      <ResultCard manifest={manifest} />
+      <RawSourceCard
+        sourceText={sourceText}
+        registryPath={registryPath}
+        languageHint="yaml"
+        title="Raw manifest"
+        helperText="This is the exact YAML the runtime loaded. The pipeline above is derived from it — there is no hidden code path."
+      />
+    </div>
+  );
+}
+
+function CodeBasedBody({
+  preview,
+}: {
+  preview: Extract<AgentManifestPreview, { kind: "code-based" }>;
+}) {
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <div className="p-6">
+          <SectionLabel>This is a code-based agent</SectionLabel>
+          <p className="mt-3 text-[13.5px] leading-relaxed text-[var(--color-text-soft)]">
+            Capabilities are declared in <code className="font-mono text-[12px]">manifest.json</code>{" "}
+            (shown below). The actual logic lives in a TypeScript module that
+            we can't pretty-print here. The runtime still enforces the
+            declared scopes and graph operations at runtime — the agent
+            cannot call anything outside what it declares.
+          </p>
+          <p className="mt-3 text-[12.5px] text-[var(--color-text-muted)]">
+            Source location: <code className="font-mono">{preview.sourceLocation}</code>
+          </p>
+        </div>
+      </Card>
+      <ScopesCard scopes={preview.metadata.scopes} />
+      {preview.sourceText && (
+        <RawSourceCard
+          sourceText={preview.sourceText}
+          registryPath={preview.registryPath}
+          languageHint="json"
+          title="manifest.json"
+          helperText="Registry metadata only. The implementation lives in TypeScript source under the same directory."
+        />
+      )}
+    </div>
+  );
+}
+
+// ─── shared bits ─────────────────────────────────────────────────────────
+
+function ScopesCard({ scopes }: { scopes: string[] }) {
+  if (scopes.length === 0) return null;
+  return (
+    <Card>
+      <div className="p-6">
+        <SectionLabel>Required Graph scopes</SectionLabel>
+        <div className="mt-3 flex flex-col gap-2">
+          {scopes.map((scope) => (
+            <div
+              key={scope}
+              className="flex items-center gap-2.5 rounded-md bg-[var(--color-bg-raised)] px-3 py-2 ring-1 ring-[var(--color-border-soft)]"
+            >
+              <IconLock size={13} className="text-[var(--color-text-muted)]" />
+              <span className="font-mono text-[12px] text-[var(--color-text)]">
+                {scope}
+              </span>
+            </div>
+          ))}
+        </div>
+        <div className="mt-4 text-[12px] text-[var(--color-text-muted)]">
+          Approved at tenant sign-in. You can revoke these from the
+          tenant's Enterprise applications view in the Microsoft Entra
+          admin center at any time.
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function PipelineCard({ steps }: { steps: TemplateStep[] }) {
+  return (
+    <Card>
+      <div className="p-6">
+        <SectionLabel>Pipeline</SectionLabel>
+        <div className="mt-1 text-[12px] text-[var(--color-text-muted)]">
+          The agent runs these steps in order. Each step's output is named
+          after its id and is available to later steps.
+        </div>
+        <ol className="mt-5 flex flex-col gap-3">
+          {steps.map((step, index) => (
+            <li key={step.id}>
+              <StepRow step={step} index={index} />
+            </li>
+          ))}
+        </ol>
+      </div>
+    </Card>
+  );
+}
+
+function StepRow({ step, index }: { step: TemplateStep; index: number }) {
+  const tone = formatTone(step.format);
+  return (
+    <div className="rounded-lg bg-[var(--color-bg-raised)] p-4 ring-1 ring-[var(--color-border-soft)]">
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--color-surface)] font-mono text-[11px] text-[var(--color-text-muted)] ring-1 ring-[var(--color-border-soft)]">
+          {index + 1}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-[13.5px] font-medium text-[var(--color-text)]">
+              {step.label}
+            </span>
+            <Pill tone={tone}>
+              <FormatIcon format={step.format} /> {formatLabel(step.format)}
+            </Pill>
+            <span className="font-mono text-[10.5px] text-[var(--color-text-muted)]">
+              id: {step.id}
+            </span>
+          </div>
+          {step.detail && (
+            <p className="mt-1.5 text-[12.5px] leading-relaxed text-[var(--color-text-soft)]">
+              {step.detail}
+            </p>
+          )}
+          <div className="mt-3">
+            <StepDetail step={step} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StepDetail({ step }: { step: TemplateStep }) {
+  switch (step.format) {
+    case "graph":
+      return <GraphDetail step={step} />;
+    case "transform":
+      return <TransformDetail step={step} />;
+    case "llm":
+      return <LlmDetail step={step} />;
+    default:
+      return null;
+  }
+}
+
+function GraphDetail({ step }: { step: GraphStep }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2 font-mono text-[11.5px]">
+        <span className="rounded bg-[var(--color-success-soft)] px-1.5 py-0.5 text-[10.5px] font-semibold uppercase tracking-wider text-[var(--color-success)]">
+          {step.settings.method}
+        </span>
+        <span className="truncate text-[var(--color-text)]">{step.settings.path}</span>
+      </div>
+      {step.settings.select && step.settings.select.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-[10.5px] uppercase tracking-wider text-[var(--color-text-muted)]">
+            $select
+          </span>
+          {step.settings.select.map((field) => (
+            <span
+              key={field}
+              className="rounded-md bg-[var(--color-surface)] px-2 py-0.5 font-mono text-[10.5px] text-[var(--color-text-soft)] ring-1 ring-[var(--color-border-soft)]"
+            >
+              {field}
+            </span>
+          ))}
+        </div>
+      )}
+      {step.settings.scopes && step.settings.scopes.length > 0 && (
+        <div className="text-[11px] text-[var(--color-text-muted)]">
+          Uses scope{step.settings.scopes.length === 1 ? "" : "s"}:{" "}
+          {step.settings.scopes.map((scope, idx) => (
+            <span key={scope}>
+              {idx > 0 ? ", " : ""}
+              <span className="font-mono text-[var(--color-text-soft)]">{scope}</span>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TransformDetail({ step }: { step: TransformStep }) {
+  const settings = step.settings as Record<string, unknown>;
+  const kind = typeof settings.kind === "string" ? settings.kind : "(unknown)";
+  const summaryFields = Object.entries(settings).filter(
+    ([key]) => key !== "kind" && key !== "source",
+  );
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2 text-[11.5px] text-[var(--color-text-soft)]">
+        <span className="rounded bg-[var(--color-info-soft)] px-1.5 py-0.5 font-mono text-[10.5px] font-semibold uppercase tracking-wider text-[var(--color-info)]">
+          {kind}
+        </span>
+        {typeof settings.source === "string" && (
+          <span className="font-mono text-[11px] text-[var(--color-text-muted)]">
+            source: {settings.source}
+          </span>
+        )}
+      </div>
+      {summaryFields.length > 0 && (
+        <pre className="overflow-x-auto rounded-md bg-[var(--color-surface)] p-3 font-mono text-[10.5px] text-[var(--color-text-soft)] ring-1 ring-[var(--color-border-soft)]">
+          {summaryFields
+            .map(([key, value]) => `${key}: ${stringify(value)}`)
+            .join("\n")}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function LlmDetail({ step }: { step: LlmStep }) {
+  const [promptOpen, setPromptOpen] = useState(false);
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-2 text-[11.5px] text-[var(--color-text-soft)]">
+        {step.when === "ctx.llm.available" && (
+          <Pill tone="default">
+            <IconShield size={9} /> Gated on LLM availability
+          </Pill>
+        )}
+        {typeof step.settings.temperature === "number" && (
+          <span className="font-mono text-[10.5px] text-[var(--color-text-muted)]">
+            temperature: {step.settings.temperature}
+          </span>
+        )}
+        {typeof step.settings.maxTokens === "number" && (
+          <span className="font-mono text-[10.5px] text-[var(--color-text-muted)]">
+            maxTokens: {step.settings.maxTokens}
+          </span>
+        )}
+      </div>
+      <button
+        onClick={() => setPromptOpen((open) => !open)}
+        className="inline-flex w-fit items-center gap-1.5 text-[11.5px] font-medium text-[var(--color-accent)] hover:text-[var(--color-accent-hover)]"
+      >
+        <IconChevronDown
+          size={11}
+          style={{
+            transform: promptOpen ? "rotate(0deg)" : "rotate(-90deg)",
+            transition: "transform 0.15s ease",
+          }}
+        />
+        {promptOpen ? "Hide prompt" : "Show prompt template"}
+      </button>
+      {promptOpen && (
+        <div className="flex flex-col gap-3 rounded-md bg-[var(--color-surface)] p-3 ring-1 ring-[var(--color-border-soft)]">
+          {step.settings.system && (
+            <div>
+              <div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+                System
+              </div>
+              <pre className="whitespace-pre-wrap font-mono text-[11px] leading-relaxed text-[var(--color-text-soft)]">
+                {step.settings.system}
+              </pre>
+            </div>
+          )}
+          <div>
+            <div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+              Prompt
+            </div>
+            <pre className="whitespace-pre-wrap font-mono text-[11px] leading-relaxed text-[var(--color-text-soft)]">
+              {step.settings.prompt}
+            </pre>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SettingsCard({ manifest }: { manifest: AgentTemplate }) {
+  const settings = manifest.definition.settings ?? [];
+  if (settings.length === 0) return null;
+  return (
+    <Card>
+      <div className="p-6">
+        <SectionLabel>Configurable settings</SectionLabel>
+        <div className="mt-1 text-[12px] text-[var(--color-text-muted)]">
+          These can be overridden at install time. Defaults shown here are
+          what the agent will use unless you change them.
+        </div>
+        <div className="mt-4 flex flex-col gap-2.5">
+          {settings.map((setting) => (
+            <div
+              key={setting.id}
+              className="flex items-center justify-between gap-4 rounded-md bg-[var(--color-bg-raised)] px-3 py-2 ring-1 ring-[var(--color-border-soft)]"
+            >
+              <div className="min-w-0">
+                <div className="text-[13px] font-medium text-[var(--color-text)]">
+                  {setting.label}
+                </div>
+                {setting.description && (
+                  <div className="mt-0.5 text-[11.5px] text-[var(--color-text-muted)]">
+                    {setting.description}
+                  </div>
+                )}
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <Pill>{setting.type}</Pill>
+                {setting.default !== undefined && (
+                  <span className="rounded-md bg-[var(--color-surface)] px-2 py-0.5 font-mono text-[10.5px] text-[var(--color-text-soft)] ring-1 ring-[var(--color-border-soft)]">
+                    default: {stringify(setting.default)}
+                  </span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function ResultCard({ manifest }: { manifest: AgentTemplate }) {
+  return (
+    <Card>
+      <div className="p-6">
+        <SectionLabel>What the run produces</SectionLabel>
+        <div className="mt-3">
+          <div className="text-[11.5px] uppercase tracking-wider text-[var(--color-text-muted)]">
+            Summary template
+          </div>
+          <pre className="mt-1.5 whitespace-pre-wrap rounded-md bg-[var(--color-bg-raised)] p-3 font-mono text-[11.5px] leading-relaxed text-[var(--color-text-soft)] ring-1 ring-[var(--color-border-soft)]">
+            {manifest.definition.result.summary}
+          </pre>
+        </div>
+        {manifest.definition.result.data && (
+          <div className="mt-4">
+            <div className="text-[11.5px] uppercase tracking-wider text-[var(--color-text-muted)]">
+              Result data shape
+            </div>
+            <pre className="mt-1.5 overflow-x-auto rounded-md bg-[var(--color-bg-raised)] p-3 font-mono text-[11px] leading-relaxed text-[var(--color-text-soft)] ring-1 ring-[var(--color-border-soft)]">
+              {stringify(manifest.definition.result.data, 2)}
+            </pre>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function RawSourceCard({
+  sourceText,
+  registryPath,
+  languageHint,
+  title,
+  helperText,
+}: {
+  sourceText: string;
+  registryPath?: string;
+  languageHint: string;
+  title: string;
+  helperText: string;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Card>
+      <div className="p-6">
+        <button
+          onClick={() => setOpen((current) => !current)}
+          className="flex w-full items-center gap-2 text-left"
+        >
+          <IconChevronDown
+            size={12}
+            className="text-[var(--color-text-muted)]"
+            style={{
+              transform: open ? "rotate(0deg)" : "rotate(-90deg)",
+              transition: "transform 0.15s ease",
+            }}
+          />
+          <SectionLabel>{title}</SectionLabel>
+          <span className="ml-auto rounded bg-[var(--color-bg-raised)] px-1.5 py-0.5 font-mono text-[10px] text-[var(--color-text-muted)]">
+            .{languageHint}
+          </span>
+        </button>
+        {registryPath && (
+          <div className="mt-2 font-mono text-[10.5px] text-[var(--color-text-muted)]">
+            {registryPath}
+          </div>
+        )}
+        {open && (
+          <>
+            <p className="mt-3 text-[11.5px] leading-relaxed text-[var(--color-text-muted)]">
+              {helperText}
+            </p>
+            <pre className="mt-3 max-h-[480px] overflow-auto rounded-lg bg-[var(--color-bg-raised)] p-4 font-mono text-[11px] leading-relaxed text-[var(--color-text-soft)] ring-1 ring-[var(--color-border-soft)]">
+              {sourceText}
+            </pre>
+          </>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function SectionLabel({ children }: { children: string }) {
+  return (
+    <span className="text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+      {children}
+    </span>
+  );
+}
+
+function FormatIcon({ format }: { format: TemplateStep["format"] }) {
+  switch (format) {
+    case "graph":
+      return <IconCloud size={9} />;
+    case "transform":
+      return <IconBolt size={9} />;
+    case "llm":
+      return <IconSparkle size={9} />;
+    default:
+      return null;
+  }
+}
+
+function formatLabel(format: TemplateStep["format"]): string {
+  switch (format) {
+    case "graph":
+      return "Graph";
+    case "transform":
+      return "Transform";
+    case "llm":
+      return "LLM";
+    default:
+      return format;
+  }
+}
+
+function formatTone(
+  format: TemplateStep["format"],
+): "success" | "warning" | "accent" | "default" {
+  switch (format) {
+    case "graph":
+      return "success";
+    case "transform":
+      return "default";
+    case "llm":
+      return "accent";
+    default:
+      return "default";
+  }
+}
+
+function collectScopesFromManifest(manifest: AgentTemplate): string[] {
+  const scopes = new Set<string>();
+  for (const step of manifest.skills) {
+    if (step.format === "graph") {
+      for (const scope of step.settings.scopes ?? []) {
+        scopes.add(scope);
+      }
+    }
+  }
+  return [...scopes];
+}
+
+function stringify(value: unknown, indent = 0): string {
+  try {
+    return JSON.stringify(value, null, indent);
+  } catch {
+    return String(value);
+  }
+}

--- a/apps/desktop/src/pages/AgentDetail.tsx
+++ b/apps/desktop/src/pages/AgentDetail.tsx
@@ -1,20 +1,21 @@
+import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { PageBody, PageHeader } from "../components/AppShell";
 import { Card } from "../components/Card";
 import { Pill } from "../components/Pill";
 import { Button } from "../components/Button";
 import { Avatar } from "../components/Avatar";
+import { ManifestPreview } from "../components/ManifestPreview";
 import { ShareMenu } from "../components/ShareMenu";
 import {
   IconArrowLeft,
   IconBadgeCheck,
   IconBolt,
-  IconLock,
   IconPlay,
   IconShield,
 } from "../components/icons";
 import { useAppState } from "../state";
-import type { RunRecord } from "../shared/openAgents";
+import type { AgentManifestPreview, RunRecord } from "../shared/openAgents";
 
 export default function AgentDetail() {
   const { slug } = useParams();
@@ -22,6 +23,38 @@ export default function AgentDetail() {
   const { state, startRun } = useAppState();
   const agent = state.installedAgents.find((a) => a.slug === slug);
   const recentRuns = state.runs.filter((run) => run.agentSlug === slug).slice(0, 3);
+  const [preview, setPreview] = useState<AgentManifestPreview | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(true);
+
+  useEffect(() => {
+    if (!slug) return;
+    let cancelled = false;
+    setPreviewLoading(true);
+    setPreviewError(null);
+    const api = window.openAgents;
+    if (!api) {
+      setPreview(null);
+      setPreviewLoading(false);
+      return;
+    }
+    api
+      .getAgentManifest(slug)
+      .then((result) => {
+        if (cancelled) return;
+        setPreview(result ?? null);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setPreviewError(error instanceof Error ? error.message : String(error));
+      })
+      .finally(() => {
+        if (!cancelled) setPreviewLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
 
   if (!agent) {
     return (
@@ -59,9 +92,17 @@ export default function AgentDetail() {
               <IconBadgeCheck size={12} className="text-[var(--color-accent)]" />
             )}
             <span className="opacity-50">·</span>
-            <span className="font-mono">{agent.version}</span>
+            <span className="font-mono">v{agent.version}</span>
             <span className="opacity-50">·</span>
             <span className="capitalize">{agent.category}</span>
+            {preview && (
+              <>
+                <span className="opacity-50">·</span>
+                <Pill tone={preview.kind === "agent-template" ? "accent" : "default"}>
+                  {preview.kind === "agent-template" ? "YAML template" : "Code-based"}
+                </Pill>
+              </>
+            )}
           </span>
         }
         actions={
@@ -98,31 +139,29 @@ export default function AgentDetail() {
               </div>
             </Card>
 
-            <Card>
-              <div className="p-6">
-                <SectionLabel>Required Graph scopes</SectionLabel>
-                <div className="mt-3 flex flex-col gap-2">
-                  {agent.scopes.map((scope) => (
-                    <div
-                      key={scope}
-                      className="flex items-center gap-2.5 rounded-md bg-[var(--color-bg-raised)] px-3 py-2 ring-1 ring-[var(--color-border-soft)]"
-                    >
-                      <IconLock
-                        size={13}
-                        className="text-[var(--color-text-muted)]"
-                      />
-                      <span className="font-mono text-[12px] text-[var(--color-text)]">
-                        {scope}
-                      </span>
-                    </div>
-                  ))}
+            {previewLoading && (
+              <Card>
+                <div className="p-6 text-[13px] text-[var(--color-text-muted)]">
+                  Loading manifest…
                 </div>
-                <div className="mt-4 text-[12px] text-[var(--color-text-muted)]">
-                  Granted at install time. You can revoke them from your
-                  tenant's enterprise apps view at any time.
+              </Card>
+            )}
+
+            {previewError && (
+              <Card>
+                <div className="p-6 text-[13px] text-[var(--color-danger)]">
+                  Couldn't load manifest: {previewError}
                 </div>
-              </div>
-            </Card>
+              </Card>
+            )}
+
+            {!previewLoading && !previewError && preview && (
+              <ManifestPreview preview={preview} />
+            )}
+
+            {!previewLoading && !preview && (
+              <FallbackScopesCard scopes={agent.scopes} />
+            )}
 
             <Card>
               <div className="p-6">
@@ -213,6 +252,24 @@ export default function AgentDetail() {
         </div>
       </PageBody>
     </>
+  );
+}
+
+function FallbackScopesCard({ scopes }: { scopes: string[] }) {
+  if (scopes.length === 0) return null;
+  return (
+    <Card>
+      <div className="p-6">
+        <SectionLabel>Required Graph scopes</SectionLabel>
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {scopes.map((scope) => (
+            <Pill key={scope}>
+              <span className="font-mono text-[11px]">{scope}</span>
+            </Pill>
+          ))}
+        </div>
+      </div>
+    </Card>
   );
 }
 

--- a/apps/desktop/src/pages/AgentDetail.tsx
+++ b/apps/desktop/src/pages/AgentDetail.tsx
@@ -122,8 +122,8 @@ export default function AgentDetail() {
         }
       />
       <PageBody>
-        <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]">
-          <div className="flex flex-col gap-6">
+        <div className="grid min-w-0 grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+          <div className="flex min-w-0 flex-col gap-6">
             <Card>
               <div className="p-6">
                 <SectionLabel>About</SectionLabel>

--- a/apps/desktop/src/pages/AgentHub.tsx
+++ b/apps/desktop/src/pages/AgentHub.tsx
@@ -226,7 +226,7 @@ function FeaturedCard({
               leadingIcon={installed ? <IconCheck size={12} /> : undefined}
               onClick={onInstall}
             >
-              {installed ? "Installed" : "Install"}
+              {installed ? "Added" : "Add"}
             </Button>
             <Button size="md" variant="secondary">
               View manifest
@@ -345,7 +345,7 @@ function TrendingCard({
               onInstall();
             }}
           >
-            {installed ? "Installed" : "Install"}
+            {installed ? "Added" : "Add"}
           </Button>
         </div>
       </div>
@@ -425,11 +425,11 @@ function HubAgentCard({
               leadingIcon={<IconCheck size={12} />}
               disabled
             >
-              Installed
+              Added
             </Button>
           ) : (
             <Button variant="primary" size="sm" onClick={onInstall}>
-              Install
+              Add
             </Button>
           )}
         </div>

--- a/apps/desktop/src/pages/AgentsHome.tsx
+++ b/apps/desktop/src/pages/AgentsHome.tsx
@@ -141,7 +141,7 @@ export default function AgentsHome() {
           <section>
             <div className="mb-3 flex items-center justify-between">
               <h2 className="text-[13px] font-medium text-[var(--color-text)]">
-                Installed
+                Added
               </h2>
               <span className="text-[11px] text-[var(--color-text-muted)]">
                 {filtered.length} of {state.installedAgents.length}
@@ -259,7 +259,7 @@ export default function AgentsHome() {
                   disabled={!retireAvailable}
                   className="mt-3 text-[11.5px] font-medium text-[var(--color-accent)] hover:text-[var(--color-accent-hover)] disabled:cursor-not-allowed disabled:opacity-50"
                 >
-                  {retireInstalled ? "Run retire" : "Install + run retire"} →
+                  {retireInstalled ? "Run retire" : "Add + run retire"} →
                 </button>
               </div>
             </Card>
@@ -321,7 +321,7 @@ function EmptyState({ hasAgents }: { hasAgents: boolean }) {
       <div className="mt-1 text-[13px] text-[var(--color-text-muted)]">
         {hasAgents
           ? "Try a different query, or browse the hub for community agents."
-          : "Install an agent from the hub once registry support is wired."}
+          : "Add an agent from the hub once registry support is wired."}
       </div>
     </div>
   );

--- a/apps/desktop/src/pages/Onboarding.tsx
+++ b/apps/desktop/src/pages/Onboarding.tsx
@@ -636,7 +636,7 @@ function PickAgent({
           onClick={onContinue}
           disabled={working || featured.length === 0}
         >
-          {working ? "Installing…" : "Install and run"}
+          {working ? "Adding…" : "Add and run"}
         </Button>
       </div>
     </div>

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -195,7 +195,36 @@ export interface OpenAgentsApi {
   setActiveTenant(id: string): Promise<AppState>;
   disconnectTenant(id: string): Promise<AppState>;
   setRealWritesEnabled(enabled: boolean): Promise<AppState>;
+  getAgentManifest(slug: string): Promise<AgentManifestPreview | undefined>;
 }
+
+/**
+ * Renderer-friendly snapshot of an agent's manifest, used by the Agent
+ * detail screen to render a transparency-first preview of what the agent
+ * actually does. Two flavours mirror the two authoring modes:
+ *
+ * - `agent-template`  — the agent ships a YAML pipeline. `manifest` is the
+ *                       parsed structure; `source` is the raw YAML text for
+ *                       the "View raw" affordance.
+ * - `code-based`      — the agent ships a TypeScript / JavaScript module.
+ *                       We can only show metadata from `manifest.json`; the
+ *                       actual logic lives in code. `sourceLocation` points
+ *                       at the file path relative to the monorepo root.
+ */
+export type AgentManifestPreview =
+  | {
+      kind: "agent-template";
+      registryPath?: string;
+      manifest: AgentTemplate;
+      sourceText: string;
+    }
+  | {
+      kind: "code-based";
+      registryPath?: string;
+      metadata: RegistryAgentSummary;
+      sourceText?: string;
+      sourceLocation: string;
+    };
 
 export type AgentDefinition = AgentContract &
   Partial<Pick<RegistryAgentSummary, "registryId" | "registryPath" | "installs" | "rating">>;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -5,6 +5,7 @@ import { pathToFileURL, fileURLToPath } from "node:url";
 import type {
   AgentAuthor,
   AgentCategory,
+  AgentManifestPreview,
   AgentMode,
   AgentModule,
   AgentRunResult,
@@ -495,6 +496,59 @@ function validatePlan(plan: WritePlan, agentSlug: string): void {
       );
     }
   }
+}
+
+/**
+ * Read-only inspection of an agent's on-disk manifest, exposed to the
+ * renderer for the Agent detail "preview" surface. Returns `undefined`
+ * when neither a manifest.yaml nor a compiled code module can be found.
+ */
+export function loadAgentManifestPreview(
+  agent: AgentSummary | RegistryAgentSummary,
+): AgentManifestPreview | undefined {
+  let agentDir: string;
+  try {
+    agentDir = resolveAgentDirectory(agent);
+  } catch {
+    return undefined;
+  }
+
+  const yamlPath = join(agentDir, "manifest.yaml");
+  if (existsSync(yamlPath)) {
+    const sourceText = readFileSync(yamlPath, "utf8");
+    let manifest;
+    try {
+      manifest = parseAgentTemplate(sourceText);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Agent template at ${yamlPath} is invalid: ${message}`,
+      );
+    }
+    return {
+      kind: "agent-template",
+      ...(agent.registryPath ? { registryPath: agent.registryPath } : {}),
+      manifest,
+      sourceText,
+    };
+  }
+
+  // Code-based fallback: show metadata from manifest.json + a pointer to the
+  // source location so curious users can inspect the code in GitHub.
+  const jsonPath = join(agentDir, "manifest.json");
+  if (existsSync(jsonPath)) {
+    const sourceText = readFileSync(jsonPath, "utf8");
+    const metadata = loadManifest(jsonPath, agentDir);
+    return {
+      kind: "code-based",
+      ...(agent.registryPath ? { registryPath: agent.registryPath } : {}),
+      metadata,
+      sourceText,
+      sourceLocation: agent.registryPath ?? agentDir,
+    };
+  }
+
+  return undefined;
 }
 
 export async function loadAgentModule(


### PR DESCRIPTION
The transparency story made visible. Renders an agent's parsed manifest as auditable cards on \`/agents/:slug\` so users can see exactly what the agent does before adding or running it.

Plus a small UX honesty fix: renames "Install" to "Add" everywhere in the UI. Nothing is actually downloaded — agents are bundled with the app; the button just enables them in user state. Calling it "Install" was misleading.

## Two render flavours

| Authoring mode | Preview shows |
| --- | --- |
| **YAML template** (\`manifest.yaml\` present) | Identity → scopes → pipeline cards (one per step with format-specific detail) → settings → result schema → raw YAML |
| **Code-based** (\`manifest.json\` only) | Honest banner: "Capabilities are in manifest.json; logic is in TypeScript." Scopes + raw \`manifest.json\` + source location pointer |

The pipeline rendering surfaces, per step:
- \`graph\` → HTTP method, path, \`$select\` fields, scopes used
- \`transform\` → kind, source binding, parameters as YAML
- \`llm\` → temperature, maxTokens, gating, expandable prompt template

Raw source is one click away in both flavours — anyone who wants to read the exact text the runtime loaded can.

## API surface

- **\`@openagents/agent-sdk\`** — new \`AgentManifestPreview\` union type with \`sourceText\`. New IPC method \`getAgentManifest(slug)\`.
- **\`@openagents/runtime\`** — \`loadAgentManifestPreview(agent)\` reads from the agent dir, parses YAML/JSON, returns the typed preview.
- **Electron** — IPC handler \`openagents:get-agent-manifest\` wired through main + preload + \`AppStateContext\`.
- **Renderer** — new \`<ManifestPreview>\` component used by \`AgentDetail\`. Header eyebrow now shows a "YAML template" / "Code-based" pill.

## Test plan

- [x] \`npm run typecheck\` + \`npm run qa\` + \`npm run build\` green.
- [x] Programmatic smoke: \`loadAgentManifestPreview\` returns \`agent-template\` for find-inactive-devices (3 steps, 3 settings) and \`code-based\` for retire-inactive-devices (with both scopes + source path).
- [ ] CI green.
- [ ] Manual: open \`/agents/find-inactive-devices\` in the dev app — see the full pipeline. Click "Show prompt template" inside the LLM step. Expand "Raw manifest" at the bottom.
- [ ] Manual: open \`/agents/retire-inactive-devices\` — see the code-based banner + manifest.json content.
- [ ] Manual: Agent Hub buttons read "Add" / "Added" instead of "Install" / "Installed".