### PR TITLE
release: v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Open Agents are recorded here. Format follows [Keep a Cha
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.1.0] - 2026-05-16
+
+First public release. Private preview showcase. Tenant-data-local-by-default desktop platform for Microsoft 365 admins. Four bundled reference agents, two authoring paths (YAML by hand or NL2Agent draft), full transparency UI over both, gated real Graph writes, static schema + Graph QA gate.
+
+Versioned packages: root `0.1.0`, `@openagents/agent-sdk@0.1.0`, `@openagents/runtime@0.1.0`, `@openagents/qa-graph@0.1.0`, `@openagents/desktop@0.1.0`.
+
+### Added
 - `agents/os-update-posture/` — third canonical Agent Template in the `updates` category. Reads `managedDevices` once and tallies the fleet twice with `count-by-field` (once on `operatingSystem`, once on `osVersion`) so end-of-life builds (Windows 10.21H2, 10.22H2) surface distinctly from current builds (11.23H2). Optional LLM step calls out the biggest update risk. YAML-only, no companion TypeScript. Smoke-verified against the synthetic fixture: 13 Windows / 5 macOS / 3 iOS / 1 Android, 12 distinct OS builds; 6 of 13 Windows devices on Windows 10 lines. Doubles as the reference shape NL2Agent should be able to draft from a plain-English prompt.
 - NL2Agent renderer: the New agent button on the hub used to be dead chrome — it now opens a two-pane flow. Pane one is a prompt textarea with a quick capability cheat-sheet and a clear callout when the LLM provider isn't reachable. Pane two is a full Manifest Preview of the generated YAML (the same component used on AgentDetail) plus inline validation errors when the LLM produced a schema-incompliant draft. Save & install wires through to `saveAgentDraft` + `installAgent` and routes the user straight to the new agent's detail page so they can run it.
 - NL2Agent backend: `draftAgentManifest(prompt)` + `saveAgentDraft(yaml)` IPC + runtime support for a second, user-writable agents root under `userData/agents/`. `draftAgentManifest` sends a structured prompt (system message + JSON Schema reference + worked example) to the active LLM provider, strips any markdown fences, parses + schema-validates the YAML, and returns either the parsed manifest or a list of validation errors. `saveAgentDraft` writes `manifest.yaml` + a projected `manifest.json` under `userData/agents/<slug>/` and refuses to shadow a bundled slug. The runtime's `listAllRegistryAgents(userRoot?)` merges both roots into a single de-duplicated registry; user-authored agents stamp their absolute path on `registryPath` so the dir resolver picks them up without colliding with the bundled tree.

--- a/agents/find-inactive-devices/package.json
+++ b/agents/find-inactive-devices/package.json
@@ -19,7 +19,7 @@
     "typecheck": "npm run build -w @openagents/agent-sdk && tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@openagents/agent-sdk": "0.1.0-dev"
