### PR TITLE
release: pin electronVersion in build config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ src-tauri/target/
 # Working artifacts (screenshots taken during dev, browser automation traces)
 /*.png
 .playwright-mcp/
+apps/desktop/release/

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -39,6 +39,7 @@
   "build": {
     "appId": "com.ugurlabs.openagents",
     "productName": "Open Agents",
+    "electronVersion": "42.1.0",
     "directories": {
       "output": "release"
     },


### PR DESCRIPTION
Both release jobs failed pre-build with `Cannot compute electron version from installed node modules`. Cause: npm workspace hoisting puts `electron` at the repo root, and the range pattern (`^42.1.0`) makes electron-builder refuse autodetection.

Fix: `build.electronVersion: "42.1.0"` — explicit pin, bypasses autodetection.

Verified locally: full arm64 build runs through to a signed DMG (notarization skipped locally because no APPLE_API_KEY env var; CI has the full set).

After this merges I'll re-dispatch the workflow.