### PR TITLE
release: v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to Open Agents are recorded here. Format follows [Keep a Cha
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.1.1] - 2026-05-16
+
+Signed-binaries follow-up to v0.1.0. The platform is unchanged; this release adds the distribution pipeline so we can ship trustable installers from CI on every tag push. End-to-end verified by a `workflow_dispatch` dry run on `main` — Windows MSIX built clean in 1m45s, macOS DMG signed + notarized in 3m23s (Apple's notarytool round-trip under 2 min on the day).
+
+### Added
 - Release pipeline. Tag-push of `v*.*.*` (or workflow_dispatch) cuts a two-channel build via `.github/workflows/release.yml`: an unsigned Windows MSIX for Microsoft Store submission (Store re-signs after upload, giving the binary Microsoft's SmartScreen reputation from day one) and a notarized + signed macOS DMG/ZIP for direct download via GitHub Releases (auto-updated by electron-updater). Build artifacts land on a draft release for review before publishing. macOS notarization uses the modern App Store Connect API key flow (`APPLE_API_KEY` / `_KEY_ID` / `_ISSUER`) rather than the legacy Apple-ID + app-specific-password path. Per-platform secrets list and the full runbook live in `docs/RELEASING.md`.
 - `electron-updater` wired in `apps/desktop/electron/updates.ts`: 15-second startup delay, 4-hour poll, native dialog when an update is downloaded ("Restart now" / "Later"). Auto-skipped in dev and on Windows when the running build is a Microsoft Store-installed AppX (so the Store and electron-updater never race over the same install).
 

--- a/agents/find-inactive-devices/package.json
+++ b/agents/find-inactive-devices/package.json
@@ -19,7 +19,7 @@
     "typecheck": "npm run build -w @openagents/agent-sdk && tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@openagents/agent-sdk": "0.1.0"
+    "@openagents/agent-sdk": "0.1.1"
   },
   "devDependencies": {
     "typescript": "~6.0.3"

--- a/agents/retire-inactive-devices/package.json
+++ b/agents/retire-inactive-devices/package.json
@@ -19,7 +19,7 @@
     "typecheck": "npm run build -w @openagents/agent-sdk && tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@openagents/agent-sdk": "0.1.0"
+    "@openagents/agent-sdk": "0.1.1"
   },
   "devDependencies": {
     "typescript": "~6.0.3"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openagents/desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "dist-electron/electron/main.js",
   "scripts": {
@@ -15,8 +15,8 @@
     "typecheck": "npm run build:packages && tsc -b --noEmit && tsc -p tsconfig.electron.json --noEmit"
   },
   "dependencies": {
-    "@openagents/agent-sdk": "0.1.0",
-    "@openagents/runtime": "0.1.0",
+    "@openagents/agent-sdk": "0.1.1",
+    "@openagents/runtime": "0.1.1",
     "electron-updater": "^6.6.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openagents",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openagents",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "workspaces": [
         "apps/*",
         "packages/*",
@@ -24,7 +24,7 @@
       "name": "@openagents/agent-find-inactive-devices",
       "version": "1.0.0",
       "dependencies": {
-        "@openagents/agent-sdk": "0.1.0"
+        "@openagents/agent-sdk": "0.1.1"
       },
       "devDependencies": {
         "typescript": "~6.0.3"
@@ -38,7 +38,7 @@
       "name": "@openagents/agent-retire-inactive-devices",
       "version": "1.0.0",
       "dependencies": {
-        "@openagents/agent-sdk": "0.1.0"
+        "@openagents/agent-sdk": "0.1.1"
       },
       "devDependencies": {
         "typescript": "~6.0.3"
@@ -46,10 +46,10 @@
     },
     "apps/desktop": {
       "name": "@openagents/desktop",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
-        "@openagents/agent-sdk": "0.1.0",
-        "@openagents/runtime": "0.1.0",
+        "@openagents/agent-sdk": "0.1.1",
+        "@openagents/runtime": "0.1.1",
         "electron-updater": "^6.6.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -6525,13 +6525,13 @@
     },
     "packages/agent-sdk": {
       "name": "@openagents/agent-sdk",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "packages/qa-graph": {
       "name": "@openagents/qa-graph",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
-        "@openagents/agent-sdk": "0.1.0",
+        "@openagents/agent-sdk": "0.1.1",
         "ajv": "^8.17.1",
         "js-yaml": "^4.1.1"
       },
@@ -6568,10 +6568,10 @@
     },
     "packages/runtime": {
       "name": "@openagents/runtime",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@azure/msal-node": "^5.2.1",
-        "@openagents/agent-sdk": "0.1.0",
+        "@openagents/agent-sdk": "0.1.1",
         "js-yaml": "^4.1.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openagents",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "workspaces": [
     "apps/*",
     "packages/*",

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents/agent-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Shared TypeScript contracts for Open Agents packages.",
   "main": "./dist/index.js",

--- a/packages/qa-graph/package.json
+++ b/packages/qa-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents/qa-graph",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -13,7 +13,7 @@
     "qa": "npm run build && node ./dist/cli.js"
   },
   "dependencies": {
-    "@openagents/agent-sdk": "0.1.0",
+    "@openagents/agent-sdk": "0.1.1",
     "ajv": "^8.17.1",
     "js-yaml": "^4.1.1"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents/runtime",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@azure/msal-node": "^5.2.1",
-    "@openagents/agent-sdk": "0.1.0",
+    "@openagents/agent-sdk": "0.1.1",
     "js-yaml": "^4.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Patch release on the v0.1 line. Workspace versions 0.1.0 → 0.1.1; CHANGELOG [Unreleased] rolled under [0.1.1].

Contents: the distribution pipeline. After this merges, `git tag -a v0.1.1 && git push origin v0.1.1` cuts the real release — both build jobs + the `publish-release` job attach the `.appx` + signed/notarized `.dmg` + `.zip` + `latest-mac.yml` to a draft GitHub release.

Verified end-to-end by the workflow_dispatch dry run on main (run [25970251948](https://github.com/ugurkocde/OpenAgents/actions/runs/25970251948)): Windows MSIX in 1m45s, macOS DMG signed + notarized in 3m23s.