### PR TITLE
docs: refresh README + v0.1 status doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,36 +2,176 @@
 
 **Open-source, local-first agents for Microsoft 365 admins.**
 
-Run AI agents against your Intune and Entra tenants from your own machine. Tenant data and prompts stay local by default. Community-contributed agents, browseable from inside the app.
+Run AI agents against your Intune and Entra tenants from your own machine. Tenant data and prompts stay on-device when a local LLM is selected. Every agent ships its full pipeline as YAML — no opaque code paths, no hidden Graph calls.
 
-> ⚠️ Pre-alpha. Not yet ready for production use. Star the repo to follow along.
+> Pre-1.0. v0.1 (private preview showcase) is feature-complete; signed installers ship with v0.2. Star the repo to follow along.
 
 ---
 
-## What it is
+## What it does
 
-Open Agents is a desktop platform that lets a Microsoft 365 administrator:
+An Intune / Entra admin can:
 
-1. Connect a tenant via MSAL.
-2. Pick an LLM provider — local (Ollama, LM Studio) or hosted (Anthropic, OpenAI, Azure OpenAI).
-3. Browse a community registry of agents (each declares the Graph scopes it needs and whether it reads or writes).
-4. Run agents against the tenant — read agents run autonomously, write agents pause for diff confirmation.
+1. **Connect a tenant** via MSAL interactive sign-in (Authorization Code + PKCE against the public Microsoft Graph CLI client). No client secret, no app registration — the user signs in with their own identity in their own browser.
+2. **Pick an LLM provider** — local (Ollama, LM Studio) or hosted (Anthropic, OpenAI, Azure OpenAI). Trust messaging changes honestly with the choice.
+3. **Browse a registry of agents.** Each agent declares the Graph scopes it needs and whether it reads or writes. The full pipeline (every Graph call, every transform, every LLM prompt) is visible before install.
+4. **Run agents** — read agents run autonomously; **write agents always pause for typed diff confirmation** ("type `RETIRE 47 DEVICES` to proceed").
+5. **Author new agents in plain English.** Describe what you want, the local LLM drafts a YAML manifest, the JSON Schema validates it, and you install it in one click.
 
-It ships as a signed desktop app for Windows and macOS (Linux best-effort), built on Electron.
+## What's in the box (v0.1)
 
-## Why
+### Agent Templates — agents as YAML pipelines
 
-Most AI tools for IT admins are wrappers around ChatGPT — single-purpose, cloud-only, no extensibility. Open Agents is a **platform**: a runtime, a registry, a trust model. Contributions accumulate over time. Think Home Assistant, but for the Microsoft 365 admin surface.
+Every shipped agent is a declarative `manifest.yaml`. No companion TypeScript needed. The runtime interprets the manifest top-to-bottom.
 
