### PR TITLE
release: v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to OpenAdminOS are recorded here. Format follows [Keep a Cha
 
 ### Added
 
+### Changed
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.1.9] - 2026-05-22
+
+### Added
+
 - **Per-agent over-the-air updates.** Each installed agent now compares its persisted version against the registry version on every `getAppState()` and surfaces an `updateAvailable` chip on the agent card plus a full "Update available" callout on the agent detail page. Clicking **Update** fetches the new `manifest.yaml` from the registry's raw GitHub URL, validates it against the agent-template schema, persists it to `<userData>/agent-updates/<slug>/manifest.yaml`, and refreshes the installed entry's registry-derived fields. User settings, schedule, and `installedAt` are preserved across the update; settings keys that no longer exist in the new manifest are dropped silently. Failures (network, schema, slug mismatch) throw with an actionable message and leave the installed manifest untouched. New IPC `openadminos:update-agent`, new bridge method `api.updateAgent(slug)`, new SDK type `AgentUpdateInfo`, new runtime exports `compareSemver` / `setAgentUpdatesDir` / `getAgentUpdatesDir`. Detection rides the existing registry refresh — no background polling, no auto-update.
 - **Offboarding agent** (`agents/offboarding-agent`) — open-source replacement for Microsoft's retired Intune Device Offboarding Agent. Reads `/deviceManagement/managedDevices` (Intune) and `/devices` (Entra), correlates by `azureADDeviceId` ↔ `deviceId`, and flags candidates that are stale by both signals (configurable: `both` | `intune-only` | `entra-only`). Excludes devices already in flight (`retirePending`, `retireIssued`, `wipePending`, `deletePending`). New free-text `instructions` setting feeds admin-supplied guidance into the LLM rationale step. Confirmation phrase: `OFFBOARD N DEVICES`. Unlike the Microsoft agent, this one actually executes the Intune retire — it is not a suggestion list. Requires the new scope `Device.Read.All` alongside the existing managed-device read + privileged-operations scopes.
 - `correlate-stale-devices` transform kind in the agent-template runtime — joins two device arrays by `azureADDeviceId`/`deviceId`, applies a per-strategy staleness filter, and skips in-flight management states. Documented and validated alongside the existing `filter-by-age` / `group-by-age` family.

--- a/agents/index.json
+++ b/agents/index.json
@@ -86,6 +86,29 @@
       "manifestUrl": "https://raw.githubusercontent.com/OpenAdminOS/OpenAdminOS/main/agents/find-inactive-devices/manifest.yaml"
     },
     {
+      "id": "offboarding-agent",
+      "slug": "offboarding-agent",
+      "name": "Offboarding agent",
+      "description": "Identifies stale devices using Intune sync + Entra sign-in signals and retires them after typed confirmation. Open replacement for Microsoft's retired Intune Device Offboarding Agent.",
+      "version": "1.0.0",
+      "mode": "write",
+      "category": "devices",
+      "tier": "agent",
+      "requiresEntraTier": "free",
+      "author": {
+        "name": "OpenAdminOS",
+        "handle": "openadminos",
+        "verified": true
+      },
+      "scopes": [
+        "DeviceManagementManagedDevices.Read.All",
+        "Device.Read.All",
+        "DeviceManagementManagedDevices.PrivilegedOperations.All"
+      ],
+      "minAppVersion": "0.1.0",
+      "manifestUrl": "https://raw.githubusercontent.com/OpenAdminOS/OpenAdminOS/main/agents/offboarding-agent/manifest.yaml"
+    },
+    {
       "id": "os-update-posture",
       "slug": "os-update-posture",
       "name": "OS update posture",
@@ -105,29 +128,6 @@
       ],
       "minAppVersion": "0.1.0",
       "manifestUrl": "https://raw.githubusercontent.com/OpenAdminOS/OpenAdminOS/main/agents/os-update-posture/manifest.yaml"
