### PR TITLE
runtime: write step format in Agent Templates + retire-inactive-devices as YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Open Agents are recorded here. Format follows [Keep a Cha
 ## [Unreleased]
 
 ### Added
+- `write` step format in Agent Templates. Write-mode agents now declare a `write` skill with `kind`, `source`, `confirmationPhrase`, and `actionTemplate` (rendered once per source item). The interpreter pauses on plan, builds a `WritePlan`, and dispatches each approved action to a registered handler (`retire-managed-device` for v0.1). `retire-inactive-devices` migrated from TypeScript to `manifest.yaml`; behaviour against synthetic Graph fixtures is identical (4 candidates, phrase `RETIRE 4 DEVICES`, per-device retire calls on apply). Manifest preview UI renders the write step with its kind, source, confirmation phrase, action template, and required scopes — every promise of transparency now applies uniformly across read and write agents.
 - Initial project handoff: SPEC.md, CLAUDE.md, design mockups, contributor docs.
 - v0.1 (private preview showcase) scope locked in SPEC.md §5a with phased plan in `tasks/todo.md`.
 - Onboarding now installs a built-in registry agent through Electron IPC and routes into a live `/runs/:id`.

--- a/agents/retire-inactive-devices/manifest.yaml
+++ b/agents/retire-inactive-devices/manifest.yaml
@@ -1,0 +1,93 @@
+# Agent Template manifest for retire-inactive-devices.
+#
+# This is the companion write-mode agent to find-inactive-devices. The
+# pipeline loads the managed-device inventory, filters to devices that have
+# been inactive past the configured threshold, then emits a write step that
+# produces one retire action per candidate. The runtime pauses on the plan,
+# requires typed confirmation, and only calls Microsoft Graph during apply
+# when the host has gated real writes.
+
+descriptor:
+  id: retire-inactive-devices
+  name: Retire inactive devices
+  description: Companion to Find inactive devices. Retires devices that have not synced in 180+ days after typed diff confirmation.
+  version: 1.0.0
+  author:
+    name: OpenAgents
+    handle: openagents
+    verified: true
+  category: devices
+  mode: write
+  preferredModel: llama3.1:8b
+
+# ─── pipeline ──────────────────────────────────────────────────────────────
+skills:
+
+  # 1) Read managedDevices from the active tenant.
+  - id: load_devices
+    format: graph
+    label: Load managed device inventory
+    detail: Reads managedDevices from the active tenant.
+    settings:
+      method: GET
+      path: /deviceManagement/managedDevices
+      select:
+        - id
+        - deviceName
+        - userPrincipalName
+        - operatingSystem
+        - osVersion
+        - lastSyncDateTime
+        - enrolledDateTime
+        - complianceState
+      scopes:
+        - DeviceManagementManagedDevices.Read.All
+
+  # 2) Filter to devices that exceed the retire threshold. Pure data shaping.
+  - id: select_retire_candidates
+    format: transform
+    label: Select retire candidates
+    detail: "Devices inactive >= {{ settings.retireDays }} days."
+    settings:
+      kind: filter-by-age
+      source: "{{ load_devices.output }}"
+      timestampField: lastSyncDateTime
+      inactiveDaysAtLeast: "{{ settings.retireDays }}"
+
+  # 3) Emit one retire action per candidate. The runtime pauses here.
+  - id: plan_retirements
+    format: write
+    label: Build retire plan
+    detail: Produces one retire action per candidate device.
+    settings:
+      kind: retire-managed-device
+      source: "{{ select_retire_candidates.output }}"
+      confirmationPhrase: "RETIRE {{ actions | size }} DEVICES"
+      summary: >-
+        Retire {{ actions | size }} devices that have not synced in
+        {{ settings.retireDays }}+ days.
+      scopes:
+        - DeviceManagementManagedDevices.PrivilegedOperations.All
+      actionTemplate:
+        label: "Retire {{ item.deviceName }}"
+        description: "{{ item.userPrincipalName }} - {{ item.operatingSystem }} - last sync {{ item.lastSyncDateTime }}"
+        severity: destructive
+        metadata:
+          deviceId: "{{ item.id }}"
+          deviceName: "{{ item.deviceName }}"
+          userPrincipalName: "{{ item.userPrincipalName }}"
+          operatingSystem: "{{ item.operatingSystem }}"
+          lastSyncDateTime: "{{ item.lastSyncDateTime }}"
+
+# ─── what makes it an agent ────────────────────────────────────────────────
+definition:
+  settings:
+    - id: retireDays
+      label: Retire threshold (days)
+      type: integer
+      default: 180
+      description: Devices inactive at least this many days are flagged for retirement.
+
+  triggers:
+    - id: manual
+      kind: manual

--- a/apps/desktop/src/components/ManifestPreview.tsx
+++ b/apps/desktop/src/components/ManifestPreview.tsx
@@ -8,6 +8,7 @@ import {
   IconLock,
   IconShield,
   IconSparkle,
+  IconWarning,
 } from "./icons";
 import type {
   AgentManifestPreview,
@@ -16,6 +17,7 @@ import type {
   LlmStep,
   TemplateStep,
   TransformStep,
+  WriteStep,
 } from "../shared/openAgents";
 
 /**
@@ -189,9 +191,83 @@ function StepDetail({ step }: { step: TemplateStep }) {
       return <TransformDetail step={step} />;
     case "llm":
       return <LlmDetail step={step} />;
+    case "write":
+      return <WriteDetail step={step} />;
     default:
       return null;
   }
+}
+
+function WriteDetail({ step }: { step: WriteStep }) {
+  const { kind, source, confirmationPhrase, actionTemplate, scopes } = step.settings;
+  return (
+    <div className="flex min-w-0 flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-2 text-[11.5px] text-[var(--color-text-soft)]">
+        <span className="rounded bg-[var(--color-danger-soft)] px-1.5 py-0.5 font-mono text-[10.5px] font-semibold uppercase tracking-wider text-[var(--color-danger)]">
+          {kind}
+        </span>
+        <span className="font-mono text-[11px] text-[var(--color-text-muted)]">
+          source: {source}
+        </span>
+      </div>
+      <div className="rounded-md bg-[var(--color-danger-soft)] px-3 py-2 ring-1 ring-[var(--color-danger)]/30">
+        <div className="flex items-start gap-2">
+          <IconWarning size={12} className="mt-0.5 shrink-0 text-[var(--color-danger)]" />
+          <div className="min-w-0">
+            <div className="text-[11.5px] font-medium text-[var(--color-text)]">
+              Typed confirmation required
+            </div>
+            <div className="mt-0.5 text-[11px] text-[var(--color-text-soft)]">
+              The runtime pauses here and will not call Microsoft Graph until
+              the user types the rendered phrase verbatim.
+            </div>
+            <pre className="mt-2 overflow-x-auto rounded bg-[var(--color-surface)] px-2 py-1 font-mono text-[11px] text-[var(--color-text)] ring-1 ring-[var(--color-border-soft)]">
+              {confirmationPhrase}
+            </pre>
+          </div>
+        </div>
+      </div>
+      <div className="rounded-md bg-[var(--color-surface)] p-3 ring-1 ring-[var(--color-border-soft)]">
+        <div className="text-[10.5px] uppercase tracking-wider text-[var(--color-text-muted)]">
+          Action template (rendered once per source item)
+        </div>
+        <div className="mt-2 flex flex-col gap-1.5 font-mono text-[11px] leading-relaxed text-[var(--color-text-soft)]">
+          <div>
+            <span className="text-[var(--color-text-muted)]">label:</span>{" "}
+            {actionTemplate.label}
+          </div>
+          {actionTemplate.description && (
+            <div>
+              <span className="text-[var(--color-text-muted)]">description:</span>{" "}
+              {actionTemplate.description}
+            </div>
+          )}
+          <div>
+            <span className="text-[var(--color-text-muted)]">severity:</span>{" "}
+            {actionTemplate.severity ?? "destructive"}
+          </div>
+          {actionTemplate.metadata && (
+            <pre className="mt-1 overflow-x-auto rounded bg-[var(--color-bg-raised)] p-2 text-[10.5px] ring-1 ring-[var(--color-border-soft)]">
+              {`metadata:\n${Object.entries(actionTemplate.metadata)
+                .map(([key, value]) => `  ${key}: ${String(value)}`)
+                .join("\n")}`}
+            </pre>
+          )}
+        </div>
+      </div>
+      {scopes && scopes.length > 0 && (
+        <div className="text-[11px] text-[var(--color-text-muted)]">
+          Uses scope{scopes.length === 1 ? "" : "s"}:{" "}
+          {scopes.map((scope, idx) => (
+            <span key={scope}>
+              {idx > 0 ? ", " : ""}
+              <span className="font-mono text-[var(--color-text-soft)]">{scope}</span>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 function GraphDetail({ step }: { step: GraphStep }) {
@@ -366,6 +442,8 @@ function SettingsCard({ manifest }: { manifest: AgentTemplate }) {
 }
 
 function ResultCard({ manifest }: { manifest: AgentTemplate }) {
+  const result = manifest.definition.result;
+  if (!result) return null;
   return (
     <Card>
       <div className="p-6">
@@ -375,16 +453,16 @@ function ResultCard({ manifest }: { manifest: AgentTemplate }) {
             Summary template
           </div>
           <pre className="mt-1.5 whitespace-pre-wrap rounded-md bg-[var(--color-bg-raised)] p-3 font-mono text-[11.5px] leading-relaxed text-[var(--color-text-soft)] ring-1 ring-[var(--color-border-soft)]">
-            {manifest.definition.result.summary}
+            {result.summary}
           </pre>
         </div>
-        {manifest.definition.result.data && (
+        {result.data && (
           <div className="mt-4">
             <div className="text-[11.5px] uppercase tracking-wider text-[var(--color-text-muted)]">
               Result data shape
             </div>
             <pre className="mt-1.5 overflow-x-auto rounded-md bg-[var(--color-bg-raised)] p-3 font-mono text-[11px] leading-relaxed text-[var(--color-text-soft)] ring-1 ring-[var(--color-border-soft)]">
-              {stringify(manifest.definition.result.data, 2)}
+              {stringify(result.data, 2)}
             </pre>
           </div>
         )}
@@ -463,6 +541,8 @@ function FormatIcon({ format }: { format: TemplateStep["format"] }) {
       return <IconBolt size={9} />;
     case "llm":
       return <IconSparkle size={9} />;
+    case "write":
+      return <IconWarning size={9} />;
     default:
       return null;
   }
@@ -476,6 +556,8 @@ function formatLabel(format: TemplateStep["format"]): string {
       return "Transform";
     case "llm":
       return "LLM";
+    case "write":
+      return "Write";
     default:
       return format;
   }
@@ -483,7 +565,7 @@ function formatLabel(format: TemplateStep["format"]): string {
 
 function formatTone(
   format: TemplateStep["format"],
-): "success" | "warning" | "accent" | "default" {
+): "success" | "warning" | "accent" | "default" | "danger" {
   switch (format) {
     case "graph":
       return "success";
@@ -491,6 +573,8 @@ function formatTone(
       return "default";
     case "llm":
       return "accent";
+    case "write":
+      return "danger";
     default:
       return "default";
   }
@@ -500,6 +584,10 @@ function collectScopesFromManifest(manifest: AgentTemplate): string[] {
   const scopes = new Set<string>();
   for (const step of manifest.skills) {
     if (step.format === "graph") {
+      for (const scope of step.settings.scopes ?? []) {
+        scopes.add(scope);
+      }
+    } else if (step.format === "write") {
       for (const scope of step.settings.scopes ?? []) {
         scopes.add(scope);
       }

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -237,7 +237,7 @@ export type AgentDefinition = AgentContract &
 // (`{{ step_id.output }}`). No code execution — the only side effects an
 // agent can have are the Graph calls and LLM calls it declares.
 
-export type TemplateStepFormat = "graph" | "transform" | "llm";
+export type TemplateStepFormat = "graph" | "transform" | "llm" | "write";
 
 export interface GraphStep {
   id: string;
@@ -280,7 +280,61 @@ export interface LlmStep {
   };
 }
 
-export type TemplateStep = GraphStep | TransformStep | LlmStep;
+/**
+ * Templated `WriteAction` definition. The runtime renders this template
+ * once per `source` item to produce the `actions[]` of a `WritePlan`.
+ * `metadata` carries handler-specific fields (e.g. `deviceId` for
+ * `retire-managed-device`); the runtime's action-kind handler reads
+ * those fields when executing the approved action.
+ */
+export interface WriteActionTemplate {
+  label: string;
+  description?: string;
+  severity?: WriteActionSeverity;
+  metadata?: Record<string, string>;
+}
+
+/**
+ * Produces a `WritePlan` from a pipeline state. The runtime pauses the
+ * run at `awaiting-confirmation` after rendering the plan; on confirm,
+ * the runtime iterates `plan.actions` and dispatches each one to the
+ * handler registered for `settings.kind`. There is no separate "apply
+ * step" in the YAML — the apply phase is implicit and lives in the
+ * runtime's action-kind handler registry.
+ */
+export interface WriteStep {
+  id: string;
+  format: "write";
+  label: string;
+  detail?: string;
+  settings: {
+    /**
+     * The action kind the runtime should dispatch each action to.
+     * v0.1 supports: "retire-managed-device".
+     */
+    kind: string;
+    /** Liquid expression that resolves to an array of items. */
+    source: string;
+    /** Per-item template applied to each `source` item. */
+    actionTemplate: WriteActionTemplate;
+    /**
+     * The phrase the user must type verbatim to confirm. Templated
+     * — usually parameterised on the action count, e.g.
+     * `"RETIRE {{ items | size }} DEVICES"`.
+     */
+    confirmationPhrase: string;
+    /** Optional plan-level summary. Templated. */
+    summary?: string;
+    /**
+     * Graph scopes required to apply actions of this kind. Concatenated
+     * with the scopes declared on graph steps when the runtime reports
+     * the agent's effective scope set.
+     */
+    scopes?: string[];
+  };
+}
+
+export type TemplateStep = GraphStep | TransformStep | LlmStep | WriteStep;
 
 export type TemplateTriggerKind = "manual" | "scheduled";
 

--- a/packages/runtime/src/agent-template.ts
+++ b/packages/runtime/src/agent-template.ts
@@ -3,14 +3,19 @@ import { load as parseYaml } from "js-yaml";
 import type {
   AgentModule,
   AgentRunResult,
+  GraphStep,
+  LlmStep,
   ManagedDeviceRecord,
   ReadAgentModule,
   RunContext,
-  GraphStep,
-  LlmStep,
   AgentTemplate,
   TemplateStep,
   TransformStep,
+  WriteAction,
+  WriteAgentModule,
+  WriteActionTemplate,
+  WritePlan,
+  WriteStep,
 } from "@openagents/agent-sdk";
 
 import { renderDeep, renderTemplate, type TemplateContext } from "./template-engine.js";
@@ -25,7 +30,7 @@ export class ManifestValidationError extends Error {
 }
 
 /**
- * Parse a agent template from YAML (or JSON) text. Throws
+ * Parse an agent template from YAML (or JSON) text. Throws
  * ManifestValidationError on schema violations.
  */
 export function parseAgentTemplate(source: string): AgentTemplate {
@@ -39,18 +44,16 @@ export function parseAgentTemplate(source: string): AgentTemplate {
   const skills = requireArray(data, "skills");
   const definition = requireObject(data, "definition");
 
-  // Quick descriptor shape checks. The runtime's existing JSON validator
-  // already does deep checks for built-in registry agents -- here we just
-  // make sure the fields the interpreter reads are present.
   for (const field of ["id", "name", "description", "version", "category", "mode"] as const) {
     if (typeof descriptor[field] !== "string" || (descriptor[field] as string).length === 0) {
       throw new ManifestValidationError(`descriptor.${field}`, "must be a non-empty string");
     }
   }
-  if (descriptor.mode !== "read" && descriptor.mode !== "write") {
+  const mode = descriptor.mode;
+  if (mode !== "read" && mode !== "write") {
     throw new ManifestValidationError(
       "descriptor.mode",
-      `expected "read" or "write", got ${JSON.stringify(descriptor.mode)}`,
+      `expected "read" or "write", got ${JSON.stringify(mode)}`,
     );
   }
 
@@ -65,12 +68,38 @@ export function parseAgentTemplate(source: string): AgentTemplate {
     return validateSkill(skill as Record<string, unknown>, `skills[${idx}]`);
   });
 
-  if (!definition.result || typeof definition.result !== "object") {
-    throw new ManifestValidationError("definition.result", "must be an object");
+  const writeSteps = validated.filter(
+    (step): step is WriteStep => step.format === "write",
+  );
+  if (mode === "write" && writeSteps.length === 0) {
+    throw new ManifestValidationError(
+      "skills",
+      'write-mode agents must declare at least one step with format: "write"',
+    );
   }
-  const resultDef = definition.result as Record<string, unknown>;
-  if (typeof resultDef.summary !== "string") {
-    throw new ManifestValidationError("definition.result.summary", "must be a string");
+  if (mode === "read" && writeSteps.length > 0) {
+    throw new ManifestValidationError(
+      "skills",
+      'read-mode agents cannot declare a write step; set descriptor.mode to "write"',
+    );
+  }
+  if (writeSteps.length > 1) {
+    throw new ManifestValidationError(
+      "skills",
+      "v0.1 supports at most one write step per agent template",
+    );
+  }
+
+  // Read agents must declare a result template; write agents don't (the
+  // runtime emits a standardised result from the apply phase).
+  if (mode === "read") {
+    if (!definition.result || typeof definition.result !== "object") {
+      throw new ManifestValidationError("definition.result", "must be an object for read agents");
+    }
+    const resultDef = definition.result as Record<string, unknown>;
+    if (typeof resultDef.summary !== "string") {
+      throw new ManifestValidationError("definition.result.summary", "must be a string");
+    }
   }
 
   return {
@@ -114,6 +143,9 @@ function validateSkill(skill: Record<string, unknown>, path: string): TemplateSt
       return skill as unknown as TransformStep;
     case "llm":
       return skill as unknown as LlmStep;
+    case "write":
+      validateWriteStepSettings(settings as Record<string, unknown>, `${path}.settings`);
+      return skill as unknown as WriteStep;
     default:
       throw new ManifestValidationError(
         `${path}.format`,
@@ -122,47 +154,37 @@ function validateSkill(skill: Record<string, unknown>, path: string): TemplateSt
   }
 }
 
-// ─── Interpreter ───────────────────────────────────────────────────────────
-
-/**
- * Execute a agent template against a live RunContext. Each skill's output
- * lands at `pipeline[skill.id].output` and is visible to later skills + the
- * final result template.
- */
-export async function runAgentTemplate(
-  manifest: AgentTemplate,
-  ctx: RunContext,
-): Promise<AgentRunResult> {
-  const settings = resolveSettings(manifest);
-  const pipeline: Record<string, { output: unknown }> = {};
-
-  const templateCtx = (): TemplateContext => ({
-    settings,
-    ctx: {
-      tenantId: ctx.agent.id, // placeholder until ctx exposes tenant info directly
-      providerId: ctx.providerId,
-      model: ctx.model,
-    },
-    ...pipeline,
-  });
-
-  for (const skill of manifest.skills) {
-    await ctx.step(skill.label, skill.detail, async () => {
-      const output = await runSkill(skill, ctx, templateCtx);
-      pipeline[skill.id] = { output };
-    });
+function validateWriteStepSettings(
+  settings: Record<string, unknown>,
+  path: string,
+): void {
+  if (typeof settings.kind !== "string" || settings.kind.length === 0) {
+    throw new ManifestValidationError(`${path}.kind`, "must be a non-empty string");
   }
-
-  const resultDef = manifest.definition.result;
-  const finalCtx = templateCtx();
-  const summary = String(renderTemplate(resultDef.summary, finalCtx) ?? "");
-  const dataRaw = resultDef.data ? renderDeep(resultDef.data, finalCtx) : undefined;
-
-  return {
-    summary: summary.trim(),
-    ...(dataRaw !== undefined ? { result: dataRaw } : {}),
-  };
+  if (!ACTION_HANDLERS[settings.kind]) {
+    throw new ManifestValidationError(
+      `${path}.kind`,
+      `unknown action kind "${settings.kind}". Supported in v0.1: ${Object.keys(ACTION_HANDLERS).join(", ")}`,
+    );
+  }
+  if (typeof settings.source !== "string" || settings.source.length === 0) {
+    throw new ManifestValidationError(`${path}.source`, "must be a non-empty string");
+  }
+  if (typeof settings.confirmationPhrase !== "string" || settings.confirmationPhrase.length === 0) {
+    throw new ManifestValidationError(`${path}.confirmationPhrase`, "must be a non-empty string");
+  }
+  if (!settings.actionTemplate || typeof settings.actionTemplate !== "object") {
+    throw new ManifestValidationError(`${path}.actionTemplate`, "must be an object");
+  }
+  const tmpl = settings.actionTemplate as Record<string, unknown>;
+  if (typeof tmpl.label !== "string" || tmpl.label.length === 0) {
+    throw new ManifestValidationError(`${path}.actionTemplate.label`, "must be a non-empty string");
+  }
 }
+
+// ─── Pipeline state shared by read + write paths ───────────────────────────
+
+type PipelineState = Record<string, { output: unknown }>;
 
 function resolveSettings(manifest: AgentTemplate): Record<string, unknown> {
   const settings: Record<string, unknown> = {};
@@ -173,6 +195,306 @@ function resolveSettings(manifest: AgentTemplate): Record<string, unknown> {
   }
   return settings;
 }
+
+function makeTemplateCtx(
+  manifest: AgentTemplate,
+  settings: Record<string, unknown>,
+  pipeline: PipelineState,
+  ctx: RunContext,
+): TemplateContext {
+  return {
+    settings,
+    ctx: {
+      providerId: ctx.providerId,
+      model: ctx.model,
+      agentId: ctx.agent.id,
+    },
+    descriptor: manifest.descriptor,
+    ...pipeline,
+  };
+}
+
+/**
+ * Run pipeline steps until the optional `stopBefore` predicate matches.
+ * Returns the pipeline state at the stop point. Each step is wrapped in
+ * ctx.step so failures surface with step granularity.
+ */
+async function runPipelineUpTo(
+  manifest: AgentTemplate,
+  ctx: RunContext,
+  stopBefore: (step: TemplateStep) => boolean = () => false,
+): Promise<{ pipeline: PipelineState; settings: Record<string, unknown> }> {
+  const settings = resolveSettings(manifest);
+  const pipeline: PipelineState = {};
+
+  for (const skill of manifest.skills) {
+    if (stopBefore(skill)) break;
+    const templateCtx = (): TemplateContext =>
+      makeTemplateCtx(manifest, settings, pipeline, ctx);
+
+    await ctx.step(skill.label, skill.detail, async () => {
+      const output = await runSkill(skill, ctx, templateCtx);
+      pipeline[skill.id] = { output };
+    });
+  }
+
+  return { pipeline, settings };
+}
+
+// ─── Read-agent path ──────────────────────────────────────────────────────
+
+/**
+ * Execute a read-mode agent template against a live RunContext. Throws if
+ * the manifest is write-mode (use runAgentTemplatePlan / Apply instead).
+ */
+export async function runAgentTemplate(
+  manifest: AgentTemplate,
+  ctx: RunContext,
+): Promise<AgentRunResult> {
+  if (manifest.descriptor.mode !== "read") {
+    throw new Error(
+      `runAgentTemplate: manifest "${manifest.descriptor.id}" is a write agent; call runAgentTemplatePlan/Apply.`,
+    );
+  }
+
+  const { pipeline, settings } = await runPipelineUpTo(manifest, ctx);
+  const finalCtx = makeTemplateCtx(manifest, settings, pipeline, ctx);
+
+  const resultDef = manifest.definition.result;
+  if (!resultDef) {
+    throw new Error(
+      `runAgentTemplate: manifest "${manifest.descriptor.id}" is missing definition.result.`,
+    );
+  }
+
+  const summary = String(renderTemplate(resultDef.summary, finalCtx) ?? "");
+  const dataRaw = resultDef.data ? renderDeep(resultDef.data, finalCtx) : undefined;
+
+  return {
+    summary: summary.trim(),
+    ...(dataRaw !== undefined ? { result: dataRaw } : {}),
+  };
+}
+
+// ─── Write-agent path: plan + apply ───────────────────────────────────────
+
+/**
+ * Run the pipeline up to (and including) the single write step, render the
+ * action template once per source item, and return a WritePlan. The runtime
+ * stamps the plan on the RunRecord and pauses for typed confirmation.
+ */
+export async function runAgentTemplatePlan(
+  manifest: AgentTemplate,
+  ctx: RunContext,
+): Promise<WritePlan> {
+  if (manifest.descriptor.mode !== "write") {
+    throw new Error(
+      `runAgentTemplatePlan: manifest "${manifest.descriptor.id}" is not a write agent.`,
+    );
+  }
+
+  const writeStepIdx = manifest.skills.findIndex((s) => s.format === "write");
+  if (writeStepIdx < 0) {
+    throw new Error(
+      `runAgentTemplatePlan: manifest "${manifest.descriptor.id}" has no write step.`,
+    );
+  }
+  const writeStep = manifest.skills[writeStepIdx] as WriteStep;
+
+  // Run every step before the write step so its `source` expression has
+  // something to resolve against.
+  const { pipeline, settings } = await runPipelineUpTo(
+    manifest,
+    ctx,
+    (step) => step === writeStep,
+  );
+
+  // Now build the plan inside its own ctx.step so the user sees a step
+  // labelled with the write step's label (matching the find-inactive path).
+  return ctx.step(writeStep.label, writeStep.detail, async () => {
+    const settingsCtx = makeTemplateCtx(manifest, settings, pipeline, ctx);
+    const sourceArray = renderTemplate(writeStep.settings.source, settingsCtx);
+    if (!Array.isArray(sourceArray)) {
+      throw new Error(
+        `write step "${writeStep.id}": source must resolve to an array (got ${typeof sourceArray}).`,
+      );
+    }
+
+    const actions: WriteAction[] = sourceArray.map((item, index) => {
+      const perItemCtx: TemplateContext = {
+        ...settingsCtx,
+        item,
+        items: sourceArray,
+        index,
+      };
+      return renderActionFromTemplate(
+        writeStep.settings.actionTemplate,
+        writeStep.settings.kind,
+        index,
+        perItemCtx,
+      );
+    });
+
+    // Confirmation phrase + plan summary template see the full action set.
+    const planCtx: TemplateContext = {
+      ...settingsCtx,
+      items: sourceArray,
+      actions,
+    };
+    const confirmationPhrase = String(
+      renderTemplate(writeStep.settings.confirmationPhrase, planCtx) ?? "",
+    );
+    const summary = writeStep.settings.summary
+      ? String(renderTemplate(writeStep.settings.summary, planCtx) ?? "")
+      : `${manifest.descriptor.name} prepared ${actions.length} action${actions.length === 1 ? "" : "s"}.`;
+
+    ctx.log(
+      "info",
+      `Plan ready: ${actions.length} action${actions.length === 1 ? "" : "s"} of kind "${writeStep.settings.kind}".`,
+    );
+
+    return {
+      summary,
+      confirmationPhrase,
+      actions,
+    };
+  });
+}
+
+function renderActionFromTemplate(
+  template: WriteActionTemplate,
+  kind: string,
+  index: number,
+  templateCtx: TemplateContext,
+): WriteAction {
+  const label = String(renderTemplate(template.label, templateCtx) ?? "");
+  const action: WriteAction = {
+    id: `${kind}:${index}`,
+    kind,
+    label,
+    severity: template.severity ?? "destructive",
+  };
+  if (template.description) {
+    const description = String(renderTemplate(template.description, templateCtx) ?? "");
+    if (description.length > 0) action.description = description;
+  }
+  if (template.metadata) {
+    const rendered: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(template.metadata)) {
+      rendered[key] = renderTemplate(value, templateCtx);
+    }
+    action.metadata = rendered;
+  }
+  return action;
+}
+
+/**
+ * Iterate the approved plan's actions. Each action is dispatched to its
+ * registered kind handler. Per-action failures are non-fatal: they land in
+ * `result.failed[]` and the run still completes. The handler chooses
+ * whether to call real Graph (when ctx.realWrites) or emit a simulated
+ * step.
+ */
+export async function runAgentTemplateApply(
+  manifest: AgentTemplate,
+  ctx: RunContext,
+  plan: WritePlan,
+): Promise<AgentRunResult> {
+  if (manifest.descriptor.mode !== "write") {
+    throw new Error(
+      `runAgentTemplateApply: manifest "${manifest.descriptor.id}" is not a write agent.`,
+    );
+  }
+
+  const realWrites = ctx.realWrites;
+  const retiredDeviceIds: string[] = [];
+  const simulatedDeviceIds: string[] = [];
+  const failed: Array<{ id: string; name: string; error: string }> = [];
+
+  if (!realWrites) {
+    ctx.log(
+      "warn",
+      "Real Graph writes are disabled (no tenant connected or the toggle in Settings is OFF). The apply phase will emit a simulated trace instead of calling Microsoft Graph.",
+    );
+  }
+
+  for (const action of plan.actions) {
+    const handler = ACTION_HANDLERS[action.kind];
+    if (!handler) {
+      failed.push({
+        id: action.id,
+        name: action.label,
+        error: `No handler registered for action kind "${action.kind}".`,
+      });
+      ctx.log("error", `Skipping ${action.label}: unknown action kind ${action.kind}.`);
+      continue;
+    }
+
+    try {
+      await ctx.step(action.label, action.description, async () => {
+        const result = await handler(action, ctx);
+        if (result.outcome === "real") {
+          if (result.targetId) retiredDeviceIds.push(result.targetId);
+          ctx.log("info", `Executed ${action.label} via Graph.`);
+        } else {
+          if (result.targetId) simulatedDeviceIds.push(result.targetId);
+          ctx.log("info", `[simulated] ${action.label}; real writes disabled.`);
+        }
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      failed.push({ id: action.id, name: action.label, error: message });
+      ctx.log("error", `Failed action "${action.label}": ${message}`);
+    }
+  }
+
+  const successCount = realWrites ? retiredDeviceIds.length : simulatedDeviceIds.length;
+  const total = plan.actions.length;
+  const verb = realWrites ? "Executed" : "Simulated";
+  const failureSuffix = failed.length > 0 ? ` ${failed.length} failed.` : "";
+  const summary = `${verb} ${successCount} of ${total} action${total === 1 ? "" : "s"}.${failureSuffix}`;
+
+  return {
+    summary,
+    result: {
+      mode: realWrites ? "real" : "simulated",
+      retiredDeviceIds,
+      simulatedDeviceIds,
+      failed,
+      successCount,
+      failureCount: failed.length,
+      total,
+    },
+  };
+}
+
+// ─── Action-kind handler registry ─────────────────────────────────────────
+
+interface ActionHandlerResult {
+  outcome: "real" | "simulated";
+  targetId?: string;
+}
+
+type ActionHandler = (action: WriteAction, ctx: RunContext) => Promise<ActionHandlerResult>;
+
+const ACTION_HANDLERS: Record<string, ActionHandler> = {
+  "retire-managed-device": async (action, ctx) => {
+    const deviceId =
+      typeof action.metadata?.deviceId === "string" ? action.metadata.deviceId : undefined;
+    if (!deviceId) {
+      throw new Error(
+        `retire-managed-device: action "${action.id}" is missing metadata.deviceId`,
+      );
+    }
+    if (ctx.realWrites) {
+      await ctx.graph.retireManagedDevice(deviceId);
+      return { outcome: "real", targetId: deviceId };
+    }
+    return { outcome: "simulated", targetId: deviceId };
+  },
+};
+
+// ─── Skill runners ────────────────────────────────────────────────────────
 
 async function runSkill(
   skill: TemplateStep,
@@ -186,6 +508,11 @@ async function runSkill(
       return runTransformSkill(skill, ctx, templateCtx);
     case "llm":
       return runLlmSkill(skill, ctx, templateCtx);
+    case "write":
+      // Write steps are executed by runAgentTemplatePlan, not here.
+      throw new Error(
+        `runSkill: encountered a write step ("${skill.id}") during the pipeline loop; this is a bug.`,
+      );
     default: {
       const exhaustive: never = skill;
       throw new Error(`Unsupported skill format: ${JSON.stringify(exhaustive)}`);
@@ -202,13 +529,10 @@ async function runGraphSkill(
 
   if (settings.method !== "GET") {
     throw new Error(
-      `graph skill "${skill.id}": only GET is supported in v0.1 expected (got ${settings.method}).`,
+      `graph step "${skill.id}": only GET is supported by the agent template interpreter (got ${settings.method}).`,
     );
   }
 
-  // v0.1 limitation: the agent-template graph step currently knows one canonical
-  // path. Expanding this requires extending RunGraphApi or a generic
-  // method on the adapter — neither is in this slice.
   if (settings.path === "/deviceManagement/managedDevices") {
     const devices = await ctx.graph.listManagedDevices();
     ctx.log("info", `Loaded ${devices.length} managed devices.`);
@@ -216,7 +540,7 @@ async function runGraphSkill(
   }
 
   throw new Error(
-    `graph skill "${skill.id}": path "${settings.path}" is not yet supported by the agent template interpreter. Use a code-based agent (manifest.json + dist/agent.js) or extend RunGraphApi.`,
+    `graph step "${skill.id}": path "${settings.path}" is not yet supported by the agent template interpreter. Use a code-based agent or extend RunGraphApi.`,
   );
 }
 
@@ -231,9 +555,11 @@ async function runTransformSkill(
   switch (kind) {
     case "group-by-age":
       return transformGroupByAge(skill.id, settings, ctx);
+    case "filter-by-age":
+      return transformFilterByAge(skill.id, settings, ctx);
     default:
       throw new Error(
-        `transform skill "${skill.id}": unknown kind "${String(kind)}". Supported in v0.1: group-by-age.`,
+        `transform "${skill.id}": unknown kind "${String(kind)}". Supported: group-by-age, filter-by-age.`,
       );
   }
 }
@@ -251,9 +577,7 @@ function transformGroupByAge(
 ): Record<string, unknown[]> {
   const spec = settings as unknown as GroupByAgeSpec;
   if (!Array.isArray(spec.source)) {
-    throw new Error(
-      `transform "${skillId}": group-by-age expects "source" to resolve to an array.`,
-    );
+    throw new Error(`transform "${skillId}": group-by-age expects "source" to resolve to an array.`);
   }
   if (typeof spec.timestampField !== "string" || spec.timestampField.length === 0) {
     throw new Error(`transform "${skillId}": group-by-age requires "timestampField".`);
@@ -264,10 +588,6 @@ function transformGroupByAge(
 
   const now = Date.now();
   const msPerDay = 86_400_000;
-
-  // Sort thresholds descending so each item lands in the *highest* bucket it
-  // qualifies for. E.g. a 200-day-inactive device should be in `retire`, not
-  // `warn` -- even though both thresholds match.
   const ordered = [...spec.groups].sort(
     (a, b) => b.inactiveDaysAtLeast - a.inactiveDaysAtLeast,
   );
@@ -295,8 +615,50 @@ function transformGroupByAge(
   const counts = Object.entries(result)
     .map(([name, items]) => `${name}=${items.length}`)
     .join(", ");
-  ctx.log("info", `Grouped devices by inactivity: ${counts}.`);
+  ctx.log("info", `Grouped by inactivity: ${counts}.`);
   return result;
+}
+
+interface FilterByAgeSpec {
+  source: unknown;
+  timestampField: string;
+  inactiveDaysAtLeast: number;
+}
+
+function transformFilterByAge(
+  skillId: string,
+  settings: Record<string, unknown>,
+  ctx: RunContext,
+): unknown[] {
+  const spec = settings as unknown as FilterByAgeSpec;
+  if (!Array.isArray(spec.source)) {
+    throw new Error(`transform "${skillId}": filter-by-age expects "source" to resolve to an array.`);
+  }
+  if (typeof spec.timestampField !== "string" || spec.timestampField.length === 0) {
+    throw new Error(`transform "${skillId}": filter-by-age requires "timestampField".`);
+  }
+  const threshold = Number(spec.inactiveDaysAtLeast);
+  if (!Number.isFinite(threshold) || threshold < 0) {
+    throw new Error(
+      `transform "${skillId}": filter-by-age requires "inactiveDaysAtLeast" as a non-negative number.`,
+    );
+  }
+
+  const now = Date.now();
+  const msPerDay = 86_400_000;
+  const matched: unknown[] = [];
+
+  for (const item of spec.source as Array<Record<string, unknown>>) {
+    const raw = item[spec.timestampField];
+    if (typeof raw !== "string") continue;
+    const ms = new Date(raw).getTime();
+    if (Number.isNaN(ms)) continue;
+    const days = Math.floor((now - ms) / msPerDay);
+    if (days >= threshold) matched.push(item);
+  }
+
+  ctx.log("info", `Filter-by-age >= ${threshold}d kept ${matched.length} of ${(spec.source as unknown[]).length}.`);
+  return matched;
 }
 
 async function runLlmSkill(
@@ -325,31 +687,55 @@ async function runLlmSkill(
   };
 }
 
-// ─── Adapter so the runtime can treat a agent template as an AgentModule ───
+// ─── Adapter so the runtime can treat a manifest as an AgentModule ───────
 
-export function agentTemplateToModule(
-  manifest: AgentTemplate,
-): ReadAgentModule {
+export function agentTemplateToModule(manifest: AgentTemplate): AgentModule {
+  if (manifest.descriptor.mode === "write") {
+    return buildWriteAgentModule(manifest);
+  }
+  return buildReadAgentModule(manifest);
+}
+
+function commonMetadata(manifest: AgentTemplate) {
   const descriptor = manifest.descriptor;
   return {
     id: descriptor.id,
     slug: descriptor.id,
     name: descriptor.name,
     description: descriptor.description,
-    mode: "read",
     category: descriptor.category,
     scopes: collectScopes(manifest),
     author: descriptor.author,
     version: descriptor.version,
     ...(descriptor.preferredModel ? { preferredModel: descriptor.preferredModel } : {}),
+  };
+}
+
+function buildReadAgentModule(manifest: AgentTemplate): ReadAgentModule {
+  return {
+    ...commonMetadata(manifest),
+    mode: "read",
     run: (ctx) => runAgentTemplate(manifest, ctx),
   } as ReadAgentModule;
+}
+
+function buildWriteAgentModule(manifest: AgentTemplate): WriteAgentModule {
+  return {
+    ...commonMetadata(manifest),
+    mode: "write",
+    plan: (ctx) => runAgentTemplatePlan(manifest, ctx),
+    apply: (ctx, plan) => runAgentTemplateApply(manifest, ctx, plan),
+  } as WriteAgentModule;
 }
 
 function collectScopes(manifest: AgentTemplate): string[] {
   const scopes = new Set<string>();
   for (const skill of manifest.skills) {
     if (skill.format === "graph") {
+      for (const scope of skill.settings.scopes ?? []) {
+        scopes.add(scope);
+      }
+    } else if (skill.format === "write") {
       for (const scope of skill.settings.scopes ?? []) {
         scopes.add(scope);
       }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -39,6 +39,8 @@ export {
   ManifestValidationError,
   parseAgentTemplate,
   runAgentTemplate,
+  runAgentTemplatePlan,
+  runAgentTemplateApply,
   agentTemplateToModule,
 } from "./agent-template.js";
 export { renderTemplate, renderDeep } from "./template-engine.js";


### PR DESCRIPTION
## Summary

- New `write` skill format closes the last gap in the Agent Template DSL — write-mode agents are now declarative YAML, same as read agents.
- `retire-inactive-devices` migrates from a 188-line TypeScript module to a ~60-line `manifest.yaml`. Behavior against the synthetic Graph fixture is identical (4 candidates ≥180 days, phrase `RETIRE 4 DEVICES`, real `ctx.graph.retireManagedDevice` calls when `realWrites=true`).
- Manifest Preview UI renders the new write step inline (kind, source, confirmation phrase, action template, scopes), so destructive agents get the same transparency treatment as read agents.

## What's in the write step

Declared in the SDK:

```yaml
- id: plan_retirements
  format: write
  label: Build retire plan
  settings:
    kind: retire-managed-device          # registered handler
    source: "{{ select_retire_candidates.output }}"  # array
    confirmationPhrase: "RETIRE {{ actions | size }} DEVICES"
    summary: >-
      Retire {{ actions | size }} devices that have not synced...
    scopes:
      - DeviceManagementManagedDevices.PrivilegedOperations.All
    actionTemplate:
      label: "Retire {{ item.deviceName }}"
      description: "..."
      severity: destructive
      metadata:
        deviceId: "{{ item.id }}"
        ...
```

Runtime:
1. `runAgentTemplatePlan` runs the pipeline up to the write step, renders `actionTemplate` once per `source` item, returns a `WritePlan`. The host pauses on `awaiting-confirmation`.
2. `runAgentTemplateApply` iterates the approved plan; each action is dispatched to a handler in `ACTION_HANDLERS`. Per-action failures are non-fatal — they land in `result.failed[]`.
3. v0.1 ships one handler — `retire-managed-device`. Adding more (assign-policy, install-app, etc.) is a one-function change.

## Acceptance criteria

- [x] YAML parses, validation rejects mode/step mismatches and unknown kinds.
- [x] Smoke test: `retire-inactive-devices` YAML on synthetic Graph produces the same plan and apply result as the TS module did.
- [x] Manifest Preview renders the write step with its kind, source, confirmation phrase, action template, and scopes.
- [x] `npm run typecheck`, `npm run qa`, `npm run build` all pass.

## Test plan

- [ ] `npm install`
- [ ] `npm run typecheck && npm run qa && npm run build`
- [ ] `npm run dev`, open `/agents/retire-inactive-devices`, confirm the manifest preview shows the write step with the confirmation phrase template
- [ ] Run the agent on the synthetic tenant, confirm the diff confirmation page shows 4 candidates and the typed phrase `RETIRE 4 DEVICES` is required
- [ ] Confirm; verify apply summary "Simulated 4 of 4 actions."