### PR TITLE
ci: dispatch release.yml explicitly after auto-tag

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -68,4 +68,18 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Open Agents $TAG"
           git push origin "$TAG"
-          echo "Pushed $TAG → release.yml will fire next."
+          echo "Pushed $TAG."
+
+      - name: Dispatch release workflow
+        # The tag push above does NOT trigger release.yml on its own —
+        # GitHub deliberately suppresses workflow chaining when one
+        # workflow's GITHUB_TOKEN is the actor that pushed (anti-loop
+        # safeguard). So we dispatch release.yml explicitly here,
+        # against the freshly-pushed tag.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh workflow run release.yml --ref "$TAG"
+          echo "Dispatched release.yml for $TAG."


### PR DESCRIPTION
The tag push from auto-tag doesn't trigger release.yml — GitHub suppresses workflow chaining when GITHUB_TOKEN is the actor. First seen on v0.1.2 (auto-tag succeeded, release.yml never fired; dispatched manually). After this lands, the chain is fully unattended: prep → review PR → merge → tag → release.