### PR TITLE
ci: fix YAML parse error in auto-tag workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -18,10 +18,13 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Sidesteps YAML's colon-in-string parsing — see the if: on the
+  # tag job, which compares the commit subject against this prefix.
+  RELEASE_PREFIX: "release: v"
 
 jobs:
   tag:
-    if: startsWith(github.event.head_commit.message, 'release: v')
+    if: startsWith(github.event.head_commit.message, env.RELEASE_PREFIX)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## Root cause

The job-level conditional was:

\`\`\`yaml
if: startsWith(github.event.head_commit.message, 'release: v')
\`\`\`

The **colon inside the single-quoted string** broke YAML parsing — the parser saw \`release:\` as a mapping key. Every push event triggered the workflow, GitHub failed to parse the file, and the run completed instantly as \"failure\" with zero jobs scheduled. **Six failed runs** since the workflow landed (#27).

## Fix

Hoist the prefix string into a workflow-level env var:

\`\`\`yaml
env:
  RELEASE_PREFIX: \"release: v\"

jobs:
  tag:
    if: startsWith(github.event.head_commit.message, env.RELEASE_PREFIX)
\`\`\`

The colon now lives in a properly quoted YAML scalar. Same semantics, no parse error.

## Side effect

The \`branches: [main]\` filter starts working too. It was being skipped because GitHub couldn't get past the parse error to evaluate it — which is why feature branch pushes (fix-app-name, changelog-app-name, etc.) also triggered failed runs of this workflow.

## Verified

- \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/auto-tag.yml'))\"\` parses cleanly now (failed before).
- Branch filter + commit-subject check both look right when inspected post-parse.

After this merges, the next \`release: v0.1.2 (#NN)\` squash-merge commit on main will trigger auto-tag.yml, which will push v0.1.2 and chain into release.yml. The non-release squash-merges (like this one) will skip cleanly.