### PR TITLE
ci: grant actions:write to auto-tag so it can dispatch release.yml

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -15,6 +15,11 @@ on:
 
 permissions:
   contents: write
+  # The "Dispatch release workflow" step calls
+  # `gh workflow run release.yml --ref vX.Y.Z`, which goes through the
+  # repos/.../actions/workflows/release.yml/dispatches endpoint —
+  # that needs actions:write, separate from contents:write.
+  actions: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
Auto-tag's chain step failed with HTTP 403 on its first real run (v0.1.3) because GITHUB_TOKEN needs `actions: write` to call the workflows-dispatches endpoint — separate from the `contents: write` already declared. Adding it.