+    "@openagents/agent-sdk": "0.1.0"
   },
   "devDependencies": {
     "typescript": "~6.0.3"

--- a/agents/retire-inactive-devices/package.json
+++ b/agents/retire-inactive-devices/package.json
@@ -19,7 +19,7 @@
     "typecheck": "npm run build -w @openagents/agent-sdk && tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@openagents/agent-sdk": "0.1.0-dev"
+    "@openagents/agent-sdk": "0.1.0"
   },
   "devDependencies": {
     "typescript": "~6.0.3"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openagents/desktop",
   "private": true,
-  "version": "0.1.0-dev",
+  "version": "0.1.0",
   "type": "module",
   "main": "dist-electron/electron/main.js",
   "scripts": {
@@ -15,8 +15,8 @@
     "typecheck": "npm run build:packages && tsc -b --noEmit && tsc -p tsconfig.electron.json --noEmit"
   },
   "dependencies": {
-    "@openagents/agent-sdk": "0.1.0-dev",
-    "@openagents/runtime": "0.1.0-dev",
+    "@openagents/agent-sdk": "0.1.0",
+    "@openagents/runtime": "0.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openagents",
-  "version": "0.1.0-dev",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openagents",
-      "version": "0.1.0-dev",
+      "version": "0.1.0",
       "workspaces": [
         "apps/*",
         "packages/*",
@@ -24,7 +24,7 @@
       "name": "@openagents/agent-find-inactive-devices",
       "version": "1.0.0",
       "dependencies": {
-        "@openagents/agent-sdk": "0.1.0-dev"
+        "@openagents/agent-sdk": "0.1.0"
       },
       "devDependencies": {
         "typescript": "~6.0.3"
@@ -38,7 +38,7 @@
       "name": "@openagents/agent-retire-inactive-devices",
       "version": "1.0.0",
       "dependencies": {
-        "@openagents/agent-sdk": "0.1.0-dev"
+        "@openagents/agent-sdk": "0.1.0"
       },
       "devDependencies": {
         "typescript": "~6.0.3"
@@ -46,10 +46,10 @@
     },
     "apps/desktop": {
       "name": "@openagents/desktop",
-      "version": "0.1.0-dev",
+      "version": "0.1.0",
       "dependencies": {
-        "@openagents/agent-sdk": "0.1.0-dev",
-        "@openagents/runtime": "0.1.0-dev",
+        "@openagents/agent-sdk": "0.1.0",
+        "@openagents/runtime": "0.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router": "^7.1.1"
@@ -6498,13 +6498,13 @@
     },
     "packages/agent-sdk": {
       "name": "@openagents/agent-sdk",
-      "version": "0.1.0-dev"
+      "version": "0.1.0"
     },
     "packages/qa-graph": {
       "name": "@openagents/qa-graph",
-      "version": "0.1.0-dev",
+      "version": "0.1.0",
       "dependencies": {
-        "@openagents/agent-sdk": "0.1.0-dev",
+        "@openagents/agent-sdk": "0.1.0",
         "ajv": "^8.17.1",
         "js-yaml": "^4.1.1"
       },
@@ -6541,10 +6541,10 @@
     },
     "packages/runtime": {
       "name": "@openagents/runtime",
-      "version": "0.1.0-dev",
+      "version": "0.1.0",
       "dependencies": {
         "@azure/msal-node": "^5.2.1",
-        "@openagents/agent-sdk": "0.1.0-dev",
+        "@openagents/agent-sdk": "0.1.0",
         "js-yaml": "^4.1.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openagents",
   "private": true,
-  "version": "0.1.0-dev",
+  "version": "0.1.0",
   "workspaces": [
     "apps/*",
     "packages/*",

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents/agent-sdk",
-  "version": "0.1.0-dev",
+  "version": "0.1.0",
   "type": "module",
   "description": "Shared TypeScript contracts for Open Agents packages.",
   "main": "./dist/index.js",

--- a/packages/qa-graph/package.json
+++ b/packages/qa-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents/qa-graph",
-  "version": "0.1.0-dev",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -13,7 +13,7 @@
     "qa": "npm run build && node ./dist/cli.js"
   },
   "dependencies": {
-    "@openagents/agent-sdk": "0.1.0-dev",
+    "@openagents/agent-sdk": "0.1.0",
     "ajv": "^8.17.1",
     "js-yaml": "^4.1.1"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents/runtime",
-  "version": "0.1.0-dev",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@azure/msal-node": "^5.2.1",
-    "@openagents/agent-sdk": "0.1.0-dev",
+    "@openagents/agent-sdk": "0.1.0",
     "js-yaml": "^4.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Final PR of the v0.1 cycle. Bumps every workspace package to `0.1.0` and rolls the `[Unreleased]` CHANGELOG section under `[0.1.0] - 2026-05-16`.

## After this merges

```bash
git checkout main && git pull
git tag -a v0.1.0 -m "Open Agents v0.1.0 — private preview showcase"
git push origin v0.1.0
gh release create v0.1.0 --title "v0.1.0 — private preview showcase" --notes-file <(...)
```

## What v0.1 ships

Full inventory in `tasks/todo.md`. The high-level shape:

- **Agent Templates** as the canonical authoring path — four step formats (graph / transform / llm / write), four transform / action handlers, install-time settings, JSON Schema validation, full Manifest Preview transparency.
- **Four reference agents** (`find-inactive-devices`, `retire-inactive-devices`, `compliance-overview`, `os-update-posture`) covering the four major Intune admin surface areas: device inventory, write-mode device action, compliance posture, OS update posture.
- **NL2Agent** end-to-end: describe an agent in English, the local LLM drafts a YAML manifest grounded in the JSON Schema, the schema validates the output, save & install persists it under `userData/agents/` and routes you to its detail page.
- **Trust story**: MSAL interactive sign-in with no client secret, encrypted token cache, optional local LLM (Ollama), real Graph writes gated behind tenant-connected + global toggle, every write agent pauses for typed phrase confirmation.
- **Static QA gate** (`npm run qa`) validates every shipped manifest against the schema and the local `merill/msgraph` index in CI.

## Acceptance

- [x] All workspace `package.json` files at `0.1.0`.
- [x] CHANGELOG `[0.1.0]` section dated and populated.
- [x] `npm run typecheck && npm run qa && npm run build` clean.
- [x] No `0.1.0-dev` references left in versioned packages.

## What's deferred to v0.2

See `README.md` and `tasks/todo.md`: hosted LLM providers (Anthropic, OpenAI, Azure OpenAI), LM Studio, signed installers + notarization, auto-update, SQLite migration for run history, scheduled triggers.