### PR TITLE
desktop: show menu bar after scheduler launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to OpenAdminOS are recorded here. Format follows [Keep a Cha
 ### Fixed
 
 - Fixed the v0.2.3 GitHub Release notes to use the full sectioned changelog instead of GitHub's generated PR summary.
+- Fixed macOS menu bar companion startup when a hidden background scheduler instance already owns the single-instance lock before the user opens the app.
 
 ### Security
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3101,6 +3101,12 @@ function createMenuBarCompanion(): void {
   });
 }
 
+function createMenuBarCompanionForInteractiveLaunch(): void {
+  if (process.platform === "darwin") {
+    createMenuBarCompanion();
+  }
+}
+
 function registerIpcHandlers() {
   ipcMain.handle(
     "openadminos:get-companion-snapshot",
@@ -3714,11 +3720,13 @@ if (!gotLock) {
 
     if (!mainWindow || mainWindow.isDestroyed()) {
       showDockForInteractiveSession();
+      createMenuBarCompanionForInteractiveLaunch();
       void createWindow({ show: true });
       return;
     }
 
     showDockForInteractiveSession();
+    createMenuBarCompanionForInteractiveLaunch();
     if (mainWindow.isMinimized()) {
       mainWindow.restore();
     }
@@ -3862,9 +3870,11 @@ if (!gotLock) {
     app.on("activate", () => {
       if (!mainWindow || mainWindow.isDestroyed()) {
         showDockForInteractiveSession();
+        createMenuBarCompanionForInteractiveLaunch();
         void createWindow({ show: true });
       } else {
         showDockForInteractiveSession();
+        createMenuBarCompanionForInteractiveLaunch();
         mainWindow.show();
         mainWindow.focus();
       }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1029,6 +1029,8 @@ Release automation treats `release: vX.Y.Z` as the canonical marker and parses i
 Release prep must bump every OpenAdminOS-owned package manifest and matching lockfile metadata that carries the product release version, including desktop, runtime, connector packages, QA packages, and the marketing website package.
 Release publishing must use the matching `CHANGELOG.md` section as the GitHub Release body and fail if that section is missing; generated PR summaries are not an acceptable fallback for release notes.
 
+The macOS menu bar companion must be created during any interactive app launch, including the case where a hidden background scheduler process already owns the Electron single-instance lock and receives the visible launch through the `second-instance` path.
+
 ---
 
 ## 3. Design system


### PR DESCRIPTION
## Summary\n\n- Fixes the macOS menu bar companion when a hidden background scheduler instance already owns the Electron single-instance lock.\n- Creates the tray item during normal interactive second-instance and activate paths before showing the main window.\n- Documents the startup invariant in SPEC and adds a changelog entry.\n\n## Validation\n\n- npm run typecheck -w @openadminos/desktop\n- npm run docs:check\n\n## Notes\n\nObserved locally after installing v0.2.3: the only running app process was /Applications/OpenAdminOS.app/Contents/MacOS/OpenAdminOS --background-scheduler. That startup path skips tray creation by design, and the existing second-instance handler showed the app window without creating the tray item.\n