### PR TITLE
web: add Windows download links to homepage and download page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to OpenAdminOS are recorded here. Format follows [Keep a Cha
 
 ### Added
 
+- Added Windows download links (signed NSIS installer + portable) to the marketing site's homepage and download page, replacing the "Planned"/"Soon" placeholders; links resolve from the latest GitHub release and fall back to the releases page until Windows assets are attached.
+
 ### Changed
 
 ### Removed

--- a/web/src/app/download/page.tsx
+++ b/web/src/app/download/page.tsx
@@ -16,9 +16,9 @@ import {
 
 export const revalidate = 900;
 
-const TITLE = "Download for macOS and Linux";
+const TITLE = "Download for Windows, macOS, and Linux";
 const DESCRIPTION =
-  "Download OpenAdminOS for macOS or Linux, review release notes, and inspect the open-source Microsoft 365 admin agent runtime before running it against a tenant.";
+  "Download OpenAdminOS for Windows, macOS, or Linux, review release notes, and inspect the open-source Microsoft 365 admin agent runtime before running it against a tenant.";
 
 export const metadata: Metadata = pageMetadata({
   title: TITLE,
@@ -47,6 +47,27 @@ export default async function DownloadPage() {
       href: latestRelease.macosPkg.url,
       label: ".pkg",
       meta: "Apple Silicon · signed and notarized",
+    },
+  ];
+  const windowsPackages = [
+    {
+      actionLabel: "Download installer",
+      badge: "Default",
+      detail: "NSIS installer for individual workstations",
+      hash: latestRelease.windowsSetup.sha256,
+      href: latestRelease.windowsSetup.url,
+      label: "Installer (.exe)",
+      meta: "Windows x64 · signed",
+      primary: true,
+    },
+    {
+      actionLabel: "Download portable",
+      badge: "Portable",
+      detail: "Single executable, no installation required",
+      hash: latestRelease.windowsPortable.sha256,
+      href: latestRelease.windowsPortable.url,
+      label: "Portable (.exe)",
+      meta: "Windows x64 · signed",
     },
   ];
   const linuxPackages = [
@@ -84,7 +105,7 @@ export default async function DownloadPage() {
       websiteSchema(),
       softwareApplicationSchema({
         downloadUrl: latestRelease.releaseNotesUrl,
-        operatingSystem: "macOS, Linux",
+        operatingSystem: "Windows, macOS, Linux",
         version: latestRelease.version,
       }),
       webPageSchema({
@@ -140,6 +161,12 @@ export default async function DownloadPage() {
         </div>
 
         <DownloadGroup
+          description="Builds are signed with Azure Trusted Signing. Use the installer for a normal workstation install."
+          id="windows-packages"
+          items={windowsPackages}
+          title="Windows x64"
+        />
+        <DownloadGroup
           description="Use the DMG for a normal workstation install. Use the PKG when you need a managed deployment package."
           id="macos-packages"
           items={macosPackages}
@@ -151,18 +178,6 @@ export default async function DownloadPage() {
           items={linuxPackages}
           title="Linux x64"
         />
-        <section className="grid gap-4 border-t border-white/10 py-6 md:grid-cols-[180px_1fr]">
-          <div>
-            <h2 className="text-base font-semibold text-white">Windows</h2>
-            <p className="mt-1 text-xs font-semibold uppercase tracking-[0.18em] text-white/35">
-              Planned
-            </p>
-          </div>
-          <p className="max-w-2xl text-sm leading-6 text-white/55">
-            Windows packaging is planned after signing is complete. The app
-            surface and write-confirmation rules are the same across platforms.
-          </p>
-        </section>
       </section>
 
       <section className="mt-12 grid gap-8 border-t border-white/10 pt-12 md:grid-cols-[0.8fr_1.2fr]">

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -188,7 +188,7 @@ export default async function HomePage() {
       softwareApplicationSchema({
         version: latestRelease.version,
         downloadUrl: latestRelease.releaseNotesUrl,
-        operatingSystem: "macOS, Linux",
+        operatingSystem: "Windows, macOS, Linux",
       }),
       webPageSchema({
         path: "/",
@@ -321,9 +321,9 @@ export default async function HomePage() {
               </Link>
             </div>
             <div className="flex min-w-0 flex-col items-stretch gap-1.5">
-              <div
-                aria-describedby="windows-download-status"
-                className="inline-flex h-11 w-full cursor-default items-center justify-center gap-2 whitespace-nowrap rounded-lg border border-white/10 bg-white/[0.03] px-4 text-sm font-medium text-white/40"
+              <a
+                href={latestRelease.windowsSetupUrl}
+                className="inline-flex h-11 w-full items-center justify-center gap-2 whitespace-nowrap rounded-lg bg-white px-4 text-sm font-semibold text-[#0a0a0c] shadow-[0_8px_30px_-4px_rgba(255,255,255,0.25)] transition hover:bg-white/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/35"
               >
                 <svg
                   aria-hidden
@@ -333,16 +333,13 @@ export default async function HomePage() {
                   <path d="M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z" />
                 </svg>
                 Download for Windows
-                <span className="ml-1 text-[10px] font-normal uppercase tracking-wider text-white/30">
-                  Soon
-                </span>
-              </div>
-              <p
-                id="windows-download-status"
-                className="min-h-4 text-center text-[11px] leading-4 text-white/35"
+              </a>
+              <Link
+                href="/download#windows-packages"
+                className="min-h-4 text-center text-[11px] leading-4 text-white/38 underline-offset-4 transition hover:text-white/70 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-white/35"
               >
-                Pending signing.
-              </p>
+                Downloads the installer. Portable build available.
+              </Link>
             </div>
           </div>
 

--- a/web/src/app/release-downloads.ts
+++ b/web/src/app/release-downloads.ts
@@ -138,6 +138,22 @@ export async function getLatestReleaseDownloads() {
       "OpenAdminOS-mac-arm64.pkg",
       checksums,
     );
+    const windowsSetup = toDownloadAsset(
+      findAsset(
+        assets,
+        (name) => name.includes("win") && name.endsWith("setup.exe"),
+      ),
+      "OpenAdminOS-win-x64-setup.exe",
+      checksums,
+    );
+    const windowsPortable = toDownloadAsset(
+      findAsset(
+        assets,
+        (name) => name.includes("win") && name.endsWith("portable.exe"),
+      ),
+      "OpenAdminOS-win-x64-portable.exe",
+      checksums,
+    );
 
     return {
       checksumUrl,
@@ -153,6 +169,10 @@ export async function getLatestReleaseDownloads() {
       macosPkgUrl: macosPkg.url,
       releaseNotesUrl: release.html_url ?? LATEST_RELEASE_URL,
       version: release.tag_name ?? "Latest release",
+      windowsPortable,
+      windowsPortableUrl: windowsPortable.url,
+      windowsSetup,
+      windowsSetupUrl: windowsSetup.url,
     };
   } catch {
     const fallbackAsset = {
@@ -175,6 +195,10 @@ export async function getLatestReleaseDownloads() {
       macosPkgUrl: LATEST_RELEASE_URL,
       releaseNotesUrl: LATEST_RELEASE_URL,
       version: "Latest release",
+      windowsPortable: fallbackAsset,
+      windowsPortableUrl: LATEST_RELEASE_URL,
+      windowsSetup: fallbackAsset,
+      windowsSetupUrl: LATEST_RELEASE_URL,
     };
   }
 }

--- a/web/src/app/seo.tsx
+++ b/web/src/app/seo.tsx
@@ -141,7 +141,7 @@ export function softwareApplicationSchema(input?: {
     name: SITE_NAME,
     applicationCategory: "BusinessApplication",
     applicationSubCategory: "Microsoft 365 administration",
-    operatingSystem: input?.operatingSystem ?? "macOS, Linux",
+    operatingSystem: input?.operatingSystem ?? "Windows, macOS, Linux",
     softwareVersion: input?.version,
     description: HOME_DESCRIPTION,
     isAccessibleForFree: true,


### PR DESCRIPTION
## Summary

- Replace the "Windows — Planned" section on /download with a real download group: signed NSIS installer (default) + portable build, including SHA-256 checksums from SHA256SUMS.txt
- Activate the greyed-out "Download for Windows · Soon" button on the homepage hero, matching the macOS/Linux button style
- Resolve Windows assets (`OpenAdminOS-<version>-win-x64-setup.exe` / `...-portable.exe`) from the latest GitHub release, falling back to the releases page until Windows assets are attached to a release
- Update page metadata and SoftwareApplication structured data to "Windows, macOS, Linux"

## Notes

The latest release (v0.2.3) does not yet include Windows assets — the signed installers are currently only uploaded as workflow artifacts in `windows-signed.yml`. Until they are attached to a release (and listed in SHA256SUMS.txt), the links resolve to the releases page. Once attached, links and checksums go live without further site changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)