### PR TITLE
ci: quote the auto-tag if: as a YAML single-quoted string

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -18,13 +18,10 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  # Sidesteps YAML's colon-in-string parsing — see the if: on the
-  # tag job, which compares the commit subject against this prefix.
-  RELEASE_PREFIX: "release: v"
 
 jobs:
   tag:
-    if: startsWith(github.event.head_commit.message, env.RELEASE_PREFIX)
+    if: 'startsWith(github.event.head_commit.message, ''release: v'')'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
PR #30 tried the env-var workaround, which doesn't work — env context isn't available in job-level `if:`. Real fix: YAML-quote the whole expression with single quotes (`'…'`) and escape the inner single quotes by doubling (`''`).

```yaml
if: 'startsWith(github.event.head_commit.message, ''release: v'')'
```

PyYAML parses this to the literal `startsWith(github.event.head_commit.message, 'release: v')`, which is what GitHub's expression evaluator wants.

After this lands, the next `release: vX.Y.Z (#NN)` squash-merge will actually trigger `auto-tag.yml` and push the tag. Day-to-day merges will skip cleanly (job's `if:` evaluates to false → run reports as skipped, not failed).