### PR TITLE
desktop: set vite base to "./" so production loads under file://

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -3,6 +3,12 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
+  // Emit relative asset URLs so the production build loads correctly
+  // when Electron serves dist/index.html over the file:// protocol.
+  // The default ("/") resolves <script src="/assets/foo.js"> to the
+  // filesystem root, so nothing loads from inside the packaged .app
+  // and the window stays blank.
+  base: "./",
   plugins: [react(), tailwindcss()],
   server: {
     port: 5173,


### PR DESCRIPTION
**Why the v0.1.2 DMG launches to a black window.**

Vite's default `base: "/"` emits absolute asset URLs in `dist/index.html`:

```html
<script src="/assets/index-wxT3-FXA.js">
```

Electron loads that html over `file://`, so `/assets/...` resolves to `file:///assets/...` (filesystem root) — neither the CSS nor the JS load. React never mounts. The window shows only the BrowserWindow's configured `backgroundColor: "#0a0c10"`.

Dev mode hid this: `http://localhost:5173/assets/...` resolved fine under the dev server.

Fix: `base: "./"` so the same html reads `<script src="./assets/index-hR_arfOH.js">` and resolves relative to the html file. Verified locally — rebuild produces relative paths.

This was a latent bug since v0.1.0; the signed DMG had simply never been launched until today. v0.1.3 ships the fix so the macOS DMG actually paints the UI.