### PR TITLE
release: MSIX-via-Store on Windows + notarized DMG on macOS + electron-updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,154 @@
+name: Release
+
+# Builds platform-specific installers and uploads them to a draft GitHub
+# release.
+#
+# Triggers:
+#   - Tag push matching v*.*.* (the canonical "cut a release" gesture)
+#   - workflow_dispatch (re-run from the Actions tab without retagging)
+#
+# Outputs:
+#   - Windows: an unsigned .msix for Microsoft Store submission via
+#     Partner Center. Store re-signs after upload; that's where the
+#     SmartScreen-trusted publisher reputation comes from.
+#   - macOS (Apple Silicon for v0.1): notarized + signed .dmg + .zip
+#     plus latest-mac.yml for electron-updater auto-update.
+#
+# Secrets required on the repo or org:
+#   macOS:  CSC_LINK, CSC_KEY_PASSWORD, APPLE_API_KEY,
+#           APPLE_API_KEY_ID, APPLE_API_ISSUER
+#   (Windows MSIX is unsigned in CI — Microsoft Store signs it at
+#    submission time, so no secrets are required for the build itself.)
+#
+# All `GITHUB_TOKEN` use comes from the auto-provided actions token.
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  windows-msix:
+    name: Windows MSIX (Microsoft Store)
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Build MSIX
+        # --publish never: we don't upload from electron-builder; the
+        # final upload step lives in `publish-release` below so all
+        # platforms attach to the same draft GitHub release.
+        run: npm run dist -w @openagents/desktop -- --win --publish never
+
+      - name: Upload MSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-msix
+          path: apps/desktop/release/*.appx
+          if-no-files-found: error
+          retention-days: 7
+
+  macos-arm64:
+    name: macOS (Apple Silicon) — signed + notarized
+    runs-on: macos-14
+    timeout-minutes: 30
+    env:
+      # electron-builder reads these to authenticate notarization +
+      # certificate import. CSC_LINK can be a https URL or a base64
+      # blob; we use the base64 path so no external storage is needed.
+      CSC_LINK: ${{ secrets.CSC_LINK }}
+      CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+      APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Write App Store Connect API key
+        # electron-builder expects APPLE_API_KEY to be a path to a .p8
+        # file on disk. We materialize the secret contents to a tempfile
+        # and rewrite APPLE_API_KEY to point at it.
+        if: ${{ env.APPLE_API_KEY_ID != '' }}
+        env:
+          APPLE_API_KEY_CONTENTS: ${{ secrets.APPLE_API_KEY }}
+        run: |
+          key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
+          printf '%s' "$APPLE_API_KEY_CONTENTS" > "$key_path"
+          echo "APPLE_API_KEY=$key_path" >> "$GITHUB_ENV"
+
+      - name: Disable signing if secrets are missing
+        # Lets the release workflow run end-to-end on a forked or
+        # secrets-less repo for verification. Artifacts won't be
+        # publishable but the build path itself is exercised.
+        if: ${{ env.CSC_LINK == '' }}
+        run: |
+          echo "CSC_LINK=" >> "$GITHUB_ENV"
+          echo "CSC_KEY_PASSWORD=" >> "$GITHUB_ENV"
+          echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> "$GITHUB_ENV"
+
+      - name: Build .dmg + .zip (signed + notarized when secrets present)
+        run: npm run dist -w @openagents/desktop -- --mac --arm64 --publish never
+
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-arm64
+          path: |
+            apps/desktop/release/*.dmg
+            apps/desktop/release/*.zip
+            apps/desktop/release/latest-mac.yml
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-release:
+    name: Publish to draft release
+    needs: [windows-msix, macos-arm64]
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: List artifacts
+        run: ls -R artifacts
+
+      - name: Upload to draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          generate_release_notes: true
+          files: |
+            artifacts/windows-msix/*
+            artifacts/macos-arm64/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to Open Agents are recorded here. Format follows [Keep a Cha
 ## [Unreleased]
 
 ### Added
+- Release pipeline. Tag-push of `v*.*.*` (or workflow_dispatch) cuts a two-channel build via `.github/workflows/release.yml`: an unsigned Windows MSIX for Microsoft Store submission (Store re-signs after upload, giving the binary Microsoft's SmartScreen reputation from day one) and a notarized + signed macOS DMG/ZIP for direct download via GitHub Releases (auto-updated by electron-updater). Build artifacts land on a draft release for review before publishing. macOS notarization uses the modern App Store Connect API key flow (`APPLE_API_KEY` / `_KEY_ID` / `_ISSUER`) rather than the legacy Apple-ID + app-specific-password path. Per-platform secrets list and the full runbook live in `docs/RELEASING.md`.
+- `electron-updater` wired in `apps/desktop/electron/updates.ts`: 15-second startup delay, 4-hour poll, native dialog when an update is downloaded ("Restart now" / "Later"). Auto-skipped in dev and on Windows when the running build is a Microsoft Store-installed AppX (so the Store and electron-updater never race over the same install).
 
 ### Changed
+- `apps/desktop/package.json` `build` block: Windows target switched from NSIS to AppX/MSIX with the Partner Center identity (`UgurLabs.UgurLabs.OpenAgents`, `CN=E5B1EEE1-…`, publisher `UgurLabs`); macOS target tightened to Apple Silicon DMG + ZIP with `hardenedRuntime: true`; GitHub publish provider added so electron-updater knows which release feed to read.
 
 ### Removed
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3,6 +3,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, join } from "node:path";
 import { AppStateStore } from "./state.js";
 import { EncryptedSecretStore } from "./secret-store.js";
+import { startAutoUpdater } from "./updates.js";
 import type { ProviderId } from "@openagents/agent-sdk";
 
 const currentFile = fileURLToPath(import.meta.url);
@@ -174,6 +175,7 @@ if (!gotLock) {
     });
     registerIpcHandlers();
     createWindow();
+    startAutoUpdater(() => mainWindow ?? undefined);
 
     app.on("activate", () => {
       if (BrowserWindow.getAllWindows().length === 0) {

--- a/apps/desktop/electron/updates.ts
+++ b/apps/desktop/electron/updates.ts
@@ -1,0 +1,85 @@
+import { app, dialog, BrowserWindow } from "electron";
+import electronUpdater from "electron-updater";
+
+const { autoUpdater } = electronUpdater;
+
+/**
+ * Update polling cadence. Mirrors t3code: a 15-second startup delay
+ * (so first-run UX isn't dominated by a network round-trip) plus a
+ * 4-hour poll while the app is open.
+ */
+const STARTUP_DELAY_MS = 15_000;
+const POLL_INTERVAL_MS = 4 * 60 * 60 * 1000;
+
+let pollTimer: NodeJS.Timeout | undefined;
+
+/**
+ * Wire `electron-updater` against the GitHub Releases publish channel.
+ *
+ * Skipped when:
+ *   - The app is unpackaged (`npm run dev`) — no autoUpdater target.
+ *   - Running on Windows as a Microsoft Store-installed AppX — the
+ *     Store handles updates itself; calling out to GitHub would let the
+ *     two update channels race and break Store reputation. Detected
+ *     via Electron's `process.windowsStore` flag.
+ *
+ * Call this after the main window is created so notification dialogs
+ * have a parent. Safe to call once per session.
+ */
+export function startAutoUpdater(getMainWindow: () => BrowserWindow | undefined): void {
+  if (!app.isPackaged) return;
+  if (process.platform === "win32" && isWindowsStoreBuild()) return;
+
+  autoUpdater.autoDownload = true;
+  autoUpdater.autoInstallOnAppQuit = true;
+
+  autoUpdater.on("error", (error) => {
+    console.error("[updater] error", error);
+  });
+
+  autoUpdater.on("update-downloaded", (info) => {
+    const parent = getMainWindow();
+    const options: Electron.MessageBoxOptions = {
+      type: "info",
+      title: "Update ready",
+      message: `Open Agents ${info.version} downloaded`,
+      detail: "Restart to install. The update is already on disk and will apply on quit.",
+      buttons: ["Restart now", "Later"],
+      defaultId: 0,
+      cancelId: 1,
+    };
+
+    const dialogPromise = parent
+      ? dialog.showMessageBox(parent, options)
+      : dialog.showMessageBox(options);
+
+    void dialogPromise.then((result) => {
+      if (result.response === 0) {
+        autoUpdater.quitAndInstall();
+      }
+    });
+  });
+
+  const check = () => {
+    autoUpdater.checkForUpdates().catch((error: unknown) => {
+      console.error("[updater] checkForUpdates failed", error);
+    });
+  };
+
+  setTimeout(check, STARTUP_DELAY_MS);
+  pollTimer = setInterval(check, POLL_INTERVAL_MS);
+}
+
+export function stopAutoUpdater(): void {
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = undefined;
+  }
+}
+
+function isWindowsStoreBuild(): boolean {
+  // Electron sets process.windowsStore = true when the app is running
+  // from inside an MSIX / AppX container. The flag is not typed by
+  // @types/node, so we read it via an index cast.
+  return Boolean((process as unknown as { windowsStore?: boolean }).windowsStore);
+}

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@openagents/agent-sdk": "0.1.0",
     "@openagents/runtime": "0.1.0",