-## How to install
+```yaml
+descriptor:
+  id: find-inactive-devices
+  mode: read
+  category: devices
 
-_Signed installers (Windows + macOS) coming with v0.2. v0.1 is a private preview — sign up at [openagents.sh](https://openagents.sh) to get early access._
+skills:
+  - id: load_devices
+    format: graph
+    settings: { method: GET, path: /deviceManagement/managedDevices, scopes: [...] }
 
-## How to write an agent
+  - id: by_age
+    format: transform
+    settings: { kind: group-by-age, source: "{{ load_devices.output }}", ... }
 
-_SDK docs coming soon. The agent contract is documented in [`docs/SPEC.md`](docs/SPEC.md) §2._
+  - id: summarize
+    format: llm
+    when: ctx.llm.available
+    settings: { prompt: "...", maxTokens: 220 }
 
-## How to contribute
+definition:
+  settings:
+    - { id: retireDays, type: integer, default: 180 }
+  result:
+    summary: "{{ buckets.retire | size }} devices ready to retire."
+```
+
+**Four step formats**: `graph` (read Microsoft Graph), `transform` (pure data shaping — `group-by-age`, `filter-by-age`, `count-by-field`), `llm` (optional, gated on provider availability), and `write` (emits one action per source item and pauses for typed phrase confirmation).
+
+### Static QA gate
+
+`npm run qa` validates every shipped manifest:
+- **JSON Schema validation** of the YAML against [`schemas/agent-template.schema.json`](schemas/agent-template.schema.json).
+- **Graph QA**: declared scopes are real, endpoints exist in the OpenAPI surface, `$select` fields exist on the resource, fixtures match the live schema. Uses the [`merill/msgraph`](https://github.com/merill/msgraph) skill — offline, no auth, no tenant calls.
+
+A malformed manifest fails CI with a structured per-field diff.
+
+### NL2Agent — describe an agent in English
+
+The "New agent" button on the hub opens a two-pane flow. Type a description, the active LLM provider drafts a YAML manifest grounded in the schema and a worked example, the draft renders through the same Manifest Preview component as bundled agents, save & install routes you straight to the new agent's detail page. User-authored agents persist under `userData/agents/<slug>/` and appear in the merged registry without a restart.
+
+### Trust model (non-negotiable)
+
+- **Tenant data never leaves the device** when a local LLM is selected. No telemetry, no analytics, no error reporting that could include tenant content.
+- **Write agents always pause for diff confirmation.** No "skip this prompt" toggle. Destructive operations require typed phrase confirmation.
+- **Real Graph writes are gated twice**: an active tenant connection AND a global toggle the user has to flip. Until both, write agents emit a simulated trace instead of calling Graph.
+
+### What's shipped vs what's coming
+
+| | v0.1 | v0.2 |
+|---|---|---|
+| Tenant connect (read) | yes (MSAL interactive) | — |
+| Real Graph writes (gated) | yes | — |
+| Local LLM (Ollama) | yes | — |
+| Hosted LLM (Anthropic / OpenAI) | no | yes |
+| LM Studio | no | yes |
+| Signed installers | no | yes |
+| Code-signing + notarization | no | yes |
+| Auto-update via electron-updater | no | yes |
+| Cross-platform builds | dev-only | Win + macOS signed |
+
+## Reference agents
+
+| Agent | Category | Mode | What it does |
+|---|---|---|---|
+| `find-inactive-devices` | devices | read | Buckets managed devices by last-sync age. |
+| `retire-inactive-devices` | devices | write | Plans retires for devices ≥180 days inactive, pauses for typed confirmation. |
+| `compliance-overview` | compliance | read | Counts devices by `complianceState`. |
+| `os-update-posture` | updates | read | Tallies fleet by OS + OS version; surfaces Windows 10 lines. |
+
+Each lives at `agents/<slug>/manifest.yaml`. Read them — they are the documentation of what the runtime can do.
+
+## Quickstart
+
+```bash
+# 1. Clone and install
+git clone https://github.com/ugurkocde/OpenAgents.git
+cd OpenAgents
+npm install
+
+# 2. (Optional) Pull a local LLM model so NL2Agent works
+brew install ollama && ollama serve &
+ollama pull llama3.1:8b
+
+# 3. Run the desktop app
+npm run dev
+
+# 4. Verify everything
+npm run typecheck   # types across the workspace
+npm run qa          # JSON Schema + Graph QA
+npm run build       # production bundle
+```
+
+The app comes up with four agents (three read-only, one write) pre-available against a synthetic Graph fixture. You can run every agent end-to-end without connecting a real tenant.
+
+## Architecture
+
+```
+apps/
+  desktop/        Electron host (main + preload + Vite/React renderer)
+  marketing/      Next.js marketing site (openagents.sh)
+agents/
+  <slug>/         manifest.yaml + manifest.json (+ optional TS)
+packages/
+  agent-sdk/      Shared types (no runtime)
+  runtime/        Agent Template interpreter, LLM providers, MSAL, synthetic Graph
+  qa-graph/       Offline manifest QA (schema + msgraph)
+schemas/
+  agent-template.schema.json    The canonical contract for manifest.yaml
+docs/
+  SPEC.md         Source of truth for product decisions
+  mockups/        8 reference HTML mockups + design system tokens
+```
+
+Stack: TypeScript, npm workspaces + Turborepo, Electron 42, Vite + React + React Router, Tailwind, MSAL (`@azure/msal-node`), `js-yaml`, `ajv`. SQLite + `keytar` arrive in v0.2 with persistence + secrets hardening.
+
+## Writing an agent by hand
+
+```yaml
+# yaml-language-server: $schema=../../schemas/agent-template.schema.json
+descriptor:
+  id: my-agent
+  name: My Agent
+  description: One sentence.
+  version: 1.0.0
+  author: { name: Your Name, handle: yourhandle }
+  category: devices  # devices | apps | policies | compliance | updates
+  mode: read
+
+skills:
+  - id: load_devices
+    format: graph
+    label: Load devices
+    settings:
+      method: GET
+      path: /deviceManagement/managedDevices
+      scopes: [DeviceManagementManagedDevices.Read.All]
+
+definition:
+  result:
+    summary: "Loaded {{ load_devices.output | size }} devices."
+```
+
+Drop that at `agents/my-agent/manifest.yaml`, run `npm run qa`, and the agent shows up in the hub.
+
+For the full schema, see [`schemas/agent-template.schema.json`](schemas/agent-template.schema.json) and [`schemas/README.md`](schemas/README.md). For deeper architecture, see [`docs/SPEC.md`](docs/SPEC.md).
+
+## Contributing
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md). Bug reports, feature requests, and agent contributions all welcome.
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,55 +1,67 @@
-# Agent Template interpreter
+# v0.1 — Private preview showcase
 
