### PR TITLE
ci: read package.json version with jq instead of node -p

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Read current version
         id: current
-        run: echo "version=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
 
       - name: Bump versions + roll CHANGELOG
         env:
@@ -62,7 +62,7 @@ jobs:
 
       - name: Read new version
         id: next
-        run: echo "version=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
 
       - name: Install (regenerate lockfile)
         run: npm install --no-audit --no-fund


### PR DESCRIPTION
Two-bug fix in the new release-prep workflow surfaced on its first run:

1. **Empty version capture.** The version-read steps shelled out to:

   ```bash
   node -p 'require(\"./package.json\").version'
   ```

   Bash leaves `\"` literal inside single quotes, so Node parsed the string `require(\"./package.json\").version` — a JS syntax error. The step's output was empty; the downstream Open-release-PR step pushed a branch named `release/v` and `gh pr create` failed with that as the source.

   Swapped both invocations for `jq -r .version package.json` — preinstalled on every runner, no quote gymnastics.

2. **Actions couldn't open PRs.** Fixed at the repo level by setting Workflow permissions → `can_approve_pull_request_reviews=true`. No file change here; the API call is documented in the commit message.

The leftover `release/v` zombie branch from the failed run has been deleted from origin. Once this merges I'll re-dispatch the workflow.