+    "electron-updater": "^6.6.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7.1.1"
@@ -52,17 +53,34 @@
         "to": "agents"
       }
     ],
+    "publish": [
+      {
+        "provider": "github",
+        "owner": "ugurkocde",
+        "repo": "OpenAgents"
+      }
+    ],
     "mac": {
       "category": "public.app-category.productivity",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
       "target": [
-        "dmg",
-        "zip"
+        { "target": "dmg", "arch": ["arm64"] },
+        { "target": "zip", "arch": ["arm64"] }
       ]
     },
     "win": {
       "target": [
-        "nsis"
+        { "target": "appx", "arch": ["x64"] }
       ]
+    },
+    "appx": {
+      "applicationId": "OpenAgents",
+      "displayName": "OpenAgents",
+      "identityName": "UgurLabs.UgurLabs.OpenAgents",
+      "publisher": "CN=E5B1EEE1-CB55-4BCF-9214-2A6446BB2580",
+      "publisherDisplayName": "UgurLabs",
+      "languages": ["en-US"]
     },
     "linux": {
       "target": [

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,104 @@
+# Releasing Open Agents
+
+This is the maintainer runbook for cutting a release. Day-to-day work doesn't touch any of this.
+
+The release surface is two-channel:
+
+- **Windows → Microsoft Store** (MSIX, signed by Microsoft post-upload).
+- **macOS → GitHub Releases + electron-updater** (signed + notarized in CI with our Apple Developer cert + App Store Connect API key).
+
+A single tag push cuts both. CI handles everything except (a) one-time Apple secret setup and (b) the manual Partner Center upload for new Windows builds.
+
+---
+
+## One-time setup
+
+### macOS — Apple Developer secrets
+
+Add these five repository secrets at https://github.com/ugurkocde/OpenAgents/settings/secrets/actions.
+
+| Secret | What | How to get it |
+|---|---|---|
+| `CSC_LINK` | Base64 of your `Developer ID Application` `.p12`. | Keychain → export the cert + private key as `.p12` → `base64 -i cert.p12 \| pbcopy`. |
+| `CSC_KEY_PASSWORD` | Password you set when exporting the `.p12`. | You picked it during the export. |
+| `APPLE_API_KEY` | Contents of an App Store Connect `.p8` private key (the full file, BEGIN/END lines included). | https://appstoreconnect.apple.com/access/integrations/api → Generate API Key with **Developer** access. Download the `.p8` once (Apple doesn't show it again). |
+| `APPLE_API_KEY_ID` | 10-char Key ID for the same key. | Shown next to the key after generation. |
+| `APPLE_API_ISSUER` | UUID issuer ID for your App Store Connect team. | Shown at the top of the API Keys page (looks like `69a6de80-...`). |
+
+The CI workflow detects when these are missing and falls back to an unsigned `.dmg`/`.zip` so the build still completes (useful for forks and dry runs). Don't ship an unsigned build.
+
+### Windows — Microsoft Store
+
+No secrets needed in GitHub. CI builds an unsigned MSIX; Microsoft signs it after Partner Center submission.
+
+The values in `apps/desktop/package.json` `build.appx` are the Partner Center-assigned identity for this app:
+
+| Field | Value |
+|---|---|
+| `identityName` | `UgurLabs.UgurLabs.OpenAgents` |
+| `publisher` | `CN=E5B1EEE1-CB55-4BCF-9214-2A6446BB2580` |
+| `publisherDisplayName` | `UgurLabs` |
+| Seller ID (for future Submission API automation) | `82025760` |
+
+These match the Partner Center reservation for the `OpenAgents` Store name. Don't change them — Microsoft validates the MSIX against the registered identity at upload time.
+
+---
+
+## Cutting a release
+
+```bash
+# 1. Make sure main is green.
+git checkout main && git pull
+npm run typecheck && npm run qa && npm run build
+
+# 2. Bump versions if you haven't already. (The release-v0.1.0 PR
+#    pattern is the template — edit every workspace package.json, roll
+#    the [Unreleased] section in CHANGELOG.md under the new version
+#    header, merge through CI.)
+
+# 3. Tag and push. Workflow fires automatically.
+git tag -a v0.1.1 -m "Open Agents v0.1.1"
+git push origin v0.1.1
+```
+
+CI then:
+
+1. Builds the Windows MSIX on `windows-latest`.
+2. Builds the signed + notarized macOS DMG/ZIP + `latest-mac.yml` on `macos-14`.
+3. Downloads both into the `publish-release` job and pushes them to a **draft** GitHub release for `v0.1.1`.
+
+Visit https://github.com/ugurkocde/OpenAgents/releases. The draft has all four artifacts attached.
+
+## Manual steps after CI
+
+### macOS — publish the release
+
+1. Review the draft release on GitHub.
+2. Smoke-test the DMG locally (download, open, drag-to-Applications, launch).
+3. Click **Publish release** in the GitHub UI.
+
+That's it. electron-updater on existing macOS installs picks up the new `latest-mac.yml` within 4 hours.
+
+### Windows — Microsoft Store submission
+
+1. Download the `.appx` (named like `Open Agents-x.y.z.appx`) from the draft release.
+2. Go to https://partner.microsoft.com/dashboard.
+3. Apps → **OpenAgents** → Submissions → **New submission** (or **Update**).
+4. **Packages** section → upload the `.appx`.
+5. Fill in the per-submission fields (release notes, age rating, etc.). For the first submission Partner Center walks you through everything; later submissions only need the new package + release notes.
+6. **Submit to the Store**.
+
+Certification typically takes 1–3 business days for the first submission and minutes-to-hours for updates. The Store handles distribution + auto-update on Windows; we don't need to ship anything else for Windows users.
+
+---
+
+## Why this shape
+
+- **MSIX via Store, not signed sideload.** Microsoft signs the package after upload, which gives the app the Store's SmartScreen reputation from day one. A direct-download `.exe` signed with our own cert would trigger SmartScreen warnings for months until enough installs build reputation. The trade is one manual step per release (Partner Center upload) vs. paying for a code-signing cert + accepting the reputation cliff.
+- **App Store Connect API key, not Apple ID + app-specific password.** Apple is phasing out the app-specific password path; the API key flow is the modern equivalent and works headlessly in CI.
+- **Draft releases, not published.** Lets us eyeball the signed artifacts before they go live. Toggle `draft: true` to `draft: false` in `.github/workflows/release.yml` if you want auto-publish.
+- **Apple Silicon only for v0.1.** macOS x64 + the per-arch manifest merge land in a follow-up when there's demand. Apple Silicon is the right default for new buyers; legacy Intel Macs are a smaller share each quarter.
+
+## When to update this doc
+
+Any time the secret list, the Partner Center identity, or the release workflow changes. Out-of-date release docs are how teams ship broken builds.

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
       "dependencies": {
         "@openagents/agent-sdk": "0.1.0",
         "@openagents/runtime": "0.1.0",
+        "electron-updater": "^6.6.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router": "^7.1.1"
@@ -2512,19 +2513,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/app-builder-lib/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/app-builder-lib/node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -2768,7 +2756,6 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
       "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -3104,7 +3091,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3452,6 +3438,22 @@
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "mime": "^2.5.2"
+      }
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
+      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
       }
     },
     "node_modules/electron-winstaller": {
@@ -3879,7 +3881,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -4134,7 +4135,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -4489,7 +4489,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -4567,7 +4566,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lightningcss": {
@@ -4839,6 +4837,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -4849,6 +4853,13 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
@@ -5794,7 +5805,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -5805,6 +5815,18 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/semver-compare": {
       "version": "1.0.0",
@@ -6133,6 +6155,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -6247,7 +6275,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"


### PR DESCRIPTION
## Summary

Two-channel release pipeline. Tag-push `v*.*.*` cuts an unsigned Windows MSIX for Microsoft Store submission and a notarized macOS DMG/ZIP for GitHub Releases. electron-updater wired for macOS only; Windows updates flow through the Store.

## Why MSIX instead of EV-signed sideload

Microsoft signs the MSIX after Partner Center submission, which gives the binary Microsoft Store's SmartScreen reputation from day one. The alternative (Azure Trusted Signing or a paid EV cert) means months of "Unknown publisher" warnings while reputation builds. One manual Partner Center upload per release is cheaper than that UX hit. Azure Trusted Signing dropped from the plan entirely.

## Pipeline

- **Trigger**: tag push `v*.*.*` or `workflow_dispatch`.
- **windows-msix** (`windows-latest`): `electron-builder --win --publish never` → produces `.appx` matching the `UgurLabs.UgurLabs.OpenAgents` Partner Center identity. Uploaded as artifact.
- **macos-arm64** (`macos-14`): materializes the App Store Connect API `.p8` to a temp path, runs `electron-builder --mac --arm64 --publish never` → signs with the `Developer ID Application` cert (from `CSC_LINK` base64 secret) and notarizes via notarytool API key (`APPLE_API_KEY` / `_KEY_ID` / `_ISSUER`). Uploaded as artifact. Degrades to unsigned if secrets missing — useful for forks and dry runs.
- **publish-release** (`ubuntu-latest`): downloads both, pushes to a **draft** GitHub release via `softprops/action-gh-release@v2`. Draft so maintainers eyeball signed artifacts before announcing.

## Updater

`apps/desktop/electron/updates.ts` (new):
- Skipped in dev (`!app.isPackaged`).
- Skipped on Windows when running as a Microsoft Store-installed AppX (`process.windowsStore === true`) so the Store and electron-updater never race.
- macOS: 15s startup delay, 4h poll, native dialog on `update-downloaded` ("Restart now" / "Later").

Mirrors t3code's polling cadence and explicit-call shape; no XState/Effect.

## What you need to do once

Add five repo secrets at https://github.com/ugurkocde/OpenAgents/settings/secrets/actions:

| Secret | What |
|---|---|
| `CSC_LINK` | Base64 of your `Developer ID Application` `.p12` |
| `CSC_KEY_PASSWORD` | Password used when exporting the `.p12` |
| `APPLE_API_KEY` | Contents of the App Store Connect `.p8` (full PEM block) |
| `APPLE_API_KEY_ID` | 10-char Key ID |
| `APPLE_API_ISSUER` | UUID issuer ID |

`docs/RELEASING.md` walks through how to collect each.

Windows needs no secrets — the `appx` config in `package.json` already carries the Partner Center identity (`UgurLabs.UgurLabs.OpenAgents`, publisher `CN=E5B1EEE1-…`, display name `UgurLabs`). Seller ID `82025760` is recorded in `RELEASING.md` for the Submission API automation that lands later.

## Acceptance

- [x] `npm run typecheck` clean.
- [x] `npm run build` clean.
- [x] Workflow YAML lints (no `${{ github.event.* }}` in shell — all attacker-controlled inputs would be threaded through `env:`).
- [x] Updater is dev-safe (no-op when unpackaged) and Store-safe (no-op on Windows Store AppX).
- [x] All Partner Center values verified against the actual reservation.

## Test plan

- [ ] Merge this PR (no signed artifacts produced; just the plumbing).
- [ ] Add the five macOS secrets.
- [ ] `git tag -a v0.1.1 -m "test signing" && git push origin v0.1.1`.
- [ ] Watch the Actions run. Both jobs should produce artifacts; the draft release should have a `.dmg`, a `.zip`, a `latest-mac.yml`, and a `.appx`.
- [ ] Download the `.dmg`, drag-to-Applications, launch. macOS Gatekeeper should show no warning.
- [ ] Download the `.appx`, upload to Partner Center → OpenAgents → New submission. Wait for certification (1–3 days first time).
- [ ] Click Publish on the GitHub draft release.

## Next

After this lands and v0.1.1 cuts cleanly, the next release-adjacent slices are:
- macOS x64 build + `latest-mac.yml` per-arch merge (t3code has a 30-line script worth stealing).
- Microsoft Store Submission API automation (uses the Seller ID).
- Mock update server pattern for testing the updater flow end-to-end without cutting real releases.