-**Goal:** Let agents be declared as YAML pipelines (no code) so non-technical contributors can author and read them. Implement the schema, interpreter, format handlers, and migrate `find-inactive-devices` as the first canonical Agent Template example. The existing TS-based path stays fully functional as a fallback for agents that need code.
+**Status: complete.** Tagged as v0.1.0. Signed installers + hosted LLM providers land in v0.2.
 
-**Status:** In progress.
+The goal of v0.1 was to ship the platform thesis end-to-end against synthetic + real Graph data, so prospective users can evaluate the trust story, the agent template DSL, and the path from "describe what you want" to "agent running on your tenant." Every promise the marketing page makes about local-first, transparency, and human-in-the-loop has a corresponding feature in the desktop app.
 
 ---
 
-## Scope for this pass
+## What landed
 
-- [ ] **Schema** in `@openagents/agent-sdk`: TS types for `AgentTemplate`, `TemplateStep`, `TemplateTrigger`, `TemplateResult`. Pure types only; the runtime owns parsing/validation.
-- [ ] **Parser + validator** in `@openagents/runtime`: `parseAgentTemplate(yamlOrJsonText)` using `js-yaml`. Returns the typed manifest or a structured `ManifestValidationError` with line context where possible.
-- [ ] **Templating** in `@openagents/runtime`: a minimal Liquid-subset (`{{ path }}`, `{{ path | filter }}`) with built-in filters `size`, `total`, `sample(n)`, `default("…")`, `join(", ")`. No big template-engine dep. Preserves primitive types when the entire string is a single `{{ … }}` expression (so `"{{ settings.warnDays }}"` evaluates to `30`, not `"30"`).
-- [ ] **Format handlers** in `@openagents/runtime`:
-  - `graph` — calls `ctx.graph` methods declared by the step.
-  - `transform` — pure data shaping. Initial transform kind: `group-by-age`. Others (`filter`, `project`, `sort`) added on demand.
-  - `llm` — renders `system` + `prompt` via the templater, calls `ctx.llm.complete`, gates on `ctx.llm.available` when `when: ctx.llm.available` is set.
-- [ ] **Interpreter** in `@openagents/runtime`: `runAgentTemplate(manifest, ctx)` walks `skills[]` top-to-bottom, executes each step with its format handler, stores outputs by step `id` in a pipeline state object, evaluates the final `result` block, and returns `AgentRunResult`.
-- [ ] **Loader update** in `@openagents/runtime`: `loadAgentModule` now prefers `agents/<slug>/manifest.yaml` if it exists with a `skills:` block; otherwise falls back to `dist/agent.js`. When the YAML path is taken, the runtime synthesizes an `AgentModule` whose `run()` invokes the interpreter.
-- [ ] **`find-inactive-devices` migration**: add `manifest.yaml` declaring the same pipeline the current `src/agent.ts` implements. The TS source stays for the transition (just unused by the loader now). Run record output matches today's: same totals, same retire bucket device IDs.
-- [ ] **QA gate**: when an agent template manifest is present, validate `skills[*].format` against the supported set, `graph` step scopes against the local msgraph index, and `transform.kind` against the registered transforms. The code-based path is unchanged.
-- [ ] Typecheck, qa, and build all green; CI passes.
+### Platform
+- [x] Electron desktop app (Windows + macOS in dev; signed builds in v0.2)
+- [x] Vite + React + React Router renderer
+- [x] Tailwind design system ported from `docs/mockups/_design.css`
+- [x] MSAL interactive authorization-code + PKCE tenant connect against the public Microsoft Graph CLI client
+- [x] Encrypted token cache via Electron `safeStorage`
+- [x] Ollama local LLM provider with NDJSON streaming + thinking display
+- [x] Synthetic Graph fixture as the default data source
+- [x] Real Graph adapter for `/deviceManagement/managedDevices` (GET + paging + retry)
+- [x] Real Graph writes gated behind tenant-connected + global toggle
 
