### PR TITLE
desktop: pin app.setName("Open Agents") to prevent npm-name leakage in Keychain prompts

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6,6 +6,18 @@ import { EncryptedSecretStore } from "./secret-store.js";
 import { startAutoUpdater } from "./updates.js";
 import type { ProviderId } from "@openagents/agent-sdk";
 
+// Set the app name BEFORE anything else that could touch the macOS
+// Keychain. Electron's safeStorage uses `app.getName()` to construct
+// the Keychain service name ("<name> Safe Storage"). In a signed
+// production build that name comes from CFBundleName ("Open Agents")
+// via Info.plist, but in dev (`npm run dev`, unpackaged Electron) it
+// falls back to package.json's `name` field — which is the npm
+// package id "@openagents/desktop" and ends up as the user-visible
+// string in Keychain prompts. Pinning it explicitly here keeps the
+// two paths consistent and gives users a single "Open Agents Safe
+// Storage" entry regardless of how they're running the app.
+app.setName("Open Agents");
+
 const currentFile = fileURLToPath(import.meta.url);
 const currentDir = dirname(currentFile);
 const devServerUrl = process.env.VITE_DEV_SERVER_URL ?? "http://localhost:5173";


### PR DESCRIPTION
## Problem

First-launch users on macOS see this Keychain prompt:

> **Open Agents** wants to use your confidential information stored in **\"@openagents/desktop Safe Storage\"** in your keychain.

The \`@openagents/desktop\` string is our npm package name leaking into a user-visible system dialog. Looks unprofessional and is a real install-time speed bump.

## Cause

Electron's \`safeStorage\` constructs the Keychain service name as \`<app.getName()> Safe Storage\`. \`app.getName()\` returns:

1. Whatever \`app.setName()\` was called with, if anything (we never did)
2. Otherwise CFBundleName from Info.plist (in signed production builds)
3. Otherwise the npm \`name\` from package.json

In **dev** (\`npm run dev\`, unpackaged Electron), branch 3 fires → \`@openagents/desktop\`. The dev process creates a Keychain entry under that name, tied to the dev signature.

In **production** (signed v0.1.1 DMG), branch 2 fires → \`Open Agents\`. That correctly creates \"Open Agents Safe Storage.\"

The two paths produce **two separate Keychain entries with two separate ACLs**. If a user has run both, the signed app tries to access an entry whose ACL was set by the unsigned dev signature → macOS prompts.

## Fix

Single line at the top of \`main.ts\`:

\`\`\`ts
app.setName(\"Open Agents\");
\`\`\`

Pins the name across dev and production. Future first-launch users (no prior dev install) get a silent \"Open Agents Safe Storage\" entry on first \`safeStorage\` call. No prompt.

## Existing users (only me right now)

Need to delete the stale \`@openagents/desktop Safe Storage\` entry once:

\`\`\`bash
security delete-generic-password -l \"@openagents/desktop Safe Storage\"
\`\`\`

After that, v0.1.1 already has its own \"Open Agents Safe Storage\" entry (which the signed build created earlier today), so no further action needed. I've already done this on my machine and verified the entry is gone.

## Acceptance

- [x] Diagnosed via \`security dump-keychain\` — confirmed both entries existed on my machine
- [x] \`app.setName(\"Open Agents\")\` added before any safeStorage-touching code
- [x] Typecheck clean
- [x] Stale entry deleted from my login keychain
- [ ] Verify in v0.1.2 build: run \`npm run dev\` → check \`security dump-keychain\` → should only see \"Open Agents Safe Storage,\" never \"@openagents/desktop\"

## Why ship it as a patch

Trust-story fix. Anyone who clicks \"Allow\" without thinking has trained themselves to ignore Keychain prompts. Anyone who reads the prompt sees an npm package name and wonders what they just installed. Either outcome is bad for an app whose whole pitch is \"local-first and trustworthy.\"

Next release cuts via the new \`Release prep\` workflow.