### PR TITLE
desktop: declare Apple Team ID for notarization

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -64,6 +64,9 @@
       "category": "public.app-category.productivity",
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
+      "notarize": {
+        "teamId": "D259ULY2B4"
+      },
       "target": [
         { "target": "dmg", "arch": ["arm64"] },
         { "target": "zip", "arch": ["arm64"] }


### PR DESCRIPTION
Adds `build.mac.notarize.teamId = D259ULY2B4` so electron-builder validates the notarytool submission against the correct App Store Connect team. All five macOS signing secrets are now live on the repo; this is the last config piece before the release workflow can sign + notarize end-to-end.