-## Out of scope for this pass
+### Agent Templates (the DSL)
+- [x] `descriptor`, `skills[]`, `definition` shape backed by SDK types
+- [x] Liquid-subset templating with `size`, `total`, `length`, `sample`, `default`, `join`, `upper`, `lower`, `type`
+- [x] Step formats: `graph`, `transform`, `llm`, `write`
+- [x] Transform kinds: `group-by-age`, `filter-by-age`, `count-by-field`
+- [x] Write action handlers: `retire-managed-device`
+- [x] Install-time settings (integer / string / boolean) — UI + persistence + runtime merge
+- [x] JSON Schema (`schemas/agent-template.schema.json`) — editor autocomplete + CI validation
+- [x] Manifest Preview component renders pipeline cards, scopes, raw YAML, settings (default + current)
 
-- **`write` format** — `retire-inactive-devices` stays code-based until the write format is designed (must integrate with the existing typed-phrase confirmation + real-writes toggle).
-- **Scheduled triggers** — manifest schema includes `triggers[]` but the interpreter only supports `kind: manual` for now.
-- **NL2Agent builder UI** — separate slice; depends on this foundation.
-- **Manifest preview UI in the Agent Hub** — separate slice; this PR lets you read the YAML in the source tree.
-- **Removing code-based source for migrated agents** — separate cleanup slice once the YAML path is proven against real and synthetic Graph for a release cycle.
-- **Install-time settings UI** — manifest declares them; runtime uses `default` values from the manifest. Per-install user overrides land later.
-- **JSON Schema export for IDE autocomplete** — nice to have, separate slice.
+### NL2Agent
+- [x] `draftAgentManifest(prompt)` — structured prompt + schema + worked example, parses + validates
+- [x] `saveAgentDraft(yaml)` — writes to `userData/agents/<slug>/`
+- [x] Two-pane modal flow on the hub: prompt → review → save & install
+- [x] Validation errors surfaced inline with raw-YAML disclosure
+- [x] User-authored agents stamped with absolute `registryPath` so they coexist with bundled agents
 
-## Acceptance criteria
+### Reference agents
+- [x] `find-inactive-devices` (devices, read) — group-by-age + LLM polish
+- [x] `retire-inactive-devices` (devices, write) — filter-by-age + write step + typed confirmation
+- [x] `compliance-overview` (compliance, read) — count-by-field with pinned buckets
+- [x] `os-update-posture` (updates, read) — two count-by-fields side by side
 