-    },
-    {
-      "id": "offboarding-agent",
-      "slug": "offboarding-agent",
-      "name": "Offboarding agent",
-      "description": "Identifies stale devices using Intune sync + Entra sign-in signals and retires them after typed confirmation. Open replacement for Microsoft's retired Intune Device Offboarding Agent.",
-      "version": "1.0.0",
-      "mode": "write",
-      "category": "devices",
-      "tier": "agent",
-      "requiresEntraTier": "free",
-      "author": {
-        "name": "OpenAdminOS",
-        "handle": "openadminos",
-        "verified": true
-      },
-      "scopes": [
-        "DeviceManagementManagedDevices.Read.All",
-        "DeviceManagementManagedDevices.PrivilegedOperations.All",
-        "Device.Read.All"
-      ],
-      "minAppVersion": "0.1.9",
-      "manifestUrl": "https://raw.githubusercontent.com/OpenAdminOS/OpenAdminOS/main/agents/offboarding-agent/manifest.yaml"
     },
     {
       "id": "risky-sign-in-triage",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openadminos/desktop",
   "private": true,
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "main": "dist-electron/electron/main.js",
   "scripts": {
@@ -15,8 +15,8 @@
     "typecheck": "npm run build:packages && tsc -b --noEmit && tsc -p tsconfig.electron.json --noEmit"
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.1.8",
-    "@openadminos/runtime": "0.1.8",
+    "@openadminos/agent-sdk": "0.1.9",
+    "@openadminos/runtime": "0.1.9",
     "electron-updater": "^6.6.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openadminos",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openadminos",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -55,10 +55,10 @@
     },
     "apps/desktop": {
       "name": "@openadminos/desktop",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.1.8",
-        "@openadminos/runtime": "0.1.8",
+        "@openadminos/agent-sdk": "0.1.9",
+        "@openadminos/runtime": "0.1.9",
         "electron-updater": "^6.6.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -118,7 +118,6 @@
       "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -506,6 +505,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -527,6 +527,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -560,6 +561,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -577,6 +579,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -594,6 +597,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -611,6 +615,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -628,6 +633,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -645,6 +651,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -662,6 +669,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -679,6 +687,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -696,6 +705,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -713,6 +723,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -730,6 +741,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -747,6 +759,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -764,6 +777,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -781,6 +795,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -798,6 +813,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -815,6 +831,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -832,6 +849,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -849,6 +867,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -866,6 +885,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -883,6 +903,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -900,6 +921,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -917,6 +939,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -934,6 +957,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -951,6 +975,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -968,6 +993,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -985,6 +1011,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1479,7 +1506,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.4",
@@ -1493,7 +1521,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.4",
@@ -1507,7 +1536,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.4",
@@ -1521,7 +1551,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.4",
@@ -1535,7 +1566,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.4",
@@ -1549,7 +1581,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.4",
@@ -1563,7 +1596,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.4",
@@ -1577,7 +1611,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.4",
@@ -1591,7 +1626,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.4",
@@ -1605,7 +1641,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.4",
@@ -1619,7 +1656,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.4",
@@ -1633,7 +1671,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.4",
@@ -1647,7 +1686,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.4",
@@ -1661,7 +1701,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.4",
@@ -1675,7 +1716,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.4",
@@ -1689,7 +1731,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.4",
@@ -1703,7 +1746,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.4",
@@ -1717,7 +1761,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.4",
@@ -1731,7 +1776,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.4",
@@ -1745,7 +1791,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.4",
@@ -1759,7 +1806,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.4",
@@ -1773,7 +1821,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.4",
@@ -1787,7 +1836,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.4",
@@ -1801,7 +1851,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.4",
@@ -1815,7 +1866,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -2161,7 +2213,8 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
@@ -2210,7 +2263,6 @@
       "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -2233,7 +2285,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2320,7 +2371,6 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3037,7 +3087,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3254,7 +3305,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -3460,6 +3510,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -3480,6 +3531,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -3495,6 +3547,7 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3505,6 +3558,7 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -3641,6 +3695,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4411,7 +4466,6 @@
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -4571,7 +4625,6 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -5034,6 +5087,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -5396,6 +5450,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -5413,6 +5468,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -5512,7 +5568,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5522,7 +5577,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5639,6 +5693,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -5712,6 +5767,7 @@
       "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6113,6 +6169,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -6228,7 +6285,6 @@
       "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -7026,13 +7082,13 @@
     },
     "packages/agent-sdk": {
       "name": "@openadminos/agent-sdk",
-      "version": "0.1.8"
+      "version": "0.1.9"
     },
     "packages/connector-teams": {
       "name": "@openadminos/connector-teams",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.1.8"
+        "@openadminos/agent-sdk": "0.1.9"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -7044,9 +7100,9 @@
     },
     "packages/qa-graph": {
       "name": "@openadminos/qa-graph",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.1.8",
+        "@openadminos/agent-sdk": "0.1.9",
         "ajv": "^8.17.1",
         "js-yaml": "^4.1.1"
       },
@@ -7084,11 +7140,11 @@
     },
     "packages/runtime": {
       "name": "@openadminos/runtime",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@azure/msal-node": "^5.2.1",
-        "@openadminos/agent-sdk": "0.1.8",
-        "@openadminos/connector-teams": "0.1.8",
+        "@openadminos/agent-sdk": "0.1.9",
+        "@openadminos/connector-teams": "0.1.9",
         "js-yaml": "^4.1.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openadminos",
   "private": true,
-  "version": "0.1.8",
+  "version": "0.1.9",
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/agent-sdk",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "description": "Shared TypeScript contracts for OpenAdminOS packages.",
   "main": "./dist/index.js",

--- a/packages/connector-teams/package.json
+++ b/packages/connector-teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-teams",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "description": "Microsoft Teams connector for OpenAdminOS. Posts channel and chat messages via Microsoft Graph using the active tenant's delegated MSAL token.",
@@ -23,7 +23,7 @@
     "typecheck": "npm run build -w @openadminos/agent-sdk && tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.1.8"
+    "@openadminos/agent-sdk": "0.1.9"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/qa-graph/package.json
+++ b/packages/qa-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/qa-graph",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -14,7 +14,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.1.8",
+    "@openadminos/agent-sdk": "0.1.9",
     "ajv": "^8.17.1",
     "js-yaml": "^4.1.1"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/runtime",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "@azure/msal-node": "^5.2.1",
-    "@openadminos/agent-sdk": "0.1.8",
-    "@openadminos/connector-teams": "0.1.8",
+    "@openadminos/agent-sdk": "0.1.9",
+    "@openadminos/connector-teams": "0.1.9",
     "js-yaml": "^4.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Auto-generated by release-prep workflow (PR creation step blocked by org permissions; created manually).

Bumped `v0.1.8` → `v0.1.9`.

Highlights from the rolled CHANGELOG section:
- Per-agent over-the-air updates (registry version compare → fetch + persist new manifest on click).
- New `offboarding-agent` (open-source replacement for Microsoft's retired Intune Device Offboarding Agent).
- New `correlate-stale-devices` transform kind in the agent-template runtime.
- Force-removal of the legacy `retire-inactive-devices` slug from persisted state on first launch.
- `TODO(uli)` → `TODO(ugur)` sweep.

Review the CHANGELOG roll (the `[Unreleased]` section becomes `[0.1.9] - 2026-05-23`) and the version bumps across workspace package.json files. When this merges to main, `auto-tag.yml` pushes `v0.1.9` and `release.yml` builds the signed installers.