### PR TITLE
release: v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to OpenAdminOS are recorded here. Format follows [Keep a Cha
 
 ### Fixed
 
+### Security
+
+## [0.2.4] - 2026-06-10
+
+### Fixed
+
 - Fixed the v0.2.3 GitHub Release notes to use the full sectioned changelog instead of GitHub's generated PR summary.
 - Fixed macOS menu bar companion startup when a hidden background scheduler instance already owns the single-instance lock before the user opens the app.
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openadminos/desktop",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Open-source, local-first agents for Microsoft 365 admins.",
   "author": {
     "name": "OpenAdminOS",
@@ -25,9 +25,9 @@
     "typecheck": "npm run build:packages && tsc -b --noEmit && tsc -p tsconfig.electron.json --noEmit"
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.2.3",
-    "@openadminos/connector-whatsapp-web": "0.2.3",
-    "@openadminos/runtime": "0.2.3",
+    "@openadminos/agent-sdk": "0.2.4",
+    "@openadminos/connector-whatsapp-web": "0.2.4",
+    "@openadminos/runtime": "0.2.4",
     "electron-updater": "^6.6.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openadminos",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openadminos",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -55,12 +55,12 @@
     },
     "apps/desktop": {
       "name": "@openadminos/desktop",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.2.3",
-        "@openadminos/connector-whatsapp-web": "0.2.3",
-        "@openadminos/runtime": "0.2.3",
+        "@openadminos/agent-sdk": "0.2.4",
+        "@openadminos/connector-whatsapp-web": "0.2.4",
+        "@openadminos/runtime": "0.2.4",
         "electron-updater": "^6.6.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -8488,13 +8488,13 @@
     },
     "packages/agent-sdk": {
       "name": "@openadminos/agent-sdk",
-      "version": "0.2.3"
+      "version": "0.2.4"
     },
     "packages/connector-teams": {
       "name": "@openadminos/connector-teams",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.2.3"
+        "@openadminos/agent-sdk": "0.2.4"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -8506,9 +8506,9 @@
     },
     "packages/connector-whatsapp-web": {
       "name": "@openadminos/connector-whatsapp-web",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.2.3",
+        "@openadminos/agent-sdk": "0.2.4",
         "baileys": "7.0.0-rc13",
         "pino": "^10.1.0",
         "qrcode": "^1.5.4"
@@ -8524,9 +8524,9 @@
     },
     "packages/qa-graph": {
       "name": "@openadminos/qa-graph",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.2.3",
+        "@openadminos/agent-sdk": "0.2.4",
         "ajv": "^8.17.1",
         "js-yaml": "^4.1.1"
       },
@@ -8564,12 +8564,12 @@
     },
     "packages/runtime": {
       "name": "@openadminos/runtime",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@azure/msal-node": "^5.2.1",
-        "@openadminos/agent-sdk": "0.2.3",
-        "@openadminos/connector-teams": "0.2.3",
-        "@openadminos/connector-whatsapp-web": "0.2.3",
+        "@openadminos/agent-sdk": "0.2.4",
+        "@openadminos/connector-teams": "0.2.4",
+        "@openadminos/connector-whatsapp-web": "0.2.4",
         "js-yaml": "^4.1.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openadminos",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.4",
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/agent-sdk",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "description": "Shared TypeScript contracts for OpenAdminOS packages.",
   "main": "./dist/index.js",

--- a/packages/connector-teams/package.json
+++ b/packages/connector-teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-teams",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "description": "Microsoft Teams connector for OpenAdminOS. Posts channel and chat messages via Microsoft Graph using the active tenant's delegated MSAL token.",
@@ -23,7 +23,7 @@
     "typecheck": "npm run build -w @openadminos/agent-sdk && tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.2.3"
+    "@openadminos/agent-sdk": "0.2.4"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-whatsapp-web/package.json
+++ b/packages/connector-whatsapp-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-whatsapp-web",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "description": "WhatsApp Web connector for OpenAdminOS. Sends outbound notification messages through a locally linked WhatsApp Web session.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.2.3",
+    "@openadminos/agent-sdk": "0.2.4",
     "baileys": "7.0.0-rc13",
     "pino": "^10.1.0",
     "qrcode": "^1.5.4"

--- a/packages/qa-graph/package.json
+++ b/packages/qa-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/qa-graph",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -14,7 +14,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.2.3",
+    "@openadminos/agent-sdk": "0.2.4",
     "ajv": "^8.17.1",
     "js-yaml": "^4.1.1"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/runtime",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -21,9 +21,9 @@
   },
   "dependencies": {
     "@azure/msal-node": "^5.2.1",
-    "@openadminos/agent-sdk": "0.2.3",
-    "@openadminos/connector-teams": "0.2.3",
-    "@openadminos/connector-whatsapp-web": "0.2.3",
+    "@openadminos/agent-sdk": "0.2.4",
+    "@openadminos/connector-teams": "0.2.4",
+    "@openadminos/connector-whatsapp-web": "0.2.4",
     "js-yaml": "^4.1.1"
   },
   "optionalDependencies": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openadminos-website",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openadminos-website",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@octokit/rest": "^21.1.1",
         "@t3-oss/env-nextjs": "^0.13.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openadminos-website",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary\n\n- Bumps OpenAdminOS package metadata from 0.2.3 to 0.2.4.\n- Rolls the changelog into a v0.2.4 patch section.\n- Ships the macOS menu bar companion startup fix from PR #52 and the release-note guardrail fix.\n\n## Validation\n\n- npm run typecheck\n- npm test\n- npm run qa\n- npm run docs:check\n- git diff --check\n