-- [x] `npm install`, `npm run typecheck`, `npm run qa`, `npm run build` all green.
-- [x] `find-inactive-devices` invoked via the Agent Template pipeline against the synthetic Graph fixture produces a `RunRecord` with:
-  - `result.data.totalDevices === 22`
-  - 4 devices in each of the warn / stale / retire buckets
-  - `result.data.buckets.retire` includes IDs `d-019..d-022`
-  - The LLM polish step runs when `ctx.llm.available === true`, skipped otherwise
-- [x] The loader picks the YAML path when `manifest.yaml` is present; renaming it falls back cleanly to `dist/agent.js`.
-- [x] No secrets, no `.env`, no emojis.
+### QA + CI
+- [x] `npm run qa` validates: schema, declared scopes against `merill/msgraph`, endpoint existence, select fields, fixture coverage
+- [x] GitHub Actions CI on push + PR: typecheck + qa + build
+- [x] All checks green; signed status badge ready for v0.2 installer signing
 
-## Naming note
+## What's deferred to v0.2
 
-Originally drafted as "Tier 1 / Tier 2" — refactored to **Agent Template** (the YAML / declarative path) and **code-based agent** (the TypeScript escape hatch). The "tier" framing implied a hierarchy and more tiers; there are really only two authoring modes, and one of them is the documented default.
+- Hosted LLM providers (Anthropic, OpenAI, Azure OpenAI) — adapter stubs exist, real wiring + secret storage land with `keytar`
+- LM Studio local provider — same shape as Ollama, separate adapter
+- Signed installers (Windows EV cert + Apple notarization)
+- Auto-update via `electron-updater` against signed GitHub releases
+- SQLite migration for run history (currently JSON-backed)
+- Scheduled triggers (`triggers[].kind: scheduled`) — manifest already declares them; interpreter only honours manual today
 
-## Review
+## How to run
 
-- `@openagents/agent-sdk` gained `AgentTemplate`, `TemplateStep` (`graph` | `transform` | `llm`), `TemplateTrigger`, `TemplateSetting`, `TemplateResult` types. Pure types — parsing and validation live in the runtime.
-- `@openagents/runtime/src/template-engine.ts` ships the Liquid-subset templater (filters: `size`, `total`, `length`, `sample(n)`, `default`, `join`, `upper`, `lower`, `type`). Standalone-expression strings preserve primitive types so `"{{ settings.warnDays }}"` evaluates to integer `30`.
-- `@openagents/runtime/src/agent-template.ts` ships `parseAgentTemplate(text)`, `runAgentTemplate(manifest, ctx)`, the format handlers (`graph`, `transform.group-by-age`, `llm`), and `agentTemplateToModule(manifest)` which adapts a parsed template into a `ReadAgentModule` for the existing run pipeline.
-- `loadAgentModule` prefers `manifest.yaml`; code-based agents fall through unchanged.
-- `agents/find-inactive-devices/manifest.yaml` is the first canonical Agent Template. Smoke-tested against the synthetic Graph fixture: 22 total devices, bucket sizes 4/4/4, retire band ids `d-019..d-022`, LLM step gated correctly, thresholds resolve from settings defaults.
+```bash
+npm install
+npm run dev
+npm run typecheck && npm run qa && npm run build
+```
+
+See [`README.md`](../README.md) for the full quickstart.


### PR DESCRIPTION
## Summary

Demo-surface refresh ahead of the v0.1.0 tag. No code changes — just the README and `tasks/todo.md` brought up to date with everything that landed this cycle.

## README highlights

- Hero rewritten to name the four pillars we actually shipped (YAML pipelines, schema validation, NL2Agent, human-in-the-loop writes) instead of generic "platform" language.
- "What's in the box (v0.1)" section walks through Agent Templates, the static QA gate, NL2Agent, and the trust model — with a real example manifest inlined.
- Shipped-vs-coming table is honest about what's deferred to v0.2: hosted LLM providers, signed installers, auto-update.
- Reference-agents table lists all four bundled agents.
- Quickstart includes the optional Ollama install so NL2Agent works for new contributors out of the box.
- "Write an agent by hand" example carries the `yaml-language-server` schema directive so editors light up on save.

## tasks/todo.md

Replaced the old Agent Template-interpreter task list (slice completed several PRs back) with the v0.1 status doc that mirrors the README structure. Listing what landed across platform / DSL / NL2Agent / reference agents / QA, plus what's deferred to v0.2.

## After this merges

v0.1.0 tag — final CHANGELOG section swap, `git tag -a v0.1.0`, push, draft GitHub release. Last PR of the v0.1 cycle.