### PR TITLE
feat: v0.2.5 multi-tenant Intune Chat and Workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,20 @@ All notable changes to OpenAdminOS are recorded here. Format follows [Keep a Cha
 
 ### Added
 
+- Added v0.2.5 multi-tenant Intune Chat for explicit read-only tenant scope review, local tenant groups, saved queries, readiness preflight, hosted-provider batch confirmation, deterministic Windows compliance aggregation, result filters, local exports, and split-to-workspaces evidence import.
+- Added single-tenant Workspaces as a top-level `/workspaces` surface with local SQLite-backed workspace CRUD, pinned evidence, notes, linked chats, linked runs, local instructions storage, Markdown dossier export, and deletion boundaries that leave chats, runs, tenants, and Graph cache intact.
+- Added multi-tenant chat and Workspaces contracts, validated Electron IPC/preload APIs, mockups `11-multi-tenant-chat.html` and `12-workspaces.html`, GitBook documentation, and focused host tests for partial tenant failures and workspace deletion/split-result boundaries.
+- Added streamed multi-tenant chat progress IPC, tenant-pinned cross-tenant agent batch records, chat-answer pinning to Workspaces, explicit workspace context attachment in Intune Chat, and hosted-provider confirmation for attached workspace context.
+
 ### Changed
+
+- Bumped app, workspace package, and UI-displayed version metadata to 0.2.5 for the v0.2.5 roadmap.
 
 ### Removed
 
 ### Fixed
+
+- Added visible keyboard focus states to the v0.2.5 Workspaces and Intune Chat custom controls and tightened the new mockups' narrow-width layout during the UI/UX verification pass.
 
 ### Security
 

--- a/apps/desktop/electron/intune-chat/chat-service.test.ts
+++ b/apps/desktop/electron/intune-chat/chat-service.test.ts
@@ -191,6 +191,274 @@ describe("Intune Chat host service", () => {
     }
   });
 
+  it("runs a read-only multi-tenant compliance query with contained tenant failures", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "openadminos-chat-host-"));
+    const now = "2026-06-01T10:00:00.000Z";
+    const statePath = join(dir, "state.json");
+    await writeFile(
+      statePath,
+      JSON.stringify(
+        {
+          activeProviderId: "ollama",
+          installedAgents: [],
+          runs: [],
+          tenants: [
+            {
+              id: "tenant-1",
+              displayName: "Contoso",
+              username: "admin@contoso.example",
+              homeAccountId: "home-account-1",
+              addedAt: now,
+            },
+            {
+              id: "tenant-2",
+              displayName: "Fabrikam",
+              username: "admin@fabrikam.example",
+              homeAccountId: "home-account-2",
+              addedAt: now,
+            },
+          ],
+          activeTenantId: "tenant-1",
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const requestedTenantIds: string[] = [];
+    const llm: RunLlmApi = {
+      available: true,
+      defaultModel: "mock-chat",
+      async complete() {
+        return {
+          text: "One tenant completed and one tenant failed. Use the comparison table for source counts.",
+          model: "mock-chat",
+        };
+      },
+      async *stream() {
+        yield {
+          delta: "",
+          accumulated: "",
+          done: true,
+          model: "mock-chat",
+        };
+      },
+    };
+
+    const store = new AppStateStore({
+      filePath: statePath,
+      tokenStore,
+      userDataPath: dir,
+      statsApiUrl: "",
+      graphFactory: ({ tenantId }) => {
+        requestedTenantIds.push(tenantId);
+        const graph: RunGraphApi = {
+          async listManagedDevices() {
+            return [];
+          },
+          async retireManagedDevice() {
+            throw new Error("retireManagedDevice should not run from multi-tenant chat.");
+          },
+          async request(input) {
+            if (input.path !== "/deviceManagement/managedDevices") {
+              return { value: [] };
+            }
+            if (tenantId === "tenant-2") {
+              throw new Error("Graph request failed: 429 too many requests");
+            }
+            return {
+              value: [
+                {
+                  id: "device-1",
+                  deviceName: "WIN-COMPLIANT",
+                  operatingSystem: "Windows",
+                  complianceState: "compliant",
+                  osVersion: "11.0.1",
+                  userPrincipalName: "owner@contoso.example",
+                  lastSyncDateTime: now,
+                },
+                {
+                  id: "device-2",
+                  deviceName: "WIN-NONCOMPLIANT",
+                  operatingSystem: "Windows",
+                  complianceState: "noncompliant",
+                  osVersion: "10.0.1",
+                  lastSyncDateTime: now,
+                },
+                {
+                  id: "device-3",
+                  deviceName: "MAC-01",
+                  operatingSystem: "macOS",
+                  complianceState: "compliant",
+                  lastSyncDateTime: now,
+                },
+              ],
+            };
+          },
+        };
+        return graph;
+      },
+      llmFactory: () => llm,
+    });
+
+    try {
+      const events: string[] = [];
+      const result = await store.streamMultiTenantIntuneChat(
+        {
+          prompt:
+            "List all compliant and all non-compliant Windows devices from every connected tenant.",
+          tenantScope: { kind: "all" },
+        },
+        (event) => {
+          events.push(event.type);
+          if (event.type === "progress") {
+            events.push(event.job.status);
+          }
+        },
+      );
+
+      assert.deepEqual(new Set(requestedTenantIds), new Set(["tenant-1", "tenant-2"]));
+      assert.ok(events.includes("started"));
+      assert.ok(events.includes("progress"));
+      assert.ok(events.includes("completed"));
+      assert.equal(result.job.status, "partial");
+      assert.equal(result.job.summary.tenantsScanned, 2);
+      assert.equal(result.job.summary.failedTenants, 1);
+      assert.equal(result.job.summary.windowsDevices, 2);
+      assert.equal(result.job.summary.compliant, 1);
+      assert.equal(result.job.summary.nonCompliant, 1);
+      assert.equal(result.job.deviceRows.length, 2);
+      assert.equal(
+        result.job.progress.find((entry) => entry.tenantId === "tenant-2")?.status,
+        "failed",
+      );
+      assert.equal(result.conversation.scopeKind, "multi-tenant");
+      assert.equal(result.conversation.multiTenantJobId, result.job.id);
+      assert.match(result.assistantMessage.content, /one tenant failed/i);
+
+      const jobs = await store.listMultiTenantChatJobs();
+      assert.equal(jobs.length, 1);
+      assert.equal(jobs[0]?.id, result.job.id);
+      const messages = await store.getIntuneChatMessages(result.conversation.id);
+      assert.equal(messages.length, 2);
+      assert.equal(messages[0]?.role, "user");
+      assert.equal(messages[1]?.role, "assistant");
+    } finally {
+      store.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("attaches explicit workspace evidence, notes, and instructions to a chat prompt", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "openadminos-chat-host-"));
+    const now = "2026-06-01T10:00:00.000Z";
+    const statePath = join(dir, "state.json");
+    await writeFile(
+      statePath,
+      JSON.stringify(
+        {
+          activeProviderId: "ollama",
+          installedAgents: [],
+          runs: [],
+          tenants: [
+            {
+              id: "tenant-1",
+              displayName: "Contoso",
+              username: "admin@contoso.example",
+              homeAccountId: "home-account-1",
+              addedAt: now,
+            },
+          ],
+          activeTenantId: "tenant-1",
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const graph: RunGraphApi = {
+      async listManagedDevices() {
+        return [];
+      },
+      async retireManagedDevice() {
+        throw new Error("retireManagedDevice should not run from chat.");
+      },
+      async request() {
+        return { value: [] };
+      },
+    };
+    let answerPackPrompt = "";
+    const llm: RunLlmApi = {
+      available: true,
+      defaultModel: "mock-chat",
+      async complete(options) {
+        answerPackPrompt = options.prompt;
+        return {
+          text: "The workspace context points to WIN-42.",
+          model: "mock-chat",
+        };
+      },
+      async *stream() {
+        yield {
+          delta: "",
+          accumulated: "",
+          done: true,
+          model: "mock-chat",
+        };
+      },
+    };
+
+    const store = new AppStateStore({
+      filePath: statePath,
+      tokenStore,
+      userDataPath: dir,
+      statsApiUrl: "",
+      graphFactory: () => graph,
+      llmFactory: () => llm,
+    });
+
+    try {
+      const workspace = await store.createWorkspace({
+        title: "Contoso pilot review",
+        instructions: "Use pinned workspace material before broad cache results.",
+      });
+      const note = await store.addWorkspaceNote(
+        workspace.id,
+        "Scope the answer to pilot devices only.",
+      );
+      const evidence = await store.pinWorkspaceEvidence({
+        workspaceId: workspace.id,
+        tenantId: "tenant-1",
+        title: "Pilot device",
+        sourceType: "manual",
+        content: { deviceName: "WIN-42", complianceState: "noncompliant" },
+      });
+
+      const result = await store.sendIntuneChatMessage({
+        content: "Summarize the attached workspace context.",
+        refreshIfStale: false,
+        workspaceContext: {
+          workspaceId: workspace.id,
+          evidenceIds: [evidence.id],
+          noteIds: [note.id],
+          includeInstructions: true,
+        },
+      });
+
+      assert.match(answerPackPrompt, /Workspace context attached by the admin/);
+      assert.match(answerPackPrompt, /WIN-42/);
+      assert.match(answerPackPrompt, /pilot devices only/);
+      assert.match(answerPackPrompt, /Use pinned workspace material/);
+      assert.equal(result.userMessage.content, "Summarize the attached workspace context.");
+      assert.doesNotMatch(result.userMessage.content, /Workspace context attached/);
+    } finally {
+      store.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("persists an assistant failure when the LLM provider errors", async () => {
     const dir = await mkdtemp(join(tmpdir(), "openadminos-chat-host-"));
     const now = "2026-06-01T10:00:00.000Z";

--- a/apps/desktop/electron/intune-chat/sqlite-store.test.ts
+++ b/apps/desktop/electron/intune-chat/sqlite-store.test.ts
@@ -13,7 +13,12 @@ import {
   staleManagedDeviceSyncThresholdDays,
   thresholdIsoDaysBefore,
 } from "./planner.js";
-import type { AgentSummary, GraphCacheResourceKind } from "@openadminos/agent-sdk";
+import type {
+  AgentSummary,
+  GraphCacheResourceKind,
+  MultiTenantAgentBatch,
+  MultiTenantChatJob,
+} from "@openadminos/agent-sdk";
 
 describe("Intune Chat SQLite store", () => {
   it("persists conversations, messages, cache rows, and self-training decisions", async () => {
@@ -230,6 +235,274 @@ describe("Intune Chat SQLite store", () => {
       assert.equal(chatCleared.chatConversationCount, 0);
       assert.equal(chatCleared.chatMessageCount, 0);
       assert.equal(chatCleared.chatToolCallCount, 0);
+      store.close();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("persists tenant groups, multi-tenant jobs, and tenant-scoped workspaces", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "openadminos-chat-"));
+    try {
+      const store = new IntelligenceSqliteStore(join(dir, "openadminos.db"));
+      const now = "2026-06-01T10:00:00.000Z";
+      const tenantNames = new Map([
+        ["tenant-1", "Contoso"],
+        ["tenant-2", "Fabrikam"],
+      ]);
+
+      const group = store.saveTenantGroup({
+        id: "group_1",
+        name: "Pilot tenants",
+        tenantIds: ["tenant-1", "tenant-2", "tenant-1"],
+        now,
+      });
+      assert.deepEqual(group.tenantIds, ["tenant-1", "tenant-2"]);
+      assert.equal(store.listTenantGroups()[0]?.name, "Pilot tenants");
+      assert.ok(
+        store
+          .listSavedMultiTenantQueries()
+          .some((query) => query.id === "windows-compliance"),
+      );
+
+      const conversation = store.createConversation({
+        id: "chat_1",
+        title: "Compliance query",
+        tenantId: "tenant-1",
+        now,
+      });
+      store.insertMessage({
+        id: "msg_1",
+        conversationId: conversation.id,
+        role: "assistant",
+        content: "Contoso has one non-compliant Windows device.",
+        status: "completed",
+        createdAt: now,
+      });
+
+      const job: MultiTenantChatJob = {
+        id: "mtjob_1",
+        conversationId: conversation.id,
+        prompt: "List Windows compliance across every connected tenant.",
+        tenantScope: { kind: "all" },
+        resolvedTenantIds: ["tenant-1", "tenant-2"],
+        providerId: "ollama",
+        providerName: "Ollama",
+        providerIsLocal: true,
+        status: "partial",
+        createdAt: now,
+        updatedAt: now,
+        preflight: {
+          id: "preflight_1",
+          prompt: "List Windows compliance across every connected tenant.",
+          tenantScope: { kind: "all" },
+          resolvedTenantIds: ["tenant-1", "tenant-2"],
+          resolvedGroups: [group],
+          resources: ["managedDevices"],
+          providerId: "ollama",
+          providerName: "Ollama",
+          providerIsLocal: true,
+          generatedAt: now,
+          tenants: [
+            {
+              tenantId: "tenant-1",
+              tenantName: "Contoso",
+              username: "admin@contoso.example",
+              status: "ready",
+              selected: true,
+              cacheFreshness: now,
+              staleResources: [],
+              missingScopes: [],
+              warnings: [],
+              recovery: "Ready to run.",
+            },
+            {
+              tenantId: "tenant-2",
+              tenantName: "Fabrikam",
+              username: "admin@fabrikam.example",
+              status: "failed",
+              selected: true,
+              staleResources: ["managedDevices"],
+              missingScopes: [],
+              warnings: ["Graph request failed."],
+              recovery: "Review the cached error or remove this tenant from the run.",
+            },
+          ],
+          canRun: true,
+        },
+        progress: [
+          {
+            tenantId: "tenant-1",
+            tenantName: "Contoso",
+            status: "ready",
+            detail: "1 Windows device row prepared.",
+            updatedAt: now,
+          },
+          {
+            tenantId: "tenant-2",
+            tenantName: "Fabrikam",
+            status: "failed",
+            detail: "Graph request failed.",
+            updatedAt: now,
+          },
+        ],
+        summary: {
+          tenantsScanned: 2,
+          failedTenants: 1,
+          skippedTenants: 0,
+          staleTenants: 0,
+          windowsDevices: 1,
+          compliant: 0,
+          nonCompliant: 1,
+          unknown: 0,
+        },
+        comparisons: [
+          {
+            tenantId: "tenant-1",
+            tenantName: "Contoso",
+            status: "ready",
+            windowsDevices: 1,
+            compliant: 0,
+            nonCompliant: 1,
+            unknown: 0,
+            lastRefresh: now,
+            warnings: [],
+          },
+          {
+            tenantId: "tenant-2",
+            tenantName: "Fabrikam",
+            status: "failed",
+            windowsDevices: 0,
+            compliant: 0,
+            nonCompliant: 0,
+            unknown: 0,
+            warnings: ["Graph request failed."],
+          },
+        ],
+        deviceRows: [
+          {
+            tenantId: "tenant-1",
+            tenantName: "Contoso",
+            deviceId: "device-1",
+            deviceName: "WIN-01",
+            complianceState: "noncompliant",
+            operatingSystem: "Windows",
+            osVersion: "11.0.1",
+            lastSyncDateTime: now,
+            owner: "owner@contoso.example",
+            sourceRefreshedAt: now,
+            stale: false,
+          },
+        ],
+        assistantText: "Contoso has one non-compliant Windows device; Fabrikam failed.",
+        exportDossierMarkdown: "# Multi-tenant Intune Chat dossier\n",
+      };
+      store.upsertMultiTenantJob(job);
+      assert.equal(store.getMultiTenantJob(job.id)?.summary.failedTenants, 1);
+
+      const batch: MultiTenantAgentBatch = {
+        id: "mtbatch_1",
+        agentSlug: "retire-stale-devices",
+        agentName: "Retire stale devices",
+        agentMode: "write",
+        tenantScope: { kind: "all" },
+        resolvedTenantIds: ["tenant-1", "tenant-2"],
+        status: "awaiting-confirmation",
+        runIds: ["run_1", "run_2"],
+        createdAt: now,
+        updatedAt: now,
+        preflight: job.preflight,
+      };
+      store.upsertMultiTenantAgentBatch(batch);
+      assert.equal(
+        store.getMultiTenantAgentBatch(batch.id)?.status,
+        "awaiting-confirmation",
+      );
+      assert.deepEqual(
+        store.listMultiTenantAgentBatches()[0]?.runIds,
+        ["run_1", "run_2"],
+      );
+
+      const workspace = store.createWorkspace({
+        id: "wksp_1",
+        tenantId: "tenant-1",
+        tenantName: "Contoso",
+        title: "Contoso compliance review",
+        instructions: "Use only locally pinned evidence.",
+        now,
+        conversationId: conversation.id,
+      });
+      assert.equal(workspace.links.length, 1);
+      assert.equal(workspace.tenantId, "tenant-1");
+
+      const note = store.addWorkspaceNote({
+        id: "note_1",
+        workspaceId: workspace.id,
+        content: "Check the owner before any remediation.",
+        now,
+      });
+      assert.equal(note.tenantId, "tenant-1");
+      const evidence = store.pinWorkspaceEvidence({
+        id: "ev_1",
+        workspaceId: workspace.id,
+        tenantId: "tenant-1",
+        title: "WIN-01 compliance row",
+        sourceType: "graph-cache-row",
+        sourceRef: { resource: "managedDevices", id: "device-1" },
+        content: { deviceName: "WIN-01", complianceState: "noncompliant" },
+        freshness: {
+          resource: "managedDevices",
+          refreshedAt: now,
+          rowCount: 1,
+          cacheStatus: "cache",
+        },
+        now,
+      });
+      assert.equal(evidence.tenantId, "tenant-1");
+      assert.throws(
+        () =>
+          store.pinWorkspaceEvidence({
+            id: "ev_bad",
+            workspaceId: workspace.id,
+            tenantId: "tenant-2",
+            title: "Wrong tenant",
+            sourceType: "manual",
+            content: {},
+            now,
+          }),
+        /tenant does not match/,
+      );
+
+      const split = store.importMultiTenantResultToWorkspaces({
+        job,
+        tenantNames,
+        mappings: [
+          { tenantId: "tenant-1", workspaceId: workspace.id },
+          { tenantId: "tenant-2", title: "Fabrikam compliance review" },
+        ],
+        createWorkspaceId: () => "wksp_2",
+        createEvidenceId: (() => {
+          let index = 1;
+          return () => `split_ev_${index++}`;
+        })(),
+        now,
+      });
+      assert.equal(split.workspaces.length, 2);
+      assert.equal(split.evidence.length, 2);
+      assert.equal(
+        store.getWorkspace("wksp_2", tenantNames)?.tenantId,
+        "tenant-2",
+      );
+
+      const dossier = store.exportWorkspaceDossier(workspace.id, tenantNames);
+      assert.match(dossier, /Contoso compliance review/);
+      assert.match(dossier, /WIN-01 compliance row/);
+      assert.match(dossier, /Check the owner/);
+
+      store.deleteWorkspace(workspace.id);
+      assert.equal(store.getWorkspace(workspace.id, tenantNames), undefined);
+      assert.equal(store.getConversation(conversation.id)?.id, conversation.id);
+      assert.equal(store.getMultiTenantJob(job.id)?.id, job.id);
       store.close();
     } finally {
       await rm(dir, { recursive: true, force: true });

--- a/apps/desktop/electron/intune-chat/sqlite-store.ts
+++ b/apps/desktop/electron/intune-chat/sqlite-store.ts
@@ -5,19 +5,34 @@ import type {
   GraphCacheResourceKind,
   GraphCacheResourceStatus,
   GraphCacheRefreshScheduleSettings,
+  ImportMultiTenantResultToWorkspacesResult,
   IntuneChatConversation,
   IntuneChatMessage,
   IntuneChatToolCall,
   LocalDataSummary,
+  MultiTenantAgentBatch,
+  MultiTenantChatJob,
+  SavedMultiTenantQuery,
   SelfTrainingSettings,
   SelfTrainingSuggestion,
   SelfTrainingSuggestionStatus,
+  TenantGroup,
+  TenantScope,
+  WorkspaceDetail,
+  WorkspaceEvidence,
+  WorkspaceLink,
+  WorkspaceNote,
+  WorkspaceStatus,
+  WorkspaceSummary,
 } from "@openadminos/agent-sdk";
 
 interface ConversationRow {
   id: string;
   title: string;
   tenant_id: string | null;
+  scope_kind: string | null;
+  scope_json: string | null;
+  multi_tenant_job_id: string | null;
   created_at: string;
   updated_at: string;
   pinned_at: string | null;
@@ -50,6 +65,7 @@ interface ResourceStatusRow {
 
 interface ResourceRow {
   raw_json: string;
+  refreshed_at?: string;
 }
 
 interface SettingRow {
@@ -67,6 +83,105 @@ interface SuggestionRow {
   source: SelfTrainingSuggestion["source"];
   created_at: string;
   decided_at: string | null;
+}
+
+interface TenantGroupRow {
+  id: string;
+  name: string;
+  tenant_ids_json: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface SavedQueryRow {
+  id: string;
+  title: string;
+  prompt: string;
+  resource_hints_json: string;
+  default_scope_json: string | null;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface MultiTenantJobRow {
+  id: string;
+  conversation_id: string | null;
+  prompt: string;
+  saved_query_id: string | null;
+  tenant_scope_json: string;
+  resolved_tenant_ids_json: string;
+  provider_id: string;
+  provider_name: string;
+  provider_is_local: number;
+  model: string | null;
+  status: MultiTenantChatJob["status"];
+  preflight_json: string;
+  progress_json: string;
+  summary_json: string;
+  comparisons_json: string;
+  device_rows_json: string;
+  assistant_text: string;
+  export_dossier_markdown: string;
+  error: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface MultiTenantAgentBatchRow {
+  id: string;
+  agent_slug: string;
+  agent_name: string;
+  agent_mode: MultiTenantAgentBatch["agentMode"];
+  tenant_scope_json: string;
+  resolved_tenant_ids_json: string;
+  status: MultiTenantAgentBatch["status"];
+  run_ids_json: string;
+  preflight_json: string;
+  error: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface WorkspaceRow {
+  id: string;
+  tenant_id: string;
+  title: string;
+  status: WorkspaceStatus;
+  instructions: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface WorkspaceEvidenceRow {
+  id: string;
+  workspace_id: string;
+  tenant_id: string;
+  title: string;
+  source_type: WorkspaceEvidence["sourceType"];
+  source_ref_json: string | null;
+  content_json: string;
+  freshness_json: string | null;
+  created_at: string;
+}
+
+interface WorkspaceNoteRow {
+  id: string;
+  workspace_id: string;
+  tenant_id: string;
+  content: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface WorkspaceLinkRow {
+  id: string;
+  workspace_id: string;
+  tenant_id: string;
+  type: WorkspaceLink["type"];
+  ref_id: string;
+  title: string;
+  created_at: string;
 }
 
 export interface GraphCacheResourceDefinition {
@@ -94,7 +209,8 @@ export class IntelligenceSqliteStore {
   listConversations(): IntuneChatConversation[] {
     const rows = this.db
       .prepare(
-        `SELECT id, title, tenant_id, created_at, updated_at, pinned_at
+        `SELECT id, title, tenant_id, scope_kind, scope_json, multi_tenant_job_id,
+                created_at, updated_at, pinned_at
          FROM chat_conversations
          ORDER BY pinned_at IS NULL, pinned_at DESC, updated_at DESC`,
       )
@@ -108,7 +224,8 @@ export class IntelligenceSqliteStore {
     const like = `%${escapeSqlLike(trimmed)}%`;
     const rows = this.db
       .prepare(
-        `SELECT c.id, c.title, c.tenant_id, c.created_at, c.updated_at, c.pinned_at
+        `SELECT c.id, c.title, c.tenant_id, c.scope_kind, c.scope_json,
+                c.multi_tenant_job_id, c.created_at, c.updated_at, c.pinned_at
          FROM chat_conversations c
          WHERE c.title LIKE ? ESCAPE '\\'
             OR EXISTS (
@@ -126,7 +243,8 @@ export class IntelligenceSqliteStore {
   getConversation(id: string): IntuneChatConversation | undefined {
     const row = this.db
       .prepare(
-        `SELECT id, title, tenant_id, created_at, updated_at, pinned_at
+        `SELECT id, title, tenant_id, scope_kind, scope_json, multi_tenant_job_id,
+                created_at, updated_at, pinned_at
          FROM chat_conversations
          WHERE id = ?`,
       )
@@ -139,20 +257,38 @@ export class IntelligenceSqliteStore {
     title: string;
     tenantId: string;
     now: string;
+    scopeKind?: IntuneChatConversation["scopeKind"];
+    tenantScope?: TenantScope;
+    multiTenantJobId?: string;
   }): IntuneChatConversation {
     this.db
       .prepare(
-        `INSERT INTO chat_conversations (id, title, tenant_id, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?)`,
+        `INSERT INTO chat_conversations (
+          id, title, tenant_id, scope_kind, scope_json, multi_tenant_job_id,
+          created_at, updated_at
+        )
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(input.id, input.title, input.tenantId, input.now, input.now);
+      .run(
+        input.id,
+        input.title,
+        input.tenantId,
+        input.scopeKind ?? "single-tenant",
+        input.tenantScope ? JSON.stringify(input.tenantScope) : null,
+        input.multiTenantJobId ?? null,
+        input.now,
+        input.now,
+      );
     return {
       id: input.id,
       title: input.title,
-        tenantId: input.tenantId,
-        createdAt: input.now,
-        updatedAt: input.now,
-      };
+      tenantId: input.tenantId,
+      scopeKind: input.scopeKind ?? "single-tenant",
+      ...(input.tenantScope ? { tenantScope: input.tenantScope } : {}),
+      ...(input.multiTenantJobId ? { multiTenantJobId: input.multiTenantJobId } : {}),
+      createdAt: input.now,
+      updatedAt: input.now,
+    };
   }
 
   renameConversation(id: string, title: string, now: string): IntuneChatConversation {
@@ -541,6 +677,542 @@ export class IntelligenceSqliteStore {
     return rows.map((row) => readJson<unknown>(row.raw_json, {}));
   }
 
+  readManagedDeviceRowsForTenant(input: {
+    tenantId: string;
+    limit?: number;
+  }): { row: unknown; refreshedAt?: string }[] {
+    const rows = this.db
+      .prepare(
+        `SELECT raw_json, refreshed_at
+         FROM graph_resources
+         WHERE tenant_id = ? AND resource = 'managedDevices'
+         ORDER BY COALESCE(last_seen_at, refreshed_at) DESC
+         LIMIT ?`,
+      )
+      .all(input.tenantId, input.limit ?? 10_000) as unknown as ResourceRow[];
+    return rows.map((row) => ({
+      row: readJson<unknown>(row.raw_json, {}),
+      ...(row.refreshed_at ? { refreshedAt: row.refreshed_at } : {}),
+    }));
+  }
+
+  listTenantGroups(): TenantGroup[] {
+    const rows = this.db
+      .prepare(
+        `SELECT id, name, tenant_ids_json, created_at, updated_at
+         FROM tenant_groups
+         ORDER BY name COLLATE NOCASE ASC`,
+      )
+      .all() as unknown as TenantGroupRow[];
+    return rows.map(readTenantGroup);
+  }
+
+  saveTenantGroup(input: {
+    id: string;
+    name: string;
+    tenantIds: string[];
+    now: string;
+  }): TenantGroup {
+    const existing = this.db
+      .prepare(
+        `SELECT id, name, tenant_ids_json, created_at, updated_at
+         FROM tenant_groups
+         WHERE id = ?`,
+      )
+      .get(input.id) as unknown as TenantGroupRow | undefined;
+    const createdAt = existing?.created_at ?? input.now;
+    this.db
+      .prepare(
+        `INSERT INTO tenant_groups (id, name, tenant_ids_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           name = excluded.name,
+           tenant_ids_json = excluded.tenant_ids_json,
+           updated_at = excluded.updated_at`,
+      )
+      .run(
+        input.id,
+        input.name,
+        JSON.stringify([...new Set(input.tenantIds)]),
+        createdAt,
+        input.now,
+      );
+    return {
+      id: input.id,
+      name: input.name,
+      tenantIds: [...new Set(input.tenantIds)],
+      createdAt,
+      updatedAt: input.now,
+    };
+  }
+
+  deleteTenantGroup(id: string): void {
+    const result = this.db.prepare(`DELETE FROM tenant_groups WHERE id = ?`).run(id);
+    if (result.changes === 0) {
+      throw new Error(`Tenant group not found: ${id}`);
+    }
+  }
+
+  listSavedMultiTenantQueries(): SavedMultiTenantQuery[] {
+    this.ensureDefaultSavedQueries(new Date().toISOString());
+    const rows = this.db
+      .prepare(
+        `SELECT id, title, prompt, resource_hints_json, default_scope_json,
+                sort_order, created_at, updated_at
+         FROM saved_multi_tenant_queries
+         ORDER BY sort_order ASC, title COLLATE NOCASE ASC`,
+      )
+      .all() as unknown as SavedQueryRow[];
+    return rows.map(readSavedQuery);
+  }
+
+  upsertMultiTenantJob(job: MultiTenantChatJob): MultiTenantChatJob {
+    this.db
+      .prepare(
+        `INSERT INTO multi_tenant_jobs (
+          id, conversation_id, prompt, saved_query_id, tenant_scope_json,
+          resolved_tenant_ids_json, provider_id, provider_name, provider_is_local,
+          model, status, preflight_json, progress_json, summary_json,
+          comparisons_json, device_rows_json, assistant_text, export_dossier_markdown,
+          error, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          conversation_id = excluded.conversation_id,
+          status = excluded.status,
+          progress_json = excluded.progress_json,
+          summary_json = excluded.summary_json,
+          comparisons_json = excluded.comparisons_json,
+          device_rows_json = excluded.device_rows_json,
+          assistant_text = excluded.assistant_text,
+          export_dossier_markdown = excluded.export_dossier_markdown,
+          error = excluded.error,
+          updated_at = excluded.updated_at`,
+      )
+      .run(
+        job.id,
+        job.conversationId ?? null,
+        job.prompt,
+        job.savedQueryId ?? null,
+        JSON.stringify(job.tenantScope),
+        JSON.stringify(job.resolvedTenantIds),
+        job.providerId,
+        job.providerName,
+        job.providerIsLocal ? 1 : 0,
+        job.model ?? null,
+        job.status,
+        JSON.stringify(job.preflight),
+        JSON.stringify(job.progress),
+        JSON.stringify(job.summary),
+        JSON.stringify(job.comparisons),
+        JSON.stringify(job.deviceRows),
+        job.assistantText,
+        job.exportDossierMarkdown,
+        job.error ?? null,
+        job.createdAt,
+        job.updatedAt,
+      );
+    return job;
+  }
+
+  listMultiTenantJobs(): MultiTenantChatJob[] {
+    const rows = this.db
+      .prepare(
+        `SELECT id, conversation_id, prompt, saved_query_id, tenant_scope_json,
+                resolved_tenant_ids_json, provider_id, provider_name, provider_is_local,
+                model, status, preflight_json, progress_json, summary_json,
+                comparisons_json, device_rows_json, assistant_text,
+                export_dossier_markdown, error, created_at, updated_at
+         FROM multi_tenant_jobs
+         ORDER BY updated_at DESC`,
+      )
+      .all() as unknown as MultiTenantJobRow[];
+    return rows.map(readMultiTenantJob);
+  }
+
+  getMultiTenantJob(id: string): MultiTenantChatJob | undefined {
+    const row = this.db
+      .prepare(
+        `SELECT id, conversation_id, prompt, saved_query_id, tenant_scope_json,
+                resolved_tenant_ids_json, provider_id, provider_name, provider_is_local,
+                model, status, preflight_json, progress_json, summary_json,
+                comparisons_json, device_rows_json, assistant_text,
+                export_dossier_markdown, error, created_at, updated_at
+         FROM multi_tenant_jobs
+         WHERE id = ?`,
+      )
+      .get(id) as unknown as MultiTenantJobRow | undefined;
+    return row ? readMultiTenantJob(row) : undefined;
+  }
+
+  upsertMultiTenantAgentBatch(batch: MultiTenantAgentBatch): MultiTenantAgentBatch {
+    this.db
+      .prepare(
+        `INSERT INTO multi_tenant_agent_batches (
+          id, agent_slug, agent_name, agent_mode, tenant_scope_json,
+          resolved_tenant_ids_json, status, run_ids_json, preflight_json,
+          error, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          status = excluded.status,
+          run_ids_json = excluded.run_ids_json,
+          preflight_json = excluded.preflight_json,
+          error = excluded.error,
+          updated_at = excluded.updated_at`,
+      )
+      .run(
+        batch.id,
+        batch.agentSlug,
+        batch.agentName,
+        batch.agentMode,
+        JSON.stringify(batch.tenantScope),
+        JSON.stringify(batch.resolvedTenantIds),
+        batch.status,
+        JSON.stringify(batch.runIds),
+        JSON.stringify(batch.preflight),
+        batch.error ?? null,
+        batch.createdAt,
+        batch.updatedAt,
+      );
+    return batch;
+  }
+
+  listMultiTenantAgentBatches(): MultiTenantAgentBatch[] {
+    const rows = this.db
+      .prepare(
+        `SELECT id, agent_slug, agent_name, agent_mode, tenant_scope_json,
+                resolved_tenant_ids_json, status, run_ids_json, preflight_json,
+                error, created_at, updated_at
+         FROM multi_tenant_agent_batches
+         ORDER BY updated_at DESC`,
+      )
+      .all() as unknown as MultiTenantAgentBatchRow[];
+    return rows.map(readMultiTenantAgentBatch);
+  }
+
+  getMultiTenantAgentBatch(id: string): MultiTenantAgentBatch | undefined {
+    const row = this.db
+      .prepare(
+        `SELECT id, agent_slug, agent_name, agent_mode, tenant_scope_json,
+                resolved_tenant_ids_json, status, run_ids_json, preflight_json,
+                error, created_at, updated_at
+         FROM multi_tenant_agent_batches
+         WHERE id = ?`,
+      )
+      .get(id) as unknown as MultiTenantAgentBatchRow | undefined;
+    return row ? readMultiTenantAgentBatch(row) : undefined;
+  }
+
+  listWorkspaces(tenantNames: Map<string, string>, tenantId?: string): WorkspaceSummary[] {
+    const rows = this.db
+      .prepare(
+        `SELECT id, tenant_id, title, status, instructions, created_at, updated_at
+         FROM workspaces
+         WHERE status != 'archived'
+           ${tenantId ? "AND tenant_id = ?" : ""}
+         ORDER BY updated_at DESC`,
+      )
+      .all(...(tenantId ? [tenantId] : [])) as unknown as WorkspaceRow[];
+    return rows.map((row) => this.readWorkspaceSummary(row, tenantNames));
+  }
+
+  getWorkspace(id: string, tenantNames: Map<string, string>): WorkspaceDetail | undefined {
+    const row = this.getWorkspaceRow(id);
+    if (!row) return undefined;
+    return {
+      ...this.readWorkspaceSummary(row, tenantNames),
+      ...(row.instructions ? { instructions: row.instructions } : {}),
+      evidence: this.listWorkspaceEvidence(id),
+      notes: this.listWorkspaceNotes(id),
+      links: this.listWorkspaceLinks(id),
+    };
+  }
+
+  createWorkspace(input: {
+    id: string;
+    tenantId: string;
+    tenantName?: string;
+    title: string;
+    instructions?: string;
+    now: string;
+    conversationId?: string;
+  }): WorkspaceDetail {
+    this.db.exec("BEGIN");
+    try {
+      this.db
+        .prepare(
+          `INSERT INTO workspaces (
+            id, tenant_id, title, status, instructions, created_at, updated_at
+          )
+          VALUES (?, ?, ?, 'active', ?, ?, ?)`,
+        )
+        .run(
+          input.id,
+          input.tenantId,
+          input.title,
+          input.instructions ?? null,
+          input.now,
+          input.now,
+        );
+      if (input.conversationId) {
+        this.linkWorkspaceConversation({
+          id: `wlink_${input.id}`,
+          workspaceId: input.id,
+          tenantId: input.tenantId,
+          conversationId: input.conversationId,
+          title: input.title,
+          now: input.now,
+        });
+      }
+      this.db.exec("COMMIT");
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+    const tenantNames = new Map([[input.tenantId, input.tenantName ?? ""]]);
+    const workspace = this.getWorkspace(input.id, tenantNames);
+    if (!workspace) throw new Error(`Workspace was not created: ${input.id}`);
+    return workspace;
+  }
+
+  updateWorkspace(input: {
+    id: string;
+    title?: string;
+    instructions?: string;
+    status?: WorkspaceStatus;
+    now: string;
+    tenantNames: Map<string, string>;
+  }): WorkspaceDetail {
+    const row = this.getWorkspaceRow(input.id);
+    if (!row) throw new Error(`Workspace not found: ${input.id}`);
+    const nextTitle = input.title ?? row.title;
+    const nextInstructions =
+      input.instructions !== undefined ? input.instructions : row.instructions;
+    const nextStatus = input.status ?? row.status;
+    this.db
+      .prepare(
+        `UPDATE workspaces
+         SET title = ?, instructions = ?, status = ?, updated_at = ?
+         WHERE id = ?`,
+      )
+      .run(nextTitle, nextInstructions ?? null, nextStatus, input.now, input.id);
+    const workspace = this.getWorkspace(input.id, input.tenantNames);
+    if (!workspace) throw new Error(`Workspace not found: ${input.id}`);
+    return workspace;
+  }
+
+  archiveWorkspace(id: string, now: string, tenantNames: Map<string, string>): WorkspaceSummary {
+    const detail = this.updateWorkspace({
+      id,
+      status: "archived",
+      now,
+      tenantNames,
+    });
+    return detail;
+  }
+
+  deleteWorkspace(id: string): void {
+    const result = this.db.prepare(`DELETE FROM workspaces WHERE id = ?`).run(id);
+    if (result.changes === 0) {
+      throw new Error(`Workspace not found: ${id}`);
+    }
+  }
+
+  addWorkspaceNote(input: {
+    id: string;
+    workspaceId: string;
+    content: string;
+    now: string;
+  }): WorkspaceNote {
+    const workspace = this.requireWorkspaceRow(input.workspaceId);
+    this.db
+      .prepare(
+        `INSERT INTO workspace_notes (
+          id, workspace_id, tenant_id, content, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(input.id, input.workspaceId, workspace.tenant_id, input.content, input.now, input.now);
+    return {
+      id: input.id,
+      workspaceId: input.workspaceId,
+      tenantId: workspace.tenant_id,
+      content: input.content,
+      createdAt: input.now,
+      updatedAt: input.now,
+    };
+  }
+
+  updateWorkspaceNote(id: string, content: string, now: string): WorkspaceNote {
+    const result = this.db
+      .prepare(
+        `UPDATE workspace_notes
+         SET content = ?, updated_at = ?
+         WHERE id = ?`,
+      )
+      .run(content, now, id);
+    if (result.changes === 0) throw new Error(`Workspace note not found: ${id}`);
+    const row = this.db
+      .prepare(
+        `SELECT id, workspace_id, tenant_id, content, created_at, updated_at
+         FROM workspace_notes
+         WHERE id = ?`,
+      )
+      .get(id) as unknown as WorkspaceNoteRow | undefined;
+    if (!row) throw new Error(`Workspace note not found: ${id}`);
+    return readWorkspaceNote(row);
+  }
+
+  pinWorkspaceEvidence(input: Omit<WorkspaceEvidence, "createdAt"> & { now: string }): WorkspaceEvidence {
+    const workspace = this.requireWorkspaceRow(input.workspaceId);
+    if (workspace.tenant_id !== input.tenantId) {
+      throw new Error("Workspace evidence tenant does not match the workspace tenant.");
+    }
+    this.db
+      .prepare(
+        `INSERT INTO workspace_evidence (
+          id, workspace_id, tenant_id, title, source_type, source_ref_json,
+          content_json, freshness_json, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        input.id,
+        input.workspaceId,
+        input.tenantId,
+        input.title,
+        input.sourceType,
+        input.sourceRef ? JSON.stringify(input.sourceRef) : null,
+        JSON.stringify(input.content),
+        input.freshness ? JSON.stringify(input.freshness) : null,
+        input.now,
+      );
+    this.touchWorkspace(input.workspaceId, input.now);
+    return {
+      id: input.id,
+      workspaceId: input.workspaceId,
+      tenantId: input.tenantId,
+      title: input.title,
+      sourceType: input.sourceType,
+      ...(input.sourceRef ? { sourceRef: input.sourceRef } : {}),
+      content: input.content,
+      ...(input.freshness ? { freshness: input.freshness } : {}),
+      createdAt: input.now,
+    };
+  }
+
+  linkWorkspaceConversation(input: {
+    id: string;
+    workspaceId: string;
+    tenantId: string;
+    conversationId: string;
+    title: string;
+    now: string;
+  }): WorkspaceLink {
+    return this.insertWorkspaceLink({
+      id: input.id,
+      workspaceId: input.workspaceId,
+      tenantId: input.tenantId,
+      type: "conversation",
+      refId: input.conversationId,
+      title: input.title,
+      now: input.now,
+    });
+  }
+
+  linkWorkspaceRun(input: {
+    id: string;
+    workspaceId: string;
+    tenantId: string;
+    runId: string;
+    title: string;
+    now: string;
+  }): WorkspaceLink {
+    return this.insertWorkspaceLink({
+      id: input.id,
+      workspaceId: input.workspaceId,
+      tenantId: input.tenantId,
+      type: "run",
+      refId: input.runId,
+      title: input.title,
+      now: input.now,
+    });
+  }
+
+  importMultiTenantResultToWorkspaces(input: {
+    job: MultiTenantChatJob;
+    tenantNames: Map<string, string>;
+    mappings: { tenantId: string; workspaceId?: string; title?: string }[];
+    createWorkspaceId: () => string;
+    createEvidenceId: () => string;
+    now: string;
+  }): ImportMultiTenantResultToWorkspacesResult {
+    const workspaces: WorkspaceSummary[] = [];
+    const evidence: WorkspaceEvidence[] = [];
+    this.db.exec("BEGIN");
+    try {
+      for (const mapping of input.mappings) {
+        const tenantRows = input.job.deviceRows.filter(
+          (row) => row.tenantId === mapping.tenantId,
+        );
+        const comparison = input.job.comparisons.find(
+          (row) => row.tenantId === mapping.tenantId,
+        );
+        if (!comparison && tenantRows.length === 0) continue;
+        let workspaceId = mapping.workspaceId;
+        if (!workspaceId) {
+          workspaceId = input.createWorkspaceId();
+          const title =
+            mapping.title ??
+            `${input.tenantNames.get(mapping.tenantId) ?? "Tenant"} · ${input.job.prompt.slice(0, 64)}`;
+          this.db
+            .prepare(
+              `INSERT INTO workspaces (
+                id, tenant_id, title, status, instructions, created_at, updated_at
+              )
+              VALUES (?, ?, ?, 'active', NULL, ?, ?)`,
+            )
+            .run(workspaceId, mapping.tenantId, title, input.now, input.now);
+        }
+        const title = `Multi-tenant chat · ${input.job.prompt.slice(0, 80)}`;
+        const pinned = this.pinWorkspaceEvidence({
+          id: input.createEvidenceId(),
+          workspaceId,
+          tenantId: mapping.tenantId,
+          title,
+          sourceType: "multi-tenant-chat-result",
+          sourceRef: { jobId: input.job.id, prompt: input.job.prompt },
+          content: {
+            comparison,
+            rows: tenantRows,
+          },
+          freshness: {
+            resource: "managedDevices",
+            refreshedAt: comparison?.lastRefresh,
+            rowCount: tenantRows.length,
+            cacheStatus: comparison?.status === "stale" ? "stale" : "cache",
+          },
+          now: input.now,
+        });
+        evidence.push(pinned);
+        const row = this.requireWorkspaceRow(workspaceId);
+        workspaces.push(this.readWorkspaceSummary(row, input.tenantNames));
+      }
+      this.db.exec("COMMIT");
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+    return { workspaces, evidence };
+  }
+
+  exportWorkspaceDossier(id: string, tenantNames: Map<string, string>): string {
+    const workspace = this.getWorkspace(id, tenantNames);
+    if (!workspace) throw new Error(`Workspace not found: ${id}`);
+    return buildWorkspaceDossier(workspace);
+  }
+
   getSelfTrainingSettings(): SelfTrainingSettings {
     const row = this.db
       .prepare(`SELECT value, updated_at FROM app_settings WHERE key = 'selfTrainingEnabled'`)
@@ -833,6 +1505,9 @@ export class IntelligenceSqliteStore {
         id TEXT PRIMARY KEY,
         title TEXT NOT NULL,
         tenant_id TEXT,
+        scope_kind TEXT,
+        scope_json TEXT,
+        multi_tenant_job_id TEXT,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL,
         pinned_at TEXT
@@ -923,6 +1598,124 @@ export class IntelligenceSqliteStore {
 
       CREATE INDEX IF NOT EXISTS idx_self_training_suggestions_status
         ON self_training_suggestions (status, tenant_id, agent_slug);
+
+      CREATE TABLE IF NOT EXISTS tenant_groups (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        tenant_ids_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS saved_multi_tenant_queries (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        prompt TEXT NOT NULL,
+        resource_hints_json TEXT NOT NULL,
+        default_scope_json TEXT,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS multi_tenant_jobs (
+        id TEXT PRIMARY KEY,
+        conversation_id TEXT,
+        prompt TEXT NOT NULL,
+        saved_query_id TEXT,
+        tenant_scope_json TEXT NOT NULL,
+        resolved_tenant_ids_json TEXT NOT NULL,
+        provider_id TEXT NOT NULL,
+        provider_name TEXT NOT NULL,
+        provider_is_local INTEGER NOT NULL,
+        model TEXT,
+        status TEXT NOT NULL,
+        preflight_json TEXT NOT NULL,
+        progress_json TEXT NOT NULL,
+        summary_json TEXT NOT NULL,
+        comparisons_json TEXT NOT NULL,
+        device_rows_json TEXT NOT NULL,
+        assistant_text TEXT NOT NULL,
+        export_dossier_markdown TEXT NOT NULL,
+        error TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_multi_tenant_jobs_updated
+        ON multi_tenant_jobs (updated_at DESC);
+
+      CREATE TABLE IF NOT EXISTS multi_tenant_agent_batches (
+        id TEXT PRIMARY KEY,
+        agent_slug TEXT NOT NULL,
+        agent_name TEXT NOT NULL,
+        agent_mode TEXT NOT NULL,
+        tenant_scope_json TEXT NOT NULL,
+        resolved_tenant_ids_json TEXT NOT NULL,
+        status TEXT NOT NULL,
+        run_ids_json TEXT NOT NULL,
+        preflight_json TEXT NOT NULL,
+        error TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_multi_tenant_agent_batches_updated
+        ON multi_tenant_agent_batches (updated_at DESC);
+
+      CREATE TABLE IF NOT EXISTS workspaces (
+        id TEXT PRIMARY KEY,
+        tenant_id TEXT NOT NULL,
+        title TEXT NOT NULL,
+        status TEXT NOT NULL,
+        instructions TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_workspaces_tenant_updated
+        ON workspaces (tenant_id, status, updated_at DESC);
+
+      CREATE TABLE IF NOT EXISTS workspace_evidence (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        tenant_id TEXT NOT NULL,
+        title TEXT NOT NULL,
+        source_type TEXT NOT NULL,
+        source_ref_json TEXT,
+        content_json TEXT NOT NULL,
+        freshness_json TEXT,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_workspace_evidence_workspace
+        ON workspace_evidence (workspace_id, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS workspace_notes (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        tenant_id TEXT NOT NULL,
+        content TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_workspace_notes_workspace
+        ON workspace_notes (workspace_id, updated_at DESC);
+
+      CREATE TABLE IF NOT EXISTS workspace_links (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        tenant_id TEXT NOT NULL,
+        type TEXT NOT NULL,
+        ref_id TEXT NOT NULL,
+        title TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        UNIQUE(workspace_id, type, ref_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_workspace_links_workspace
+        ON workspace_links (workspace_id, type, created_at DESC);
     `);
     this.db
       .prepare(
@@ -938,6 +1731,212 @@ export class IntelligenceSqliteStore {
       "INTEGER NOT NULL DEFAULT 0",
     );
     ensureColumn(this.db, "chat_conversations", "pinned_at", "TEXT");
+    ensureColumn(this.db, "chat_conversations", "scope_kind", "TEXT");
+    ensureColumn(this.db, "chat_conversations", "scope_json", "TEXT");
+    ensureColumn(this.db, "chat_conversations", "multi_tenant_job_id", "TEXT");
+    this.ensureDefaultSavedQueries(new Date().toISOString());
+  }
+
+  private ensureDefaultSavedQueries(now: string): void {
+    const defaults: Omit<SavedMultiTenantQuery, "createdAt" | "updatedAt">[] = [
+      {
+        id: "windows-compliance",
+        title: "Windows compliance by tenant",
+        prompt: "List all compliant and non-compliant Windows devices from every connected tenant.",
+        resourceHints: ["managedDevices"],
+        defaultScope: { kind: "all" },
+        order: 10,
+      },
+      {
+        id: "stale-windows-devices",
+        title: "Stale Windows devices",
+        prompt: "Which Windows devices have not synced in the last 7 days across selected tenants?",
+        resourceHints: ["managedDevices"],
+        defaultScope: { kind: "selected", tenantIds: [] },
+        order: 20,
+      },
+      {
+        id: "bitlocker-gaps",
+        title: "BitLocker gaps",
+        prompt: "Show Windows devices that appear unencrypted or unknown for BitLocker across selected tenants.",
+        resourceHints: ["managedDevices", "managedDeviceEncryptionStates"],
+        defaultScope: { kind: "selected", tenantIds: [] },
+        order: 30,
+      },
+      {
+        id: "risky-sign-ins",
+        title: "Risky sign-ins",
+        prompt: "Summarize recent risky or failed sign-ins across selected tenants.",
+        resourceHints: ["signIns"],
+        defaultScope: { kind: "selected", tenantIds: [] },
+        order: 40,
+      },
+      {
+        id: "conditional-access-gaps",
+        title: "Conditional Access gaps",
+        prompt: "Compare Conditional Access policy coverage across selected tenants.",
+        resourceHints: ["conditionalAccessPolicies"],
+        defaultScope: { kind: "selected", tenantIds: [] },
+        order: 50,
+      },
+    ];
+    const insert = this.db.prepare(
+      `INSERT OR IGNORE INTO saved_multi_tenant_queries (
+        id, title, prompt, resource_hints_json, default_scope_json,
+        sort_order, created_at, updated_at
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const query of defaults) {
+      insert.run(
+        query.id,
+        query.title,
+        query.prompt,
+        JSON.stringify(query.resourceHints),
+        query.defaultScope ? JSON.stringify(query.defaultScope) : null,
+        query.order,
+        now,
+        now,
+      );
+    }
+  }
+
+  private getWorkspaceRow(id: string): WorkspaceRow | undefined {
+    return this.db
+      .prepare(
+        `SELECT id, tenant_id, title, status, instructions, created_at, updated_at
+         FROM workspaces
+         WHERE id = ?`,
+      )
+      .get(id) as unknown as WorkspaceRow | undefined;
+  }
+
+  private requireWorkspaceRow(id: string): WorkspaceRow {
+    const row = this.getWorkspaceRow(id);
+    if (!row) throw new Error(`Workspace not found: ${id}`);
+    return row;
+  }
+
+  private readWorkspaceSummary(
+    row: WorkspaceRow,
+    tenantNames: Map<string, string>,
+  ): WorkspaceSummary {
+    const evidenceCount = this.countRows("workspace_evidence", "workspace_id = ?", [row.id]);
+    const noteCount = this.countRows("workspace_notes", "workspace_id = ?", [row.id]);
+    const conversationCount = this.countRows(
+      "workspace_links",
+      "workspace_id = ? AND type = 'conversation'",
+      [row.id],
+    );
+    const runCount = this.countRows("workspace_links", "workspace_id = ? AND type = 'run'", [row.id]);
+    const freshnessRow = this.db
+      .prepare(
+        `SELECT freshness_json
+         FROM workspace_evidence
+         WHERE workspace_id = ? AND freshness_json IS NOT NULL
+         ORDER BY created_at DESC
+         LIMIT 1`,
+      )
+      .get(row.id) as { freshness_json?: string } | undefined;
+    const freshness = freshnessRow?.freshness_json
+      ? readJson<{ refreshedAt?: string }>(freshnessRow.freshness_json, {}).refreshedAt
+      : undefined;
+    return {
+      id: row.id,
+      tenantId: row.tenant_id,
+      tenantName: tenantNames.get(row.tenant_id),
+      title: row.title,
+      status: row.status,
+      evidenceCount,
+      conversationCount,
+      runCount,
+      noteCount,
+      ...(freshness ? { freshness } : {}),
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  private listWorkspaceEvidence(workspaceId: string): WorkspaceEvidence[] {
+    const rows = this.db
+      .prepare(
+        `SELECT id, workspace_id, tenant_id, title, source_type, source_ref_json,
+                content_json, freshness_json, created_at
+         FROM workspace_evidence
+         WHERE workspace_id = ?
+         ORDER BY created_at DESC`,
+      )
+      .all(workspaceId) as unknown as WorkspaceEvidenceRow[];
+    return rows.map(readWorkspaceEvidence);
+  }
+
+  private listWorkspaceNotes(workspaceId: string): WorkspaceNote[] {
+    const rows = this.db
+      .prepare(
+        `SELECT id, workspace_id, tenant_id, content, created_at, updated_at
+         FROM workspace_notes
+         WHERE workspace_id = ?
+         ORDER BY updated_at DESC`,
+      )
+      .all(workspaceId) as unknown as WorkspaceNoteRow[];
+    return rows.map(readWorkspaceNote);
+  }
+
+  private listWorkspaceLinks(workspaceId: string): WorkspaceLink[] {
+    const rows = this.db
+      .prepare(
+        `SELECT id, workspace_id, tenant_id, type, ref_id, title, created_at
+         FROM workspace_links
+         WHERE workspace_id = ?
+         ORDER BY created_at DESC`,
+      )
+      .all(workspaceId) as unknown as WorkspaceLinkRow[];
+    return rows.map(readWorkspaceLink);
+  }
+
+  private insertWorkspaceLink(input: {
+    id: string;
+    workspaceId: string;
+    tenantId: string;
+    type: WorkspaceLink["type"];
+    refId: string;
+    title: string;
+    now: string;
+  }): WorkspaceLink {
+    const workspace = this.requireWorkspaceRow(input.workspaceId);
+    if (workspace.tenant_id !== input.tenantId) {
+      throw new Error("Workspace link tenant does not match the workspace tenant.");
+    }
+    this.db
+      .prepare(
+        `INSERT OR IGNORE INTO workspace_links (
+          id, workspace_id, tenant_id, type, ref_id, title, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        input.id,
+        input.workspaceId,
+        input.tenantId,
+        input.type,
+        input.refId,
+        input.title,
+        input.now,
+      );
+    this.touchWorkspace(input.workspaceId, input.now);
+    return {
+      id: input.id,
+      workspaceId: input.workspaceId,
+      tenantId: input.tenantId,
+      type: input.type,
+      refId: input.refId,
+      title: input.title,
+      createdAt: input.now,
+    };
+  }
+
+  private touchWorkspace(id: string, now: string): void {
+    this.db.prepare(`UPDATE workspaces SET updated_at = ? WHERE id = ?`).run(now, id);
   }
 }
 
@@ -946,6 +1945,9 @@ function readConversation(row: ConversationRow): IntuneChatConversation {
     id: row.id,
     title: row.title,
     tenantId: row.tenant_id ?? undefined,
+    scopeKind: row.scope_kind === "multi-tenant" ? "multi-tenant" : "single-tenant",
+    tenantScope: row.scope_json ? readJson<TenantScope | undefined>(row.scope_json, undefined) : undefined,
+    multiTenantJobId: row.multi_tenant_job_id ?? undefined,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     pinnedAt: row.pinned_at ?? undefined,
@@ -982,6 +1984,182 @@ function readSuggestion(row: SuggestionRow): SelfTrainingSuggestion {
     createdAt: row.created_at,
     decidedAt: row.decided_at ?? undefined,
   };
+}
+
+function readTenantGroup(row: TenantGroupRow): TenantGroup {
+  return {
+    id: row.id,
+    name: row.name,
+    tenantIds: readJson<string[]>(row.tenant_ids_json, []),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function readSavedQuery(row: SavedQueryRow): SavedMultiTenantQuery {
+  return {
+    id: row.id,
+    title: row.title,
+    prompt: row.prompt,
+    resourceHints: readJson<GraphCacheResourceKind[]>(row.resource_hints_json, []),
+    defaultScope: row.default_scope_json
+      ? readJson<TenantScope | undefined>(row.default_scope_json, undefined)
+      : undefined,
+    order: row.sort_order,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function readMultiTenantJob(row: MultiTenantJobRow): MultiTenantChatJob {
+  return {
+    id: row.id,
+    conversationId: row.conversation_id ?? undefined,
+    prompt: row.prompt,
+    savedQueryId: row.saved_query_id ?? undefined,
+    tenantScope: readJson<TenantScope>(row.tenant_scope_json, { kind: "active" }),
+    resolvedTenantIds: readJson<string[]>(row.resolved_tenant_ids_json, []),
+    providerId: row.provider_id as MultiTenantChatJob["providerId"],
+    providerName: row.provider_name,
+    providerIsLocal: row.provider_is_local === 1,
+    model: row.model ?? undefined,
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    preflight: readJson<MultiTenantChatJob["preflight"]>(
+      row.preflight_json,
+      {} as MultiTenantChatJob["preflight"],
+    ),
+    progress: readJson<MultiTenantChatJob["progress"]>(row.progress_json, []),
+    summary: readJson<MultiTenantChatJob["summary"]>(row.summary_json, {
+      tenantsScanned: 0,
+      failedTenants: 0,
+      skippedTenants: 0,
+      staleTenants: 0,
+      windowsDevices: 0,
+      compliant: 0,
+      nonCompliant: 0,
+      unknown: 0,
+    }),
+    comparisons: readJson<MultiTenantChatJob["comparisons"]>(row.comparisons_json, []),
+    deviceRows: readJson<MultiTenantChatJob["deviceRows"]>(row.device_rows_json, []),
+    assistantText: row.assistant_text,
+    exportDossierMarkdown: row.export_dossier_markdown,
+    error: row.error ?? undefined,
+  };
+}
+
+function readMultiTenantAgentBatch(
+  row: MultiTenantAgentBatchRow,
+): MultiTenantAgentBatch {
+  return {
+    id: row.id,
+    agentSlug: row.agent_slug,
+    agentName: row.agent_name,
+    agentMode: row.agent_mode,
+    tenantScope: readJson<TenantScope>(row.tenant_scope_json, { kind: "active" }),
+    resolvedTenantIds: readJson<string[]>(row.resolved_tenant_ids_json, []),
+    status: row.status,
+    runIds: readJson<string[]>(row.run_ids_json, []),
+    preflight: readJson<MultiTenantAgentBatch["preflight"]>(
+      row.preflight_json,
+      {} as MultiTenantAgentBatch["preflight"],
+    ),
+    error: row.error ?? undefined,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function readWorkspaceEvidence(row: WorkspaceEvidenceRow): WorkspaceEvidence {
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    tenantId: row.tenant_id,
+    title: row.title,
+    sourceType: row.source_type,
+    sourceRef: row.source_ref_json
+      ? readJson<Record<string, unknown>>(row.source_ref_json, {})
+      : undefined,
+    content: readJson<unknown>(row.content_json, {}),
+    freshness: row.freshness_json
+      ? readJson<WorkspaceEvidence["freshness"]>(row.freshness_json, undefined)
+      : undefined,
+    createdAt: row.created_at,
+  };
+}
+
+function readWorkspaceNote(row: WorkspaceNoteRow): WorkspaceNote {
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    tenantId: row.tenant_id,
+    content: row.content,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function readWorkspaceLink(row: WorkspaceLinkRow): WorkspaceLink {
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    tenantId: row.tenant_id,
+    type: row.type,
+    refId: row.ref_id,
+    title: row.title,
+    createdAt: row.created_at,
+  };
+}
+
+function buildWorkspaceDossier(workspace: WorkspaceDetail): string {
+  const lines = [
+    `# ${workspace.title}`,
+    "",
+    `Tenant: ${workspace.tenantName ?? workspace.tenantId}`,
+    `Status: ${workspace.status}`,
+    `Updated: ${workspace.updatedAt}`,
+    "",
+    "## Notes",
+    "",
+  ];
+  if (workspace.notes.length === 0) {
+    lines.push("No notes recorded.", "");
+  } else {
+    for (const note of workspace.notes) {
+      lines.push(`- ${note.updatedAt}: ${note.content.replace(/\s+/g, " ").trim()}`);
+    }
+    lines.push("");
+  }
+  lines.push("## Pinned Evidence", "");
+  if (workspace.evidence.length === 0) {
+    lines.push("No evidence pinned.", "");
+  } else {
+    for (const evidence of workspace.evidence) {
+      lines.push(`### ${evidence.title}`);
+      lines.push(`- Source: ${evidence.sourceType}`);
+      lines.push(`- Created: ${evidence.createdAt}`);
+      if (evidence.freshness?.refreshedAt) {
+        lines.push(`- Refreshed: ${evidence.freshness.refreshedAt}`);
+      }
+      lines.push("");
+      lines.push("```json");
+      lines.push(JSON.stringify(evidence.content, null, 2));
+      lines.push("```", "");
+    }
+  }
+  lines.push("## Linked Context", "");
+  if (workspace.links.length === 0) {
+    lines.push("No linked conversations or runs.");
+  } else {
+    for (const link of workspace.links) {
+      lines.push(`- ${link.type}: ${link.title} (${link.refId})`);
+    }
+  }
+  if (workspace.instructions) {
+    lines.push("", "## Local Instructions", "", workspace.instructions);
+  }
+  return `${lines.join("\n")}\n`;
 }
 
 function graphCacheScheduleKey(tenantId: string): string {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -47,11 +47,18 @@ import type {
   AgentWhatsAppWebDelivery,
   CompanionRunDueReadSchedulesResult,
   CompanionSnapshot,
+  CreateWorkspaceInput,
+  ImportMultiTenantResultToWorkspacesInput,
+  MultiTenantChatStreamEvent,
   PendingConnectorDecision,
+  PinWorkspaceEvidenceInput,
+  PreflightMultiTenantChatInput,
   ProviderId,
+  QueueMultiTenantAgentBatchInput,
   RefreshGraphCacheOptions,
   ReleaseDiagnostics,
   ResetSelfTrainingInput,
+  RunMultiTenantChatInput,
   RunGraphApi,
   RunLlmApi,
   RunRecord,
@@ -66,6 +73,10 @@ import type {
   SupportIssueSubmissionResult,
   IntuneChatStreamEvent,
   StartRunOptions,
+  TenantScope,
+  UpdateWorkspaceInput,
+  WorkspaceEvidenceSourceType,
+  WorkspaceStatus,
 } from "@openadminos/agent-sdk";
 import { providerCatalog } from "@openadminos/agent-sdk";
 import {
@@ -147,6 +158,7 @@ const supportIssueSources = new Set([
   "native-menu",
 ]);
 const intuneChatStreamControllers = new Map<string, AbortController>();
+const multiTenantChatStreamControllers = new Map<string, AbortController>();
 const agentSlugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const agentCategories = new Set([
   "devices",
@@ -160,6 +172,14 @@ const selfTrainingSuggestionStatuses = new Set<SelfTrainingSuggestionStatus>([
   "accepted",
   "rejected",
   "reset",
+]);
+const workspaceStatuses = new Set<WorkspaceStatus>(["active", "archived"]);
+const workspaceEvidenceSourceTypes = new Set<WorkspaceEvidenceSourceType>([
+  "multi-tenant-chat-result",
+  "chat-message",
+  "graph-cache-row",
+  "run-result",
+  "manual",
 ]);
 const DEFAULT_SUPPORT_API_URL = "https://openadminos.com";
 const COMPANION_WINDOW_WIDTH = 390;
@@ -711,6 +731,39 @@ async function intuneChatSmokeScript(): Promise<Record<string, unknown>> {
     textarea.dispatchEvent(new Event("input", { bubbles: true }));
     await waitFor(() => textarea.value === value, "chat input value");
   };
+  const selectFirstOption = async (ariaLabel: string) => {
+    await waitFor(
+      () => Boolean(document.querySelector(`select[aria-label="${ariaLabel}"]`)),
+      `${ariaLabel} select`,
+    );
+    const select = document.querySelector(`select[aria-label="${ariaLabel}"]`);
+    if (!(select instanceof HTMLSelectElement)) {
+      throw new Error(`${ariaLabel} select was not found.`);
+    }
+    const option = Array.from(select.options).find((candidate) => candidate.value);
+    if (!option) {
+      throw new Error(`${ariaLabel} has no selectable option.`);
+    }
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLSelectElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(select, option.value);
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+    await waitFor(() => select.value === option.value, `${ariaLabel} selected`);
+  };
+  const clickFirstEnabledCheckbox = async (label: string) => {
+    await waitFor(
+      () => Boolean(document.querySelector('input[type="checkbox"]:not(:disabled)')),
+      label,
+    );
+    const checkbox = document.querySelector('input[type="checkbox"]:not(:disabled)');
+    if (!(checkbox instanceof HTMLInputElement)) {
+      throw new Error(`${label} checkbox was not found.`);
+    }
+    checkbox.click();
+    await waitFor(() => checkbox.checked, `${label} checked`);
+  };
   const pressEnterInTextarea = async () => {
     await waitFor(() => Boolean(document.querySelector("textarea")), "chat input");
     const textarea = document.querySelector("textarea");
@@ -775,6 +828,32 @@ async function intuneChatSmokeScript(): Promise<Record<string, unknown>> {
   await clickNamedButton("Show chat history");
   await waitFor(() => bodyText().includes("Smoke Tenant"), "expanded chat history");
 
+  await selectFirstOption("Saved multi-tenant query");
+  await waitFor(() => {
+    const textarea = document.querySelector("textarea");
+    return textarea instanceof HTMLTextAreaElement &&
+      textarea.value.includes("List all compliant and non-compliant Windows devices");
+  }, "saved multi-tenant query loaded");
+  await clickButton("Send");
+  await waitFor(() => bodyText().includes("Review multi-tenant scope"), "scope review");
+  const sawMultiTenantScopeReview =
+    bodyText().includes("Review multi-tenant scope") &&
+    bodyText().includes("Smoke Tenant");
+  await clickButton("Run read-only query");
+  await waitFor(() => bodyText().includes("Multi-tenant result"), "multi-tenant result");
+  const sawMultiTenantResult = bodyText().includes("Multi-tenant result");
+  await clickButton("Split to Workspaces");
+  await waitFor(() => bodyText().includes("Split result to Workspaces"), "split to workspaces modal");
+  await clickModalButton("Create evidence");
+  await waitFor(() => bodyText().includes("Created") && bodyText().includes("evidence"), "split workspace evidence");
+  const sawSplitToWorkspaces = bodyText().includes("workspace evidence");
+  await clickModalButton("Close");
+  await clickButton("New");
+  await waitFor(
+    () => bodyText().includes("New conversation") && bodyText().includes("Ready"),
+    "new conversation after multi-tenant result",
+  );
+
   await setTextarea("Hold response for cancellation smoke.");
   await pressEnterInTextarea();
   await waitFor(() => Boolean(findButton("Stop")), "chat stop action", 2500);
@@ -836,11 +915,54 @@ async function intuneChatSmokeScript(): Promise<Record<string, unknown>> {
   }
   await waitFor(() => bodyText().includes("WIN-01 is stale"), "chat answer");
   await waitFor(() => bodyText().includes("Offboarding agent"), "agent suggestion");
+  const sawAgentSuggestion = bodyText().includes("Offboarding agent");
   await clickSummary("Source details");
   await waitFor(
     () => bodyText().includes("/deviceManagement/managedDevices"),
     "source details endpoint",
   );
+  await clickButton("Details");
+  await waitFor(
+      () =>
+        bodyText().includes("Why suggested") &&
+        bodyText().includes("Required scopes") &&
+        bodyText().includes("Write intent") &&
+        bodyText().includes("DeviceManagementManagedDevices.Read.All") &&
+        bodyText().includes("Write actions still use the normal plan and confirmation flow."),
+    "agent suggestion details",
+  );
+  await clickButton("Workspace");
+  await waitFor(
+    () => bodyText().includes("Created workspace") && bodyText().includes("linked this conversation"),
+    "workspace created from conversation",
+  );
+  await clickButton("Pin answer");
+  await waitFor(() => bodyText().includes("Pin answer to workspace"), "pin answer modal");
+  await clickModalButton("Pin answer");
+  await waitFor(() => bodyText().includes("Pinned evidence to"), "pinned answer evidence");
+  const sawWorkspacePin = bodyText().includes("Pinned evidence to");
+  await clickButton("New");
+  await waitFor(
+    () => bodyText().includes("New conversation") && bodyText().includes("Ready"),
+    "new conversation for workspace context",
+  );
+  await selectFirstOption("Attach workspace context");
+  await waitFor(() => bodyText().includes("Chat answer"), "workspace evidence option");
+  await clickFirstEnabledCheckbox("workspace context evidence");
+  await waitFor(
+    () => bodyText().includes("Workspace context selected: 1 evidence"),
+    "workspace context attached",
+  );
+  await setTextarea("Use the attached workspace context to summarize the device evidence.");
+  await pressEnterInTextarea();
+  await waitFor(
+    () => bodyText().includes(smokeAnswer),
+    "workspace context chat response",
+  );
+  const workspaceResponseCount = textOccurrenceCount(smokeAnswer);
+  const sawWorkspaceContextAttachment =
+    bodyText().includes("Workspace context selected: 1 evidence") ||
+    bodyText().includes("Use the attached workspace context");
   await clickButton("Regenerate");
   await waitFor(
     () =>
@@ -850,16 +972,16 @@ async function intuneChatSmokeScript(): Promise<Record<string, unknown>> {
     2500,
   );
   await waitFor(
-    () => textOccurrenceCount(smokeAnswer) >= responseCount + 1,
+    () => textOccurrenceCount(smokeAnswer) >= workspaceResponseCount + 1,
     "regenerated chat response",
   );
   await waitFor(() => !bodyText().includes("Thinking"), "regenerate send settled");
-  const sawRegenerate = textOccurrenceCount(smokeAnswer) >= responseCount + 1;
+  const sawRegenerate = textOccurrenceCount(smokeAnswer) >= workspaceResponseCount + 1;
   await clickButton("Edit");
   await waitFor(() => {
     const textarea = document.querySelector("textarea");
     return textarea instanceof HTMLTextAreaElement &&
-      textarea.value.includes("Which managed devices have not synced");
+      textarea.value.includes("Use the attached workspace context");
   }, "edit prompt loaded into composer");
   await clickButton("Pin");
   await waitFor(
@@ -889,26 +1011,14 @@ async function intuneChatSmokeScript(): Promise<Record<string, unknown>> {
   await clickNamedButton("Copy response");
   await waitFor(() => bodyText().includes("Copied"), "copied response feedback");
   const sawAnswer = bodyText().includes("WIN-01 is stale");
-  const sawAgentSuggestion = bodyText().includes("Offboarding agent");
   const sawConversationLifecycle =
     bodyText().includes("Smoke lifecycle review") && bodyText().includes("Unpin");
   const sawSourceDetails = bodyText().includes("/deviceManagement/managedDevices");
   const sawEditResend = (() => {
     const textarea = document.querySelector("textarea");
     return textarea instanceof HTMLTextAreaElement &&
-      textarea.value.includes("Which managed devices have not synced");
+      textarea.value.includes("Use the attached workspace context");
   })();
-
-  await clickButton("Details");
-  await waitFor(
-      () =>
-        bodyText().includes("Why suggested") &&
-        bodyText().includes("Required scopes") &&
-        bodyText().includes("Write intent") &&
-        bodyText().includes("DeviceManagementManagedDevices.Read.All") &&
-        bodyText().includes("Write actions still use the normal plan and confirmation flow."),
-    "agent suggestion details",
-  );
 
   location.hash = "/settings";
   await waitFor(() => bodyText().includes("Settings"), "Settings route");
@@ -949,12 +1059,17 @@ async function intuneChatSmokeScript(): Promise<Record<string, unknown>> {
     hasEditResend: sawEditResend,
     hasRegenerate: sawRegenerate,
     hasStopGeneration: sawStopGeneration,
+    hasWorkspacePin: sawWorkspacePin,
+    hasWorkspaceContextAttachment: sawWorkspaceContextAttachment,
     hasPinnedCategory: sawPinnedCategory,
     hasContextMenuDelete: sawContextMenuDelete,
     hasAcceptedLearning: bodyText().includes("Active overlays"),
     hasScheduledRefresh: bodyText().includes("Enabled"),
     hasLocalDataControls: sawLocalDataControls,
     hasLocalDataClearModal: sawLocalDataClearModal,
+    hasMultiTenantScopeReview: sawMultiTenantScopeReview,
+    hasMultiTenantResult: sawMultiTenantResult,
+    hasSplitToWorkspaces: sawSplitToWorkspaces,
   };
 }
 
@@ -2102,6 +2217,21 @@ function optionalBoundedString(
   return requireBoundedString(value, name, maxLength);
 }
 
+function optionalTextString(
+  value: unknown,
+  name: string,
+  maxLength: number,
+): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string") {
+    throw new Error(`${name} must be a string.`);
+  }
+  if (value.length > maxLength) {
+    throw new Error(`${name} is too long.`);
+  }
+  return value;
+}
+
 function validateSetRegistrySourceOptions(
   value: unknown,
 ): { confirmExternalSource?: boolean } {
@@ -2126,6 +2256,9 @@ function validateJsonRecord(
   try {
     serialized = JSON.stringify(value);
   } catch {
+    throw new Error(`${name} must be JSON-serializable.`);
+  }
+  if (serialized === undefined) {
     throw new Error(`${name} must be JSON-serializable.`);
   }
   if (Buffer.byteLength(serialized, "utf8") > maxBytes) {
@@ -2647,11 +2780,90 @@ function validateHostedProviderConsent(
   if (value.remember !== undefined && typeof value.remember !== "boolean") {
     throw new Error("hostedProviderConsent.remember must be a boolean.");
   }
+  let workspaceContext:
+    | NonNullable<SendIntuneChatMessageInput["hostedProviderConsent"]>["workspaceContext"]
+    | undefined;
+  if (value.workspaceContext !== undefined) {
+    if (!isPlainRecord(value.workspaceContext)) {
+      throw new Error("hostedProviderConsent.workspaceContext must be an object.");
+    }
+    const evidenceCount = Number(value.workspaceContext.evidenceCount);
+    const noteCount = Number(value.workspaceContext.noteCount);
+    if (
+      !Number.isInteger(evidenceCount) ||
+      evidenceCount < 0 ||
+      evidenceCount > 250 ||
+      !Number.isInteger(noteCount) ||
+      noteCount < 0 ||
+      noteCount > 250
+    ) {
+      throw new Error("hostedProviderConsent.workspaceContext counts must be non-negative integers.");
+    }
+    if (typeof value.workspaceContext.includesInstructions !== "boolean") {
+      throw new Error("hostedProviderConsent.workspaceContext.includesInstructions must be a boolean.");
+    }
+    workspaceContext = {
+      workspaceId: requireBoundedString(
+        value.workspaceContext.workspaceId,
+        "hostedProviderConsent.workspaceContext.workspaceId",
+        128,
+      ),
+      workspaceTitle: requireBoundedString(
+        value.workspaceContext.workspaceTitle,
+        "hostedProviderConsent.workspaceContext.workspaceTitle",
+        140,
+      ),
+      tenantId: requireBoundedString(
+        value.workspaceContext.tenantId,
+        "hostedProviderConsent.workspaceContext.tenantId",
+        256,
+      ),
+      evidenceCount,
+      noteCount,
+      includesInstructions: value.workspaceContext.includesInstructions,
+    };
+  }
   return {
     tenantId: requireBoundedString(value.tenantId, "hostedProviderConsent.tenantId", 256),
     providerId: validateProviderId(value.providerId, "hostedProviderConsent.providerId"),
     acknowledgedAt,
     ...(typeof value.remember === "boolean" ? { remember: value.remember } : {}),
+    ...(workspaceContext ? { workspaceContext } : {}),
+  };
+}
+
+function validateWorkspacePromptContextInput(
+  value: unknown,
+): NonNullable<SendIntuneChatMessageInput["workspaceContext"]> {
+  if (!isPlainRecord(value)) {
+    throw new Error("workspaceContext must be an object.");
+  }
+  if (
+    value.includeInstructions !== undefined &&
+    typeof value.includeInstructions !== "boolean"
+  ) {
+    throw new Error("workspaceContext.includeInstructions must be a boolean.");
+  }
+  return {
+    workspaceId: requireBoundedString(value.workspaceId, "workspaceContext.workspaceId", 128),
+    ...(value.evidenceIds !== undefined
+      ? {
+          evidenceIds: validateStringArray(
+            value.evidenceIds,
+            "workspaceContext.evidenceIds",
+            50,
+            128,
+          ),
+        }
+      : {}),
+    ...(value.noteIds !== undefined
+      ? {
+          noteIds: validateStringArray(value.noteIds, "workspaceContext.noteIds", 50, 128),
+        }
+      : {}),
+    ...(typeof value.includeInstructions === "boolean"
+      ? { includeInstructions: value.includeInstructions }
+      : {}),
   };
 }
 
@@ -2673,7 +2885,257 @@ function validateSendIntuneChatMessageInput(value: unknown): SendIntuneChatMessa
     ...(value.hostedProviderConsent !== undefined
       ? { hostedProviderConsent: validateHostedProviderConsent(value.hostedProviderConsent) }
       : {}),
+    ...(value.workspaceContext !== undefined
+      ? { workspaceContext: validateWorkspacePromptContextInput(value.workspaceContext) }
+      : {}),
   };
+}
+
+function validateTenantScope(value: unknown): TenantScope {
+  if (!isPlainRecord(value)) {
+    throw new Error("tenantScope must be an object.");
+  }
+  const kind = requireBoundedString(value.kind, "tenantScope.kind", 32);
+  if (kind === "active") return { kind };
+  const groupIds = validateOptionalStringArray(value.groupIds, "tenantScope.groupIds", 100, 256);
+  if (kind === "all") {
+    return { kind, ...(groupIds ? { groupIds } : {}) };
+  }
+  if (kind === "selected") {
+    const tenantIds = validateStringArray(value.tenantIds, "tenantScope.tenantIds", 250, 256);
+    return { kind, tenantIds, ...(groupIds ? { groupIds } : {}) };
+  }
+  throw new Error("tenantScope.kind must be active, selected, or all.");
+}
+
+function validatePreflightMultiTenantChatInput(
+  value: unknown,
+): PreflightMultiTenantChatInput {
+  if (!isPlainRecord(value)) {
+    throw new Error("Multi-tenant preflight input must be an object.");
+  }
+  return {
+    prompt: requireBoundedString(value.prompt, "prompt", 20_000),
+    tenantScope: validateTenantScope(value.tenantScope),
+    ...(value.savedQueryId !== undefined
+      ? { savedQueryId: requireBoundedString(value.savedQueryId, "savedQueryId", 128) }
+      : {}),
+  };
+}
+
+function validateHostedProviderBatchConsent(
+  value: unknown,
+): RunMultiTenantChatInput["hostedProviderConsent"] | undefined {
+  if (value === undefined) return undefined;
+  if (!isPlainRecord(value)) {
+    throw new Error("hostedProviderConsent must be an object.");
+  }
+  const acknowledgedAt = requireBoundedString(
+    value.acknowledgedAt,
+    "hostedProviderConsent.acknowledgedAt",
+    64,
+  );
+  if (!Number.isFinite(Date.parse(acknowledgedAt))) {
+    throw new Error("hostedProviderConsent.acknowledgedAt must be an ISO timestamp.");
+  }
+  if (value.remember !== undefined && typeof value.remember !== "boolean") {
+    throw new Error("hostedProviderConsent.remember must be a boolean.");
+  }
+  return {
+    tenantIds: validateStringArray(
+      value.tenantIds,
+      "hostedProviderConsent.tenantIds",
+      250,
+      256,
+    ),
+    providerId: validateProviderId(value.providerId, "hostedProviderConsent.providerId"),
+    acknowledgedAt,
+    ...(typeof value.remember === "boolean" ? { remember: value.remember } : {}),
+  };
+}
+
+function validateRunMultiTenantChatInput(value: unknown): RunMultiTenantChatInput {
+  const preflight = validatePreflightMultiTenantChatInput(value);
+  if (!isPlainRecord(value)) {
+    throw new Error("Multi-tenant chat input must be an object.");
+  }
+  if (value.refreshIfStale !== undefined && typeof value.refreshIfStale !== "boolean") {
+    throw new Error("refreshIfStale must be a boolean.");
+  }
+  return {
+    ...preflight,
+    ...(typeof value.refreshIfStale === "boolean"
+      ? { refreshIfStale: value.refreshIfStale }
+      : {}),
+    ...(value.hostedProviderConsent !== undefined
+      ? { hostedProviderConsent: validateHostedProviderBatchConsent(value.hostedProviderConsent) }
+      : {}),
+  };
+}
+
+function validateQueueMultiTenantAgentBatchInput(
+  value: unknown,
+): QueueMultiTenantAgentBatchInput {
+  if (!isPlainRecord(value)) {
+    throw new Error("Multi-tenant agent batch input must be an object.");
+  }
+  return {
+    agentSlug: requireBoundedString(value.agentSlug, "agentSlug", 160),
+    tenantScope: validateTenantScope(value.tenantScope),
+    ...(value.savedQueryId !== undefined
+      ? { savedQueryId: requireBoundedString(value.savedQueryId, "savedQueryId", 128) }
+      : {}),
+    ...(value.prompt !== undefined
+      ? { prompt: requireBoundedString(value.prompt, "prompt", 20_000) }
+      : {}),
+  };
+}
+
+function validateTenantGroupInput(value: unknown): {
+  id?: string;
+  name: string;
+  tenantIds: string[];
+} {
+  if (!isPlainRecord(value)) throw new Error("Tenant group input must be an object.");
+  return {
+    ...(value.id !== undefined ? { id: requireBoundedString(value.id, "id", 128) } : {}),
+    name: requireBoundedString(value.name, "name", 80),
+    tenantIds: validateStringArray(value.tenantIds, "tenantIds", 250, 256),
+  };
+}
+
+function validateCreateWorkspaceInput(value: unknown): CreateWorkspaceInput {
+  if (!isPlainRecord(value)) throw new Error("Workspace input must be an object.");
+  return {
+    title: requireBoundedString(value.title, "workspace title", 140),
+    ...(value.tenantId !== undefined
+      ? { tenantId: requireBoundedString(value.tenantId, "tenantId", 256) }
+      : {}),
+    ...(value.instructions !== undefined
+      ? { instructions: optionalTextString(value.instructions, "instructions", 10_000) }
+      : {}),
+    ...(value.conversationId !== undefined
+      ? { conversationId: requireBoundedString(value.conversationId, "conversationId", 256) }
+      : {}),
+  };
+}
+
+function validateUpdateWorkspaceInput(value: unknown): UpdateWorkspaceInput {
+  if (!isPlainRecord(value)) throw new Error("Workspace update input must be an object.");
+  const status =
+    value.status === undefined
+      ? undefined
+      : requireBoundedString(value.status, "workspace status", 32);
+  if (status !== undefined && !workspaceStatuses.has(status as WorkspaceStatus)) {
+    throw new Error("Unknown workspace status.");
+  }
+  return {
+    ...(value.title !== undefined
+      ? { title: requireBoundedString(value.title, "workspace title", 140) }
+      : {}),
+    ...(value.instructions !== undefined
+      ? { instructions: optionalTextString(value.instructions, "instructions", 10_000) }
+      : {}),
+    ...(status !== undefined ? { status: status as WorkspaceStatus } : {}),
+  };
+}
+
+function validatePinWorkspaceEvidenceInput(value: unknown): PinWorkspaceEvidenceInput {
+  if (!isPlainRecord(value)) {
+    throw new Error("Workspace evidence input must be an object.");
+  }
+  const sourceType = requireBoundedString(value.sourceType, "sourceType", 64);
+  if (!workspaceEvidenceSourceTypes.has(sourceType as WorkspaceEvidenceSourceType)) {
+    throw new Error("Unknown workspace evidence source type.");
+  }
+  return {
+    workspaceId: requireBoundedString(value.workspaceId, "workspaceId", 128),
+    ...(value.tenantId !== undefined
+      ? { tenantId: requireBoundedString(value.tenantId, "tenantId", 256) }
+      : {}),
+    title: requireBoundedString(value.title, "evidence title", 140),
+    sourceType: sourceType as WorkspaceEvidenceSourceType,
+    ...(value.sourceRef !== undefined
+      ? { sourceRef: validateJsonRecord(value.sourceRef, "sourceRef", 20_000) }
+      : {}),
+    content: validateJsonValue(value.content, "content", 500_000),
+    ...(value.freshness !== undefined
+      ? { freshness: validateJsonRecord(value.freshness, "freshness", 20_000) }
+      : {}),
+  };
+}
+
+function validateImportMultiTenantResultToWorkspacesInput(
+  value: unknown,
+): ImportMultiTenantResultToWorkspacesInput {
+  if (!isPlainRecord(value)) throw new Error("Workspace import input must be an object.");
+  if (!Array.isArray(value.tenantMappings) || value.tenantMappings.length > 250) {
+    throw new Error("tenantMappings must be an array with at most 250 entries.");
+  }
+  return {
+    jobId: requireBoundedString(value.jobId, "jobId", 128),
+    tenantMappings: value.tenantMappings.map((mapping, index) => {
+      if (!isPlainRecord(mapping)) {
+        throw new Error(`tenantMappings[${index}] must be an object.`);
+      }
+      return {
+        tenantId: requireBoundedString(
+          mapping.tenantId,
+          `tenantMappings[${index}].tenantId`,
+          256,
+        ),
+        ...(mapping.workspaceId !== undefined
+          ? {
+              workspaceId: requireBoundedString(
+                mapping.workspaceId,
+                `tenantMappings[${index}].workspaceId`,
+                128,
+              ),
+            }
+          : {}),
+        ...(mapping.title !== undefined
+          ? { title: requireBoundedString(mapping.title, `tenantMappings[${index}].title`, 140) }
+          : {}),
+      };
+    }),
+  };
+}
+
+function validateStringArray(
+  value: unknown,
+  name: string,
+  maxItems: number,
+  maxLength: number,
+): string[] {
+  if (!Array.isArray(value) || value.length > maxItems) {
+    throw new Error(`${name} must be an array with at most ${maxItems} entries.`);
+  }
+  return [...new Set(value.map((entry, index) =>
+    requireBoundedString(entry, `${name}[${index}]`, maxLength),
+  ))];
+}
+
+function validateOptionalStringArray(
+  value: unknown,
+  name: string,
+  maxItems: number,
+  maxLength: number,
+): string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  return validateStringArray(value, name, maxItems, maxLength);
+}
+
+function validateJsonValue<T>(value: T, name: string, maxBytes: number): T {
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    throw new Error(`${name} must be JSON-serializable.`);
+  }
+  if (Buffer.byteLength(serialized, "utf8") > maxBytes) {
+    throw new Error(`${name} is too large.`);
+  }
+  return value;
 }
 
 function validateRefreshGraphCacheOptions(
@@ -2872,8 +3334,15 @@ function buildAppMenu(): Menu {
         },
       },
       {
-        label: "Activity",
+        label: "Workspaces",
         accelerator: "CmdOrCtrl+4",
+        click: () => {
+          void openMainWindow("/workspaces");
+        },
+      },
+      {
+        label: "Activity",
+        accelerator: "CmdOrCtrl+5",
         click: () => {
           void openMainWindow("/activity");
         },
@@ -3435,6 +3904,95 @@ function registerIpcHandlers() {
     }),
   );
   ipcMain.handle(
+    "openadminos:list-tenant-groups",
+    handleTrusted(() => store.listTenantGroups()),
+  );
+  ipcMain.handle(
+    "openadminos:save-tenant-group",
+    handleTrusted((_event, input: unknown) =>
+      store.saveTenantGroup(validateTenantGroupInput(input)),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:delete-tenant-group",
+    handleTrusted((_event, id: unknown) =>
+      store.deleteTenantGroup(requireBoundedString(id, "tenant group id", 128)),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:list-saved-multi-tenant-queries",
+    handleTrusted(() => store.listSavedMultiTenantQueries()),
+  );
+  ipcMain.handle(
+    "openadminos:preflight-multi-tenant-intune-chat",
+    handleTrusted((_event, input: unknown) =>
+      store.preflightMultiTenantIntuneChat(
+        validatePreflightMultiTenantChatInput(input),
+      ),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:run-multi-tenant-intune-chat",
+    handleTrusted((_event, input: unknown) =>
+      store.runMultiTenantIntuneChat(validateRunMultiTenantChatInput(input)),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:stream-multi-tenant-intune-chat",
+    handleTrusted((event, streamId: unknown, input: unknown) => {
+      const safeStreamId = requireBoundedString(streamId, "streamId", 128);
+      const controller = new AbortController();
+      multiTenantChatStreamControllers.set(safeStreamId, controller);
+      return store.streamMultiTenantIntuneChat(
+        validateRunMultiTenantChatInput(input),
+        (streamEvent: MultiTenantChatStreamEvent) => {
+          event.sender.send("openadminos:multi-tenant-chat-stream-event", {
+            streamId: safeStreamId,
+            event: streamEvent,
+          });
+        },
+        { signal: controller.signal },
+      ).finally(() => {
+        multiTenantChatStreamControllers.delete(safeStreamId);
+      });
+    }),
+  );
+  ipcMain.handle(
+    "openadminos:cancel-multi-tenant-intune-chat-stream",
+    handleTrusted((_event, streamId: unknown) => {
+      const safeStreamId = requireBoundedString(streamId, "streamId", 128);
+      multiTenantChatStreamControllers.get(safeStreamId)?.abort();
+    }),
+  );
+  ipcMain.handle(
+    "openadminos:list-multi-tenant-chat-jobs",
+    handleTrusted(() => store.listMultiTenantChatJobs()),
+  );
+  ipcMain.handle(
+    "openadminos:get-multi-tenant-chat-job",
+    handleTrusted((_event, id: unknown) =>
+      store.getMultiTenantChatJob(requireBoundedString(id, "jobId", 128)),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:queue-multi-tenant-agent-batch",
+    handleTrusted((_event, input: unknown) =>
+      store.queueMultiTenantAgentBatch(
+        validateQueueMultiTenantAgentBatchInput(input),
+      ),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:list-multi-tenant-agent-batches",
+    handleTrusted(() => store.listMultiTenantAgentBatches()),
+  );
+  ipcMain.handle(
+    "openadminos:get-multi-tenant-agent-batch",
+    handleTrusted((_event, id: unknown) =>
+      store.getMultiTenantAgentBatch(requireBoundedString(id, "batchId", 128)),
+    ),
+  );
+  ipcMain.handle(
     "openadminos:refresh-graph-cache",
     handleTrusted((_event, options?: unknown) =>
       store.refreshGraphCache(validateRefreshGraphCacheOptions(options)),
@@ -3520,6 +4078,101 @@ function registerIpcHandlers() {
     "openadminos:reset-self-training-suggestions",
     handleTrusted((_event, input: unknown) =>
       store.resetSelfTrainingSuggestions(validateResetSelfTrainingInput(input)),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:list-workspaces",
+    handleTrusted((_event, tenantId?: unknown) =>
+      store.listWorkspaces(optionalBoundedString(tenantId, "tenantId", 256)),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:get-workspace",
+    handleTrusted((_event, id: unknown) =>
+      store.getWorkspace(requireBoundedString(id, "workspaceId", 128)),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:create-workspace",
+    handleTrusted((_event, input: unknown) =>
+      store.createWorkspace(validateCreateWorkspaceInput(input)),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:update-workspace",
+    handleTrusted((_event, id: unknown, input: unknown) =>
+      store.updateWorkspace(
+        requireBoundedString(id, "workspaceId", 128),
+        validateUpdateWorkspaceInput(input),
+      ),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:archive-workspace",
+    handleTrusted((_event, id: unknown) =>
+      store.archiveWorkspace(requireBoundedString(id, "workspaceId", 128)),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:delete-workspace",
+    handleTrusted((_event, id: unknown) =>
+      store.deleteWorkspace(requireBoundedString(id, "workspaceId", 128)),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:add-workspace-note",
+    handleTrusted((_event, workspaceId: unknown, content: unknown) =>
+      store.addWorkspaceNote(
+        requireBoundedString(workspaceId, "workspaceId", 128),
+        requireBoundedString(content, "note content", 20_000),
+      ),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:update-workspace-note",
+    handleTrusted((_event, noteId: unknown, content: unknown) =>
+      store.updateWorkspaceNote(
+        requireBoundedString(noteId, "noteId", 128),
+        requireBoundedString(content, "note content", 20_000),
+      ),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:pin-workspace-evidence",
+    handleTrusted((_event, input: unknown) =>
+      store.pinWorkspaceEvidence(validatePinWorkspaceEvidenceInput(input)),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:link-workspace-conversation",
+    handleTrusted((_event, workspaceId: unknown, conversationId: unknown) =>
+      store.linkWorkspaceConversation(
+        requireBoundedString(workspaceId, "workspaceId", 128),
+        requireBoundedString(conversationId, "conversationId", 256),
+      ),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:link-workspace-run",
+    handleTrusted((_event, workspaceId: unknown, runId: unknown) =>
+      store.linkWorkspaceRun(
+        requireBoundedString(workspaceId, "workspaceId", 128),
+        requireBoundedString(runId, "runId", 128),
+      ),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:import-multi-tenant-result-to-workspaces",
+    handleTrusted((_event, input: unknown) =>
+      store.importMultiTenantResultToWorkspaces(
+        validateImportMultiTenantResultToWorkspacesInput(input),
+      ),
+    ),
+  );
+  ipcMain.handle(
+    "openadminos:export-workspace-dossier",
+    handleTrusted((_event, id: unknown) =>
+      store.exportWorkspaceDossier(requireBoundedString(id, "workspaceId", 128)),
     ),
   );
   ipcMain.handle(

--- a/apps/desktop/electron/preload.cts
+++ b/apps/desktop/electron/preload.cts
@@ -12,10 +12,12 @@ import type {
   StartRunOptions,
   UpdateState,
   IntuneChatStreamEvent,
+  MultiTenantChatStreamEvent,
 } from "@openadminos/agent-sdk";
 
 const platform: HostPlatform = detectPlatform();
 const activeIntuneChatStreamIds = new Set<string>();
+const activeMultiTenantChatStreamIds = new Set<string>();
 
 function detectPlatform(): HostPlatform {
   const userAgent = navigator.userAgent.toLowerCase();
@@ -132,6 +134,77 @@ const api: OpenAdminOSApi = {
       ),
     );
   },
+  listTenantGroups: () => ipcRenderer.invoke("openadminos:list-tenant-groups"),
+  saveTenantGroup: (input) =>
+    ipcRenderer.invoke("openadminos:save-tenant-group", input),
+  deleteTenantGroup: (id: string) =>
+    ipcRenderer.invoke("openadminos:delete-tenant-group", id),
+  listSavedMultiTenantQueries: () =>
+    ipcRenderer.invoke("openadminos:list-saved-multi-tenant-queries"),
+  preflightMultiTenantIntuneChat: (input) =>
+    ipcRenderer.invoke("openadminos:preflight-multi-tenant-intune-chat", input),
+  runMultiTenantIntuneChat: (input) =>
+    ipcRenderer.invoke("openadminos:run-multi-tenant-intune-chat", input),
+  streamMultiTenantIntuneChat: (input, onEvent) => {
+    const streamId = crypto.randomUUID();
+    let cleanedUp = false;
+    let terminalEventSeen = false;
+    activeMultiTenantChatStreamIds.add(streamId);
+    const cleanup = () => {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      activeMultiTenantChatStreamIds.delete(streamId);
+      ipcRenderer.removeListener(
+        "openadminos:multi-tenant-chat-stream-event",
+        handler,
+      );
+    };
+    const handler = (
+      _event: unknown,
+      payload: { streamId: string; event: MultiTenantChatStreamEvent },
+    ) => {
+      if (payload.streamId === streamId) {
+        onEvent(payload.event);
+        if (
+          payload.event.type === "completed" ||
+          payload.event.type === "failed" ||
+          payload.event.type === "cancelled"
+        ) {
+          terminalEventSeen = true;
+          window.setTimeout(cleanup, 0);
+        }
+      }
+    };
+    ipcRenderer.on("openadminos:multi-tenant-chat-stream-event", handler);
+    return ipcRenderer
+      .invoke("openadminos:stream-multi-tenant-intune-chat", streamId, input)
+      .finally(() => {
+        if (!terminalEventSeen) {
+          window.setTimeout(cleanup, 1000);
+        }
+      });
+  },
+  cancelMultiTenantIntuneChatStream: async () => {
+    const streamIds = [...activeMultiTenantChatStreamIds];
+    await Promise.all(
+      streamIds.map((streamId) =>
+        ipcRenderer.invoke(
+          "openadminos:cancel-multi-tenant-intune-chat-stream",
+          streamId,
+        ),
+      ),
+    );
+  },
+  listMultiTenantChatJobs: () =>
+    ipcRenderer.invoke("openadminos:list-multi-tenant-chat-jobs"),
+  getMultiTenantChatJob: (id: string) =>
+    ipcRenderer.invoke("openadminos:get-multi-tenant-chat-job", id),
+  queueMultiTenantAgentBatch: (input) =>
+    ipcRenderer.invoke("openadminos:queue-multi-tenant-agent-batch", input),
+  listMultiTenantAgentBatches: () =>
+    ipcRenderer.invoke("openadminos:list-multi-tenant-agent-batches"),
+  getMultiTenantAgentBatch: (id: string) =>
+    ipcRenderer.invoke("openadminos:get-multi-tenant-agent-batch", id),
   refreshGraphCache: (options) =>
     ipcRenderer.invoke("openadminos:refresh-graph-cache", options),
   getGraphCacheStatus: (tenantId?: string) =>
@@ -158,6 +231,35 @@ const api: OpenAdminOSApi = {
     ipcRenderer.invoke("openadminos:reject-self-training-suggestion", id),
   resetSelfTrainingSuggestions: (input) =>
     ipcRenderer.invoke("openadminos:reset-self-training-suggestions", input),
+  listWorkspaces: (tenantId?: string) =>
+    ipcRenderer.invoke("openadminos:list-workspaces", tenantId),
+  getWorkspace: (id: string) => ipcRenderer.invoke("openadminos:get-workspace", id),
+  createWorkspace: (input) =>
+    ipcRenderer.invoke("openadminos:create-workspace", input),
+  updateWorkspace: (id, input) =>
+    ipcRenderer.invoke("openadminos:update-workspace", id, input),
+  archiveWorkspace: (id: string) =>
+    ipcRenderer.invoke("openadminos:archive-workspace", id),
+  deleteWorkspace: (id: string) =>
+    ipcRenderer.invoke("openadminos:delete-workspace", id),
+  addWorkspaceNote: (workspaceId: string, content: string) =>
+    ipcRenderer.invoke("openadminos:add-workspace-note", workspaceId, content),
+  updateWorkspaceNote: (noteId: string, content: string) =>
+    ipcRenderer.invoke("openadminos:update-workspace-note", noteId, content),
+  pinWorkspaceEvidence: (input) =>
+    ipcRenderer.invoke("openadminos:pin-workspace-evidence", input),
+  linkWorkspaceConversation: (workspaceId: string, conversationId: string) =>
+    ipcRenderer.invoke(
+      "openadminos:link-workspace-conversation",
+      workspaceId,
+      conversationId,
+    ),
+  linkWorkspaceRun: (workspaceId: string, runId: string) =>
+    ipcRenderer.invoke("openadminos:link-workspace-run", workspaceId, runId),
+  importMultiTenantResultToWorkspaces: (input) =>
+    ipcRenderer.invoke("openadminos:import-multi-tenant-result-to-workspaces", input),
+  exportWorkspaceDossier: (id: string) =>
+    ipcRenderer.invoke("openadminos:export-workspace-dossier", id),
   listConnectors: () => ipcRenderer.invoke("openadminos:list-connectors"),
   testConnector: (id: string) =>
     ipcRenderer.invoke("openadminos:test-connector", id),

--- a/apps/desktop/electron/state.ts
+++ b/apps/desktop/electron/state.ts
@@ -65,15 +65,32 @@ import type {
   GraphCacheRefreshResourceResult,
   GraphCacheRefreshScheduleSettings,
   GraphCacheResourceKind,
+  GraphCacheResourceStatus,
   GraphCacheStatus,
+  HostedProviderBatchConsent,
+  ImportMultiTenantResultToWorkspacesInput,
+  ImportMultiTenantResultToWorkspacesResult,
+  CreateWorkspaceInput,
   IntuneChatConversation,
   IntuneChatMessage,
   IntuneChatProgressStep,
   IntuneChatStreamStage,
   IntuneChatStreamEvent,
   LocalDataSummary,
+  MultiTenantAgentBatch,
+  MultiTenantChatJob,
+  MultiTenantChatRunResult,
+  MultiTenantChatStreamEvent,
+  MultiTenantDeviceRow,
+  MultiTenantTenantComparison,
+  PinWorkspaceEvidenceInput,
+  PreflightMultiTenantChatInput,
+  QueueMultiTenantAgentBatchInput,
+  QueueMultiTenantAgentBatchResult,
   RefreshGraphCacheOptions,
   ResetSelfTrainingInput,
+  RunMultiTenantChatInput,
+  SavedMultiTenantQuery,
   SetGraphCacheRefreshScheduleInput,
   SelfTrainingSettings,
   SelfTrainingSuggestion,
@@ -81,6 +98,18 @@ import type {
   SendIntuneChatMessageInput,
   SendIntuneChatMessageResult,
   SecretAccessor,
+  TenantGroup,
+  TenantReadinessStatus,
+  TenantScope,
+  TenantScopePreflight,
+  UpdateWorkspaceInput,
+  WorkspaceDetail,
+  WorkspaceEvidence,
+  WorkspaceLink,
+  WorkspaceNote,
+  WorkspacePromptContextInput,
+  WorkspacePromptContextSummary,
+  WorkspaceSummary,
 } from "@openadminos/agent-sdk";
 import {
   ConnectorNotConfiguredError,
@@ -121,6 +150,12 @@ import {
   validatePath,
   type EndpointSummary,
 } from "./graph-catalog.js";
+
+type WorkspacePromptContextPayload = {
+  summary: WorkspacePromptContextSummary;
+  promptBlock: string;
+};
+
 import {
   DEFAULT_REGISTRY_SOURCE,
   refreshRegistry,
@@ -1004,6 +1039,715 @@ export class AppStateStore {
     return this.requireIntelligenceStore().listMessages(conversationId);
   }
 
+  async listTenantGroups(): Promise<TenantGroup[]> {
+    return this.requireIntelligenceStore().listTenantGroups();
+  }
+
+  async saveTenantGroup(input: {
+    id?: string;
+    name: string;
+    tenantIds: string[];
+  }): Promise<TenantGroup> {
+    const persisted = await this.read();
+    const knownTenantIds = new Set(persisted.tenants.map((tenant) => tenant.id));
+    const tenantIds = [...new Set(input.tenantIds)].filter((tenantId) => {
+      if (!knownTenantIds.has(tenantId)) {
+        throw new Error(`Tenant group includes an unknown tenant: ${tenantId}`);
+      }
+      return true;
+    });
+    const name = normalizeTenantGroupName(input.name);
+    return this.requireIntelligenceStore().saveTenantGroup({
+      id: input.id?.trim() || `tgrp_${randomUUID()}`,
+      name,
+      tenantIds,
+      now: new Date().toISOString(),
+    });
+  }
+
+  async deleteTenantGroup(id: string): Promise<void> {
+    if (!id.trim()) throw new Error("Tenant group id is required.");
+    this.requireIntelligenceStore().deleteTenantGroup(id);
+  }
+
+  async listSavedMultiTenantQueries(): Promise<SavedMultiTenantQuery[]> {
+    return this.requireIntelligenceStore().listSavedMultiTenantQueries();
+  }
+
+  async preflightMultiTenantIntuneChat(
+    input: PreflightMultiTenantChatInput,
+  ): Promise<TenantScopePreflight> {
+    return this.buildMultiTenantPreflight(input);
+  }
+
+  async runMultiTenantIntuneChat(
+    input: RunMultiTenantChatInput,
+    onEvent?: (event: MultiTenantChatStreamEvent) => void,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<MultiTenantChatRunResult> {
+    const content = input.prompt.trim();
+    if (!content) throw new Error("Multi-tenant chat prompt is required.");
+    const store = this.requireIntelligenceStore();
+    const persisted = await this.read();
+    const preflight = await this.buildMultiTenantPreflight(input);
+    const providers = await this.listProviders();
+    const activeTenant = this.resolveTenant(persisted);
+    const provider =
+      providers.find((entry) => entry.id === persisted.activeProviderId) ?? providers[0];
+    const providerId = provider?.id ?? persisted.activeProviderId;
+    this.requireHostedBatchConsent(input.hostedProviderConsent, preflight, provider, providerId);
+
+    const now = new Date().toISOString();
+    const jobId = `mtjob_${randomUUID()}`;
+    let job: MultiTenantChatJob = {
+      id: jobId,
+      prompt: content,
+      ...(input.savedQueryId ? { savedQueryId: input.savedQueryId } : {}),
+      tenantScope: preflight.tenantScope,
+      resolvedTenantIds: preflight.resolvedTenantIds,
+      providerId,
+      providerName: preflight.providerName,
+      providerIsLocal: preflight.providerIsLocal,
+      ...(preflight.model ? { model: preflight.model } : {}),
+      status: "running",
+      createdAt: now,
+      updatedAt: now,
+      preflight,
+      progress: preflight.tenants.map((tenant) => ({
+        tenantId: tenant.tenantId,
+        tenantName: tenant.tenantName,
+        status:
+          tenant.status === "expired" ||
+          tenant.status === "missing-scopes" ||
+          tenant.status === "throttled" ||
+          tenant.status === "failed"
+            ? "skipped"
+            : "queued",
+        detail: tenant.recovery,
+        updatedAt: now,
+      })),
+      summary: emptyMultiTenantSummary(),
+      comparisons: [],
+      deviceRows: [],
+      assistantText: "",
+      exportDossierMarkdown: "",
+    };
+    const persistJob = (eventType: "started" | "progress" = "progress") => {
+      store.upsertMultiTenantJob(job);
+      onEvent?.({ type: eventType, job });
+    };
+    const assertNotCancelled = () => {
+      if (options.signal?.aborted !== true) return;
+      job = {
+        ...job,
+        status: "cancelled",
+        error: "Stopped by user.",
+        updatedAt: new Date().toISOString(),
+      };
+      store.upsertMultiTenantJob(job);
+      onEvent?.({ type: "cancelled", job });
+      throw new Error("Multi-tenant chat run stopped.");
+    };
+    persistJob("started");
+
+    const runnable = preflight.tenants.filter(
+      (tenant) =>
+        tenant.selected &&
+        tenant.status !== "expired" &&
+        tenant.status !== "missing-scopes" &&
+        tenant.status !== "throttled" &&
+        tenant.status !== "failed" &&
+        tenant.status !== "skipped",
+    );
+    const refreshTenant = async (tenant: (typeof runnable)[number]) => {
+      const startedAt = new Date().toISOString();
+      job = updateJobTenantProgress(job, tenant.tenantId, {
+        status: input.refreshIfStale === false ? "reading-cache" : "refreshing-cache",
+        detail:
+          input.refreshIfStale === false
+            ? "Reading existing local cache."
+            : "Refreshing prompt-relevant cache.",
+        updatedAt: startedAt,
+      });
+      persistJob();
+      try {
+        assertNotCancelled();
+        if (input.refreshIfStale !== false && tenant.staleResources.length > 0) {
+          const refreshResult = await this.refreshGraphCacheInternal({
+            tenantId: tenant.tenantId,
+            resources: tenant.staleResources,
+          });
+          const failedResources = refreshResult.resources.filter((resource) => !resource.ok);
+          if (
+            failedResources.some((resource) => resource.resource === "managedDevices") ||
+            failedResources.length === refreshResult.resources.length
+          ) {
+            throw new Error(
+              failedResources
+                .map(
+                  (resource) =>
+                    `${resource.label}: ${resource.error ?? "Graph cache refresh failed."}`,
+                )
+                .join("; "),
+            );
+          }
+        }
+        job = updateJobTenantProgress(job, tenant.tenantId, {
+          status: "building-result",
+          detail: "Computing tenant result from local cache.",
+          updatedAt: new Date().toISOString(),
+        });
+        persistJob();
+      } catch (error) {
+        if (options.signal?.aborted === true) {
+          throw error;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        job = updateJobTenantProgress(job, tenant.tenantId, {
+          status: "failed",
+          detail: message,
+          updatedAt: new Date().toISOString(),
+        });
+        persistJob();
+      }
+    };
+    assertNotCancelled();
+    await runWithConcurrency(runnable, 2, refreshTenant);
+    assertNotCancelled();
+
+    const comparisons: MultiTenantTenantComparison[] = [];
+    const deviceRows: MultiTenantDeviceRow[] = [];
+    for (const tenant of preflight.tenants) {
+      if (!tenant.selected) continue;
+      const failedProgress = job.progress.find(
+        (entry) => entry.tenantId === tenant.tenantId && entry.status === "failed",
+      );
+      if (failedProgress) {
+        comparisons.push({
+          tenantId: tenant.tenantId,
+          tenantName: tenant.tenantName,
+          status: "failed",
+          windowsDevices: 0,
+          compliant: 0,
+          nonCompliant: 0,
+          unknown: 0,
+          lastRefresh: tenant.cacheFreshness,
+          warnings: [...tenant.warnings, failedProgress.detail ?? "Tenant refresh failed."],
+        });
+        continue;
+      }
+      if (!runnable.some((entry) => entry.tenantId === tenant.tenantId)) {
+        comparisons.push({
+          tenantId: tenant.tenantId,
+          tenantName: tenant.tenantName,
+          status: tenant.status,
+          windowsDevices: 0,
+          compliant: 0,
+          nonCompliant: 0,
+          unknown: 0,
+          lastRefresh: tenant.cacheFreshness,
+          warnings: tenant.warnings,
+        });
+        continue;
+      }
+      const tenantRows = store.readManagedDeviceRowsForTenant({
+        tenantId: tenant.tenantId,
+        limit: 10_000,
+      });
+      const normalizedRows = tenantRows
+        .map((entry) =>
+          normalizeMultiTenantDeviceRow({
+            row: entry.row,
+            tenantId: tenant.tenantId,
+            tenantName: tenant.tenantName,
+            sourceRefreshedAt: entry.refreshedAt,
+          }),
+        )
+        .filter((row): row is MultiTenantDeviceRow => Boolean(row));
+      const windowsRows = normalizedRows.filter((row) =>
+        row.operatingSystem.toLowerCase().includes("windows"),
+      );
+      deviceRows.push(...windowsRows);
+      comparisons.push(buildTenantComparison({
+        tenant,
+        rows: windowsRows,
+      }));
+      job = updateJobTenantProgress(job, tenant.tenantId, {
+        status: "ready",
+        detail: `${windowsRows.length.toLocaleString()} Windows device rows prepared.`,
+        updatedAt: new Date().toISOString(),
+      });
+      persistJob();
+    }
+
+    const summary = buildMultiTenantSummary(comparisons);
+    const assistantText = await this.buildMultiTenantAssistantText({
+      prompt: content,
+      providerId,
+      provider,
+      model: preflight.model,
+      summary,
+      comparisons,
+    });
+    const exportDossierMarkdown = buildMultiTenantDossierMarkdown({
+      prompt: content,
+      providerName: preflight.providerName,
+      model: preflight.model,
+      generatedAt: new Date().toISOString(),
+      summary,
+      comparisons,
+      rows: deviceRows,
+    });
+    const finalStatus =
+      comparisons.some((comparison) =>
+        ["failed", "expired", "missing-scopes", "throttled", "skipped"].includes(
+          comparison.status,
+        ),
+      )
+        ? "partial"
+        : "completed";
+    job = {
+      ...job,
+      status: finalStatus,
+      summary,
+      comparisons,
+      deviceRows,
+      assistantText,
+      exportDossierMarkdown,
+      updatedAt: new Date().toISOString(),
+    };
+
+    const conversation = store.createConversation({
+      id: `chat_${randomUUID()}`,
+      title: chatTitleForPrompt(content),
+      tenantId: activeTenant.id,
+      now,
+      scopeKind: "multi-tenant",
+      tenantScope: preflight.tenantScope,
+      multiTenantJobId: job.id,
+    });
+    job = { ...job, conversationId: conversation.id, updatedAt: new Date().toISOString() };
+    persistJob();
+    const userMessage: IntuneChatMessage = {
+      id: `msg_${randomUUID()}`,
+      conversationId: conversation.id,
+      role: "user",
+      content,
+      status: "completed",
+      createdAt: now,
+    };
+    const assistantMessage: IntuneChatMessage = {
+      id: `msg_${randomUUID()}`,
+      conversationId: conversation.id,
+      role: "assistant",
+      content: assistantText,
+      status: finalStatus === "completed" || finalStatus === "partial" ? "completed" : "failed",
+      createdAt: new Date().toISOString(),
+      providerId,
+      ...(preflight.model ? { model: preflight.model } : {}),
+      sources: [
+        {
+          resource: "managedDevices",
+          label: "Intune managed devices",
+          rows: deviceRows.length,
+          source: "cache",
+          path: "/deviceManagement/managedDevices",
+        },
+      ],
+    };
+    store.insertMessage(userMessage);
+    store.insertMessage(assistantMessage);
+    store.touchConversation(conversation.id, undefined, assistantMessage.createdAt);
+
+    const result = {
+      job,
+      conversation: store.getConversation(conversation.id) ?? conversation,
+      userMessage,
+      assistantMessage,
+    };
+    onEvent?.({ type: "completed", result });
+    return result;
+  }
+
+  async streamMultiTenantIntuneChat(
+    input: RunMultiTenantChatInput,
+    onEvent: (event: MultiTenantChatStreamEvent) => void,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<MultiTenantChatRunResult> {
+    try {
+      return await this.runMultiTenantIntuneChat(input, onEvent, options);
+    } catch (caught) {
+      if (options.signal?.aborted !== true) {
+        onEvent({
+          type: "failed",
+          error: caught instanceof Error ? caught.message : String(caught),
+        });
+      }
+      throw caught;
+    }
+  }
+
+  private buildWorkspacePromptContext(
+    input: WorkspacePromptContextInput,
+    tenantId: string,
+    persisted: PersistedState,
+  ): WorkspacePromptContextPayload {
+    const workspaceId = input.workspaceId.trim();
+    if (!workspaceId) throw new Error("Workspace context requires a workspace id.");
+    const store = this.requireIntelligenceStore();
+    const workspace = store.getWorkspace(workspaceId, tenantNamesById(persisted.tenants));
+    if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`);
+    if (workspace.tenantId !== tenantId) {
+      throw new Error("Workspace context tenant does not match the active chat tenant.");
+    }
+
+    const selectedEvidenceIds = new Set(input.evidenceIds ?? []);
+    const selectedNoteIds = new Set(input.noteIds ?? []);
+    const evidence =
+      selectedEvidenceIds.size > 0
+        ? workspace.evidence.filter((entry) => selectedEvidenceIds.has(entry.id))
+        : [];
+    const notes =
+      selectedNoteIds.size > 0
+        ? workspace.notes.filter((entry) => selectedNoteIds.has(entry.id))
+        : [];
+    const includesInstructions =
+      input.includeInstructions === true && Boolean(workspace.instructions?.trim());
+
+    if (!includesInstructions && evidence.length === 0 && notes.length === 0) {
+      throw new Error("Select workspace evidence, notes, or instructions before attaching context.");
+    }
+
+    const missingEvidence = [...selectedEvidenceIds].filter(
+      (id) => !workspace.evidence.some((entry) => entry.id === id),
+    );
+    const missingNotes = [...selectedNoteIds].filter(
+      (id) => !workspace.notes.some((entry) => entry.id === id),
+    );
+    if (missingEvidence.length > 0 || missingNotes.length > 0) {
+      throw new Error("Workspace context includes evidence or notes that no longer exist.");
+    }
+
+    const lines = [
+      "Workspace context attached by the admin.",
+      `Workspace: ${workspace.title}`,
+      `Tenant: ${workspace.tenantName ?? workspace.tenantId}`,
+    ];
+    if (includesInstructions && workspace.instructions) {
+      lines.push("", "Workspace instructions:", workspace.instructions.trim());
+    }
+    if (notes.length > 0) {
+      lines.push("", "Workspace notes:");
+      notes.slice(0, 12).forEach((note, index) => {
+        lines.push(`${index + 1}. ${trimForPrompt(note.content, 1400)}`);
+      });
+    }
+    if (evidence.length > 0) {
+      lines.push("", "Workspace evidence:");
+      evidence.slice(0, 8).forEach((entry, index) => {
+        lines.push(
+          `${index + 1}. ${entry.title} (${entry.sourceType}, ${entry.createdAt})`,
+          trimForPrompt(JSON.stringify(entry.content, null, 2), 2800),
+        );
+      });
+    }
+
+    return {
+      summary: {
+        workspaceId: workspace.id,
+        workspaceTitle: workspace.title,
+        tenantId: workspace.tenantId,
+        evidenceCount: evidence.length,
+        noteCount: notes.length,
+        includesInstructions,
+      },
+      promptBlock: lines.join("\n"),
+    };
+  }
+
+  async listMultiTenantChatJobs(): Promise<MultiTenantChatJob[]> {
+    return this.requireIntelligenceStore().listMultiTenantJobs();
+  }
+
+  async getMultiTenantChatJob(id: string): Promise<MultiTenantChatJob | undefined> {
+    if (!id.trim()) throw new Error("Multi-tenant job id is required.");
+    return this.requireIntelligenceStore().getMultiTenantJob(id);
+  }
+
+  async queueMultiTenantAgentBatch(
+    input: QueueMultiTenantAgentBatchInput,
+  ): Promise<QueueMultiTenantAgentBatchResult> {
+    const agentSlug = input.agentSlug.trim();
+    if (!agentSlug) throw new Error("Agent slug is required.");
+    const store = this.requireIntelligenceStore();
+    const persisted = await this.read();
+    const agent = persisted.installedAgents.find((entry) => entry.slug === agentSlug);
+    if (!agent) {
+      throw new Error(`Agent is not installed: ${agentSlug}`);
+    }
+    assertAgentCompatible(withAgentCompatibility(agent, this.appVersion), "run");
+
+    const prompt =
+      input.prompt?.trim() || `Run ${agent.name} against the selected tenant scope.`;
+    const preflight = await this.buildMultiTenantPreflight({
+      prompt,
+      tenantScope: input.tenantScope,
+      ...(input.savedQueryId ? { savedQueryId: input.savedQueryId } : {}),
+    });
+    const runnable = preflight.tenants.filter(
+      (tenant) =>
+        tenant.selected &&
+        tenant.status !== "expired" &&
+        tenant.status !== "missing-scopes" &&
+        tenant.status !== "throttled" &&
+        tenant.status !== "failed" &&
+        tenant.status !== "skipped",
+    );
+    if (runnable.length === 0) {
+      throw new Error("No selected tenants are ready for this agent batch.");
+    }
+
+    const now = new Date().toISOString();
+    let batch: MultiTenantAgentBatch = {
+      id: `mtbatch_${randomUUID()}`,
+      agentSlug: agent.slug,
+      agentName: agent.name,
+      agentMode: agent.mode,
+      tenantScope: preflight.tenantScope,
+      resolvedTenantIds: runnable.map((tenant) => tenant.tenantId),
+      status: "queued",
+      runIds: [],
+      createdAt: now,
+      updatedAt: now,
+      preflight,
+    };
+    store.upsertMultiTenantAgentBatch(batch);
+
+    const runs: RunRecord[] = [];
+    const failures: string[] = [];
+    for (const tenant of runnable) {
+      try {
+        const run = await this.startRun(agent.slug, {
+          tenantId: tenant.tenantId,
+          trigger: "manual",
+        });
+        runs.push(run);
+        batch = {
+          ...batch,
+          status: agent.mode === "write" ? "awaiting-confirmation" : "running",
+          runIds: runs.map((entry) => entry.id),
+          updatedAt: new Date().toISOString(),
+        };
+        store.upsertMultiTenantAgentBatch(batch);
+      } catch (caught) {
+        failures.push(
+          `${tenant.tenantName}: ${caught instanceof Error ? caught.message : String(caught)}`,
+        );
+      }
+    }
+
+    const finalStatus =
+      failures.length === 0
+        ? agent.mode === "write"
+          ? "awaiting-confirmation"
+          : "running"
+        : runs.length > 0
+          ? "partial"
+          : "failed";
+    batch = {
+      ...batch,
+      status: finalStatus,
+      runIds: runs.map((entry) => entry.id),
+      ...(failures.length > 0 ? { error: failures.join("; ") } : {}),
+      updatedAt: new Date().toISOString(),
+    };
+    store.upsertMultiTenantAgentBatch(batch);
+    return { batch, runs };
+  }
+
+  async listMultiTenantAgentBatches(): Promise<MultiTenantAgentBatch[]> {
+    return this.requireIntelligenceStore().listMultiTenantAgentBatches();
+  }
+
+  async getMultiTenantAgentBatch(
+    id: string,
+  ): Promise<MultiTenantAgentBatch | undefined> {
+    if (!id.trim()) throw new Error("Multi-tenant agent batch id is required.");
+    return this.requireIntelligenceStore().getMultiTenantAgentBatch(id);
+  }
+
+  private async buildMultiTenantPreflight(
+    input: PreflightMultiTenantChatInput,
+  ): Promise<TenantScopePreflight> {
+    const prompt = input.prompt.trim();
+    if (!prompt) throw new Error("Multi-tenant chat prompt is required.");
+    const store = this.requireIntelligenceStore();
+    const persisted = await this.read();
+    const activeTenant = this.resolveTenant(persisted);
+    if (persisted.tenants.length === 0) {
+      throw new Error("Connect at least one tenant before using multi-tenant Intune Chat.");
+    }
+    const groups = store.listTenantGroups();
+    const resolvedGroups = resolveTenantGroups(input.tenantScope, groups);
+    const resolvedTenantIds = resolveTenantScopeIds({
+      scope: input.tenantScope,
+      groups: resolvedGroups,
+      tenants: persisted.tenants,
+      activeTenantId: activeTenant.id,
+    });
+    const selectedTenantSet = new Set(resolvedTenantIds);
+    const savedQuery = input.savedQueryId
+      ? store
+          .listSavedMultiTenantQueries()
+          .find((query) => query.id === input.savedQueryId)
+      : undefined;
+    const planned = planChatContext(prompt);
+    const resourceSet = new Set<GraphCacheResourceKind>([
+      ...planned.resources,
+      ...(savedQuery?.resourceHints ?? []),
+    ]);
+    if (isWindowsCompliancePrompt(prompt)) {
+      resourceSet.add("managedDevices");
+    }
+    const resources = sanitizeGraphResources([...resourceSet]);
+    const requiredScopes = requiredScopesForResources(resources);
+    const providers = await this.listProviders();
+    const provider =
+      providers.find((entry) => entry.id === persisted.activeProviderId) ?? providers[0];
+    const providerId = provider?.id ?? persisted.activeProviderId;
+    const model = resolveProviderDefaultModel(
+      provider,
+      persisted.activeModelByProviderId,
+    ).model;
+    const now = new Date().toISOString();
+    const tenants = persisted.tenants
+      .filter((tenant) => selectedTenantSet.has(tenant.id))
+      .map((tenant) => {
+        const statusRows = store.getGraphCacheStatus(tenant.id, [...GRAPH_CACHE_RESOURCES]);
+        const relevantStatus = statusRows.filter((status) =>
+          resources.includes(status.resource),
+        );
+        const staleResources = relevantStatus
+          .filter((status) => isGraphCacheStatusStale(status))
+          .map((status) => status.resource);
+        const cacheFreshness = newestRefreshedAt(relevantStatus);
+        const errors = relevantStatus
+          .map((status) => status.lastError)
+          .filter((error): error is string => Boolean(error));
+        const missingScopes = errors.some((error) => /scope|consent|permission/i.test(error))
+          ? requiredScopes
+          : [];
+        const status = tenantReadinessStatus({
+          missingScopes,
+          staleResources,
+          errors,
+          hasRows: relevantStatus.some((entry) => entry.rows > 0),
+        });
+        return {
+          tenantId: tenant.id,
+          tenantName: tenant.displayName,
+          username: tenant.username,
+          status,
+          selected: true,
+          cacheFreshness,
+          staleResources,
+          missingScopes,
+          warnings: readinessWarnings({ status, staleResources, errors }),
+          recovery: readinessRecovery(status),
+        };
+      });
+    return {
+      id: `preflight_${randomUUID()}`,
+      prompt,
+      tenantScope: input.tenantScope,
+      resolvedTenantIds,
+      resolvedGroups,
+      resources,
+      providerId,
+      providerName: provider?.name ?? providerId,
+      providerIsLocal: provider?.isLocal !== false,
+      ...(model ? { model } : {}),
+      generatedAt: now,
+      tenants,
+      canRun:
+        tenants.length > 0 &&
+        tenants.some((tenant) =>
+          tenant.status === "ready" || tenant.status === "stale",
+        ),
+    };
+  }
+
+  private requireHostedBatchConsent(
+    consent: HostedProviderBatchConsent | undefined,
+    preflight: TenantScopePreflight,
+    provider: ProviderSummary | undefined,
+    providerId: ProviderId,
+  ): void {
+    if (provider?.isLocal !== false) return;
+    if (!consent) {
+      throw new Error(
+        "Hosted provider confirmation is required before multi-tenant chat can send tenant context to the selected provider.",
+      );
+    }
+    if (consent.providerId !== providerId) {
+      throw new Error("Hosted provider confirmation does not match the selected provider.");
+    }
+    const expected = new Set(preflight.resolvedTenantIds);
+    const acknowledged = new Set(consent.tenantIds);
+    for (const tenantId of expected) {
+      if (!acknowledged.has(tenantId)) {
+        throw new Error("Hosted provider confirmation does not cover every selected tenant.");
+      }
+    }
+    const acknowledgedAt = Date.parse(consent.acknowledgedAt);
+    const now = Date.now();
+    if (
+      !Number.isFinite(acknowledgedAt) ||
+      now - acknowledgedAt > 5 * 60 * 1000 ||
+      acknowledgedAt - now > 60 * 1000
+    ) {
+      throw new Error("Hosted provider confirmation expired. Confirm the batch again.");
+    }
+  }
+
+  private async buildMultiTenantAssistantText(input: {
+    prompt: string;
+    providerId: ProviderId;
+    provider: ProviderSummary | undefined;
+    model?: string;
+    summary: MultiTenantChatJob["summary"];
+    comparisons: MultiTenantChatJob["comparisons"];
+  }): Promise<string> {
+    const deterministic = summarizeMultiTenantResult(input.summary, input.comparisons);
+    const llm = await this.buildLlm(input.providerId, input.model);
+    if (!llm.available) return deterministic;
+    try {
+      const completion = await llm.complete({
+        system: buildIntuneChatSystemPrompt(input.provider?.isLocal === true),
+        prompt: [
+          "Summarize this read-only multi-tenant Intune Chat result for an admin.",
+          "The JSON table is the source of truth. Mention partial, failed, skipped, or stale tenants.",
+          `Question: ${input.prompt}`,
+          JSON.stringify(
+            {
+              summary: input.summary,
+              tenants: input.comparisons,
+            },
+            null,
+            2,
+          ),
+        ].join("\n\n"),
+        ...(input.model ? { model: input.model } : {}),
+        temperature: 0.2,
+        maxTokens: 700,
+      });
+      return completion.text.trim() || deterministic;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return `${deterministic}\n\nThe selected LLM provider failed while summarizing this multi-tenant result. ${message}`;
+    }
+  }
+
   async getGraphCacheStatus(tenantId?: string): Promise<GraphCacheStatus> {
     const persisted = await this.read();
     const resolvedTenant = this.resolveTenant(persisted, tenantId);
@@ -1194,13 +1938,25 @@ export class AppStateStore {
       persisted.activeModelByProviderId,
     ).model;
     const chatBudget = intuneChatProviderBudget(providerId);
-    this.requireHostedChatConsent(input, tenant, provider, providerId);
+    const workspaceContext = input.workspaceContext
+      ? this.buildWorkspacePromptContext(input.workspaceContext, tenant.id, persisted)
+      : undefined;
+    this.requireHostedChatConsent(
+      input,
+      tenant,
+      provider,
+      providerId,
+      workspaceContext?.summary,
+    );
     const planned = planChatContext(content);
     const now = new Date().toISOString();
 
     let conversation = input.conversationId
       ? store.getConversation(input.conversationId)
       : undefined;
+    if (conversation) {
+      assertConversationTenant(conversation, tenant.id);
+    }
     if (!conversation) {
       conversation = store.createConversation({
         id: `chat_${randomUUID()}`,
@@ -1282,8 +2038,11 @@ export class AppStateStore {
         "No LLM provider is connected. Start Ollama or choose another provider in Settings, then try again.";
       assistantContent = assistantError;
     } else {
+      const modelQuestion = workspaceContext
+        ? `${content}\n\n${workspaceContext.promptBlock}`
+        : content;
       const answerPack = buildAnswerPack({
-        question: content,
+        question: modelQuestion,
         tenant,
         cacheStatus,
         rows,
@@ -1369,13 +2128,25 @@ export class AppStateStore {
       persisted.activeModelByProviderId,
     ).model;
     const chatBudget = intuneChatProviderBudget(providerId);
-    this.requireHostedChatConsent(input, tenant, provider, providerId);
+    const workspaceContext = input.workspaceContext
+      ? this.buildWorkspacePromptContext(input.workspaceContext, tenant.id, persisted)
+      : undefined;
+    this.requireHostedChatConsent(
+      input,
+      tenant,
+      provider,
+      providerId,
+      workspaceContext?.summary,
+    );
     const planned = planChatContext(content);
     const now = new Date().toISOString();
 
     let conversation = input.conversationId
       ? store.getConversation(input.conversationId)
       : undefined;
+    if (conversation) {
+      assertConversationTenant(conversation, tenant.id);
+    }
     if (!conversation) {
       conversation = store.createConversation({
         id: `chat_${randomUUID()}`,
@@ -1611,8 +2382,11 @@ export class AppStateStore {
         "No LLM provider is connected. Start Ollama or choose another provider in Settings, then try again.";
       assistantContent = assistantError;
     } else {
+      const modelQuestion = workspaceContext
+        ? `${content}\n\n${workspaceContext.promptBlock}`
+        : content;
       const answerPack = buildAnswerPack({
-        question: content,
+        question: modelQuestion,
         tenant,
         cacheStatus,
         rows,
@@ -1766,6 +2540,7 @@ export class AppStateStore {
     tenant: TenantRecord,
     provider: ProviderSummary | undefined,
     providerId: ProviderId,
+    workspaceContext?: WorkspacePromptContextSummary,
   ): void {
     if (provider?.isLocal !== false) {
       return;
@@ -1793,6 +2568,24 @@ export class AppStateStore {
     ) {
       throw new Error(
         "Hosted provider confirmation expired. Confirm the chat send again.",
+      );
+    }
+
+    if (!workspaceContext) {
+      return;
+    }
+
+    const acknowledgedWorkspace = consent.workspaceContext;
+    if (
+      !acknowledgedWorkspace ||
+      acknowledgedWorkspace.workspaceId !== workspaceContext.workspaceId ||
+      acknowledgedWorkspace.tenantId !== workspaceContext.tenantId ||
+      acknowledgedWorkspace.evidenceCount !== workspaceContext.evidenceCount ||
+      acknowledgedWorkspace.noteCount !== workspaceContext.noteCount ||
+      acknowledgedWorkspace.includesInstructions !== workspaceContext.includesInstructions
+    ) {
+      throw new Error(
+        "Hosted provider confirmation does not include the attached workspace context. Confirm the chat send again.",
       );
     }
   }
@@ -1842,6 +2635,200 @@ export class AppStateStore {
     });
     await this.writeSelfTrainingFile(tenantId, input.agentSlug);
     return reset;
+  }
+
+  async listWorkspaces(tenantId?: string): Promise<WorkspaceSummary[]> {
+    const persisted = await this.read();
+    const resolvedTenant = tenantId ? this.resolveTenant(persisted, tenantId) : undefined;
+    return this.requireIntelligenceStore().listWorkspaces(
+      tenantNamesById(persisted.tenants),
+      resolvedTenant?.id,
+    );
+  }
+
+  async getWorkspace(id: string): Promise<WorkspaceDetail | undefined> {
+    if (!id.trim()) throw new Error("Workspace id is required.");
+    const persisted = await this.read();
+    return this.requireIntelligenceStore().getWorkspace(
+      id,
+      tenantNamesById(persisted.tenants),
+    );
+  }
+
+  async createWorkspace(input: CreateWorkspaceInput): Promise<WorkspaceDetail> {
+    const persisted = await this.read();
+    const tenant = this.resolveTenant(persisted, input.tenantId);
+    return this.requireIntelligenceStore().createWorkspace({
+      id: `wksp_${randomUUID()}`,
+      tenantId: tenant.id,
+      tenantName: tenant.displayName,
+      title: normalizeWorkspaceTitle(input.title),
+      ...(input.instructions ? { instructions: normalizeWorkspaceInstructions(input.instructions) } : {}),
+      now: new Date().toISOString(),
+      ...(input.conversationId ? { conversationId: input.conversationId } : {}),
+    });
+  }
+
+  async updateWorkspace(
+    id: string,
+    input: UpdateWorkspaceInput,
+  ): Promise<WorkspaceDetail> {
+    if (!id.trim()) throw new Error("Workspace id is required.");
+    const persisted = await this.read();
+    return this.requireIntelligenceStore().updateWorkspace({
+      id,
+      ...(input.title !== undefined ? { title: normalizeWorkspaceTitle(input.title) } : {}),
+      ...(input.instructions !== undefined
+        ? { instructions: normalizeWorkspaceInstructions(input.instructions) }
+        : {}),
+      ...(input.status !== undefined ? { status: input.status } : {}),
+      now: new Date().toISOString(),
+      tenantNames: tenantNamesById(persisted.tenants),
+    });
+  }
+
+  async archiveWorkspace(id: string): Promise<WorkspaceSummary> {
+    if (!id.trim()) throw new Error("Workspace id is required.");
+    const persisted = await this.read();
+    return this.requireIntelligenceStore().archiveWorkspace(
+      id,
+      new Date().toISOString(),
+      tenantNamesById(persisted.tenants),
+    );
+  }
+
+  async deleteWorkspace(id: string): Promise<void> {
+    if (!id.trim()) throw new Error("Workspace id is required.");
+    this.requireIntelligenceStore().deleteWorkspace(id);
+  }
+
+  async addWorkspaceNote(workspaceId: string, content: string): Promise<WorkspaceNote> {
+    if (!workspaceId.trim()) throw new Error("Workspace id is required.");
+    const trimmed = content.trim();
+    if (!trimmed) throw new Error("Workspace note content is required.");
+    return this.requireIntelligenceStore().addWorkspaceNote({
+      id: `wnote_${randomUUID()}`,
+      workspaceId,
+      content: trimmed,
+      now: new Date().toISOString(),
+    });
+  }
+
+  async updateWorkspaceNote(noteId: string, content: string): Promise<WorkspaceNote> {
+    if (!noteId.trim()) throw new Error("Workspace note id is required.");
+    const trimmed = content.trim();
+    if (!trimmed) throw new Error("Workspace note content is required.");
+    return this.requireIntelligenceStore().updateWorkspaceNote(
+      noteId,
+      trimmed,
+      new Date().toISOString(),
+    );
+  }
+
+  async pinWorkspaceEvidence(
+    input: PinWorkspaceEvidenceInput,
+  ): Promise<WorkspaceEvidence> {
+    const persisted = await this.read();
+    const tenant = this.resolveTenant(persisted, input.tenantId);
+    return this.requireIntelligenceStore().pinWorkspaceEvidence({
+      id: `wev_${randomUUID()}`,
+      workspaceId: input.workspaceId,
+      tenantId: tenant.id,
+      title: normalizeWorkspaceTitle(input.title),
+      sourceType: input.sourceType,
+      ...(input.sourceRef ? { sourceRef: input.sourceRef } : {}),
+      content: input.content,
+      ...(input.freshness ? { freshness: input.freshness } : {}),
+      now: new Date().toISOString(),
+    });
+  }
+
+  async linkWorkspaceConversation(
+    workspaceId: string,
+    conversationId: string,
+  ): Promise<WorkspaceLink> {
+    const persisted = await this.read();
+    const store = this.requireIntelligenceStore();
+    const workspace = store.getWorkspace(workspaceId, tenantNamesById(persisted.tenants));
+    if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`);
+    const conversation = store.getConversation(conversationId);
+    if (!conversation) throw new Error(`Conversation not found: ${conversationId}`);
+    if (conversation.scopeKind === "multi-tenant") {
+      throw new Error("Multi-tenant conversations cannot be linked directly to one workspace. Split the result into tenant-specific evidence instead.");
+    }
+    if (conversation.tenantId && conversation.tenantId !== workspace.tenantId) {
+      throw new Error("Conversation tenant does not match the workspace tenant.");
+    }
+    return store.linkWorkspaceConversation({
+      id: `wlink_${randomUUID()}`,
+      workspaceId,
+      tenantId: workspace.tenantId,
+      conversationId,
+      title: conversation.title,
+      now: new Date().toISOString(),
+    });
+  }
+
+  async linkWorkspaceRun(workspaceId: string, runId: string): Promise<WorkspaceLink> {
+    const persisted = await this.read();
+    const store = this.requireIntelligenceStore();
+    const workspace = store.getWorkspace(workspaceId, tenantNamesById(persisted.tenants));
+    if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`);
+    const run = persisted.runs.find((entry) => entry.id === runId);
+    if (!run) throw new Error(`Run not found: ${runId}`);
+    if (run.tenantId && run.tenantId !== workspace.tenantId) {
+      throw new Error("Run tenant does not match the workspace tenant.");
+    }
+    return store.linkWorkspaceRun({
+      id: `wlink_${randomUUID()}`,
+      workspaceId,
+      tenantId: workspace.tenantId,
+      runId,
+      title: run.summary ?? run.agentSlug,
+      now: new Date().toISOString(),
+    });
+  }
+
+  async importMultiTenantResultToWorkspaces(
+    input: ImportMultiTenantResultToWorkspacesInput,
+  ): Promise<ImportMultiTenantResultToWorkspacesResult> {
+    const persisted = await this.read();
+    const store = this.requireIntelligenceStore();
+    const job = store.getMultiTenantJob(input.jobId);
+    if (!job) throw new Error(`Multi-tenant job not found: ${input.jobId}`);
+    const resolvedTenantIds = new Set(job.resolvedTenantIds);
+    for (const mapping of input.tenantMappings) {
+      if (!resolvedTenantIds.has(mapping.tenantId)) {
+        throw new Error(`Tenant ${mapping.tenantId} is not part of this multi-tenant result.`);
+      }
+      if (mapping.workspaceId) {
+        const workspace = store.getWorkspace(
+          mapping.workspaceId,
+          tenantNamesById(persisted.tenants),
+        );
+        if (!workspace) throw new Error(`Workspace not found: ${mapping.workspaceId}`);
+        if (workspace.tenantId !== mapping.tenantId) {
+          throw new Error("Target workspace tenant does not match the imported tenant.");
+        }
+      }
+    }
+    return store.importMultiTenantResultToWorkspaces({
+      job,
+      tenantNames: tenantNamesById(persisted.tenants),
+      mappings: input.tenantMappings,
+      createWorkspaceId: () => `wksp_${randomUUID()}`,
+      createEvidenceId: () => `wev_${randomUUID()}`,
+      now: new Date().toISOString(),
+    });
+  }
+
+  async exportWorkspaceDossier(id: string): Promise<string> {
+    if (!id.trim()) throw new Error("Workspace id is required.");
+    const persisted = await this.read();
+    return this.requireIntelligenceStore().exportWorkspaceDossier(
+      id,
+      tenantNamesById(persisted.tenants),
+    );
   }
 
   async listConnectors(): Promise<ConnectorSummary[]> {
@@ -6722,6 +7709,12 @@ function truncateForDelivery(value: string, maxLength: number): string {
   return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
 }
 
+function trimForPrompt(value: string, maxLength: number): string {
+  const normalized = value.replace(/\r\n/g, "\n").trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxLength - 32)).trimEnd()}\n[truncated locally]`;
+}
+
 function whatsappWebStatusToConnectorStatus(
   status: WhatsAppWebStatus,
 ): ConnectorSummary["status"] {
@@ -8325,6 +9318,362 @@ function sanitizeGraphResources(
     : GRAPH_CACHE_RESOURCES.map((entry) => entry.resource)
   ).filter((resource): resource is GraphCacheResourceKind => allowed.has(resource));
   return [...new Set(selected)];
+}
+
+function tenantNamesById(tenants: TenantRecord[]): Map<string, string> {
+  return new Map(tenants.map((tenant) => [tenant.id, tenant.displayName]));
+}
+
+function normalizeTenantGroupName(name: string): string {
+  const trimmed = name.trim().replace(/\s+/g, " ");
+  if (!trimmed) throw new Error("Tenant group name is required.");
+  if (trimmed.length > 80) throw new Error("Tenant group name is too long.");
+  return trimmed;
+}
+
+function normalizeWorkspaceTitle(title: string): string {
+  const trimmed = title.trim().replace(/\s+/g, " ");
+  if (!trimmed) throw new Error("Workspace title is required.");
+  if (trimmed.length > 140) throw new Error("Workspace title is too long.");
+  return trimmed;
+}
+
+function normalizeWorkspaceInstructions(instructions: string): string {
+  const trimmed = instructions.trim();
+  if (trimmed.length > 10_000) {
+    throw new Error("Workspace instructions are too long.");
+  }
+  return trimmed;
+}
+
+function resolveTenantGroups(scope: TenantScope, groups: TenantGroup[]): TenantGroup[] {
+  const groupIds = new Set(
+    scope.kind === "selected" || scope.kind === "all" ? scope.groupIds ?? [] : [],
+  );
+  return groups.filter((group) => groupIds.has(group.id));
+}
+
+function resolveTenantScopeIds(input: {
+  scope: TenantScope;
+  groups: TenantGroup[];
+  tenants: TenantRecord[];
+  activeTenantId?: string;
+}): string[] {
+  const known = new Set(input.tenants.map((tenant) => tenant.id));
+  if (input.scope.kind === "all") {
+    return input.tenants.map((tenant) => tenant.id);
+  }
+  const selected = new Set<string>();
+  if (input.scope.kind === "active") {
+    if (input.activeTenantId && known.has(input.activeTenantId)) {
+      selected.add(input.activeTenantId);
+    }
+  } else {
+    for (const tenantId of input.scope.tenantIds) {
+      if (!known.has(tenantId)) throw new Error(`Unknown tenant selected: ${tenantId}`);
+      selected.add(tenantId);
+    }
+  }
+  for (const group of input.groups) {
+    for (const tenantId of group.tenantIds) {
+      if (known.has(tenantId)) selected.add(tenantId);
+    }
+  }
+  return [...selected];
+}
+
+function isWindowsCompliancePrompt(prompt: string): boolean {
+  return /\b(windows|device|devices|compliant|non-?compliant|compliance)\b/i.test(prompt);
+}
+
+function isGraphCacheStatusStale(status: GraphCacheResourceStatus): boolean {
+  if (status.lastError) return false;
+  if (!status.refreshedAt || status.rows === 0) return true;
+  const refreshedMs = Date.parse(status.refreshedAt);
+  if (!Number.isFinite(refreshedMs)) return true;
+  return Date.now() - refreshedMs > 6 * 60 * 60 * 1000;
+}
+
+function newestRefreshedAt(statuses: GraphCacheResourceStatus[]): string | undefined {
+  return statuses
+    .map((status) => status.refreshedAt)
+    .filter((value): value is string => Boolean(value))
+    .sort()
+    .at(-1);
+}
+
+function tenantReadinessStatus(input: {
+  missingScopes: string[];
+  staleResources: GraphCacheResourceKind[];
+  errors: string[];
+  hasRows: boolean;
+}): TenantReadinessStatus {
+  if (input.missingScopes.length > 0) return "missing-scopes";
+  if (input.errors.some((error) => /throttl|429|too many requests/i.test(error))) {
+    return "throttled";
+  }
+  if (input.errors.some((error) => /expired|interaction required|login/i.test(error))) {
+    return "expired";
+  }
+  if (input.errors.length > 0 && !input.hasRows) return "failed";
+  if (input.staleResources.length > 0 || !input.hasRows) return "stale";
+  return "ready";
+}
+
+function readinessWarnings(input: {
+  status: TenantReadinessStatus;
+  staleResources: GraphCacheResourceKind[];
+  errors: string[];
+}): string[] {
+  const warnings: string[] = [];
+  if (input.status === "stale") {
+    warnings.push(
+      input.staleResources.length > 0
+        ? `${input.staleResources.length} resource cache needs refresh.`
+        : "No local cache rows yet.",
+    );
+  }
+  if (input.errors.length > 0) warnings.push(input.errors[0]!);
+  return warnings;
+}
+
+function readinessRecovery(status: TenantReadinessStatus): string {
+  const copy: Record<TenantReadinessStatus, string> = {
+    ready: "Ready to run.",
+    stale: "Run can refresh cache before answering.",
+    expired: "Reconnect this tenant before including it.",
+    "missing-scopes": "Grant the missing delegated Graph scopes, then retry.",
+    throttled: "Wait for Microsoft Graph throttling to clear or remove this tenant.",
+    skipped: "Tenant is skipped for this run.",
+    failed: "Review the cached error or remove this tenant from the run.",
+  };
+  return copy[status];
+}
+
+function emptyMultiTenantSummary(): MultiTenantChatJob["summary"] {
+  return {
+    tenantsScanned: 0,
+    failedTenants: 0,
+    skippedTenants: 0,
+    staleTenants: 0,
+    windowsDevices: 0,
+    compliant: 0,
+    nonCompliant: 0,
+    unknown: 0,
+  };
+}
+
+function updateJobTenantProgress(
+  job: MultiTenantChatJob,
+  tenantId: string,
+  patch: Partial<MultiTenantChatJob["progress"][number]>,
+): MultiTenantChatJob {
+  return {
+    ...job,
+    progress: job.progress.map((entry) =>
+      entry.tenantId === tenantId ? { ...entry, ...patch } : entry,
+    ),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+async function runWithConcurrency<T>(
+  items: T[],
+  limit: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  let index = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (index < items.length) {
+      const item = items[index];
+      index += 1;
+      if (item !== undefined) {
+        await worker(item);
+      }
+    }
+  });
+  await Promise.all(workers);
+}
+
+function normalizeMultiTenantDeviceRow(input: {
+  row: unknown;
+  tenantId: string;
+  tenantName: string;
+  sourceRefreshedAt?: string;
+}): MultiTenantDeviceRow | undefined {
+  if (!isRecord(input.row)) return undefined;
+  const deviceName = stringValue(input.row.deviceName) ?? stringValue(input.row.displayName);
+  const operatingSystem = stringValue(input.row.operatingSystem) ?? "Unknown";
+  if (!deviceName) return undefined;
+  const lastSyncDateTime = stringValue(input.row.lastSyncDateTime);
+  const stale = lastSyncDateTime
+    ? Date.now() - Date.parse(lastSyncDateTime) > 7 * 24 * 60 * 60 * 1000
+    : true;
+  return {
+    tenantId: input.tenantId,
+    tenantName: input.tenantName,
+    deviceId: stringValue(input.row.id),
+    deviceName,
+    complianceState:
+      stringValue(input.row.complianceState) ??
+      stringValue(input.row.complianceStatus) ??
+      "unknown",
+    operatingSystem,
+    osVersion: stringValue(input.row.osVersion),
+    lastSyncDateTime,
+    owner:
+      stringValue(input.row.userPrincipalName) ??
+      stringValue(input.row.emailAddress) ??
+      stringValue(input.row.owner),
+    sourceRefreshedAt: input.sourceRefreshedAt,
+    stale,
+  };
+}
+
+function buildTenantComparison(input: {
+  tenant: TenantScopePreflight["tenants"][number];
+  rows: MultiTenantDeviceRow[];
+}): MultiTenantTenantComparison {
+  let compliant = 0;
+  let nonCompliant = 0;
+  let unknown = 0;
+  for (const row of input.rows) {
+    const state = normalizeComplianceState(row.complianceState);
+    if (state === "compliant") compliant += 1;
+    else if (state === "non-compliant") nonCompliant += 1;
+    else unknown += 1;
+  }
+  return {
+    tenantId: input.tenant.tenantId,
+    tenantName: input.tenant.tenantName,
+    status: input.tenant.status === "stale" ? "stale" : "ready",
+    windowsDevices: input.rows.length,
+    compliant,
+    nonCompliant,
+    unknown,
+    lastRefresh: newestString(input.rows.map((row) => row.sourceRefreshedAt)),
+    warnings: input.tenant.warnings,
+  };
+}
+
+function normalizeComplianceState(value: string): "compliant" | "non-compliant" | "unknown" {
+  const normalized = value.toLowerCase().replace(/[\s_]+/g, "-");
+  if (normalized === "compliant") return "compliant";
+  if (normalized === "noncompliant" || normalized === "non-compliant") {
+    return "non-compliant";
+  }
+  return "unknown";
+}
+
+function buildMultiTenantSummary(
+  comparisons: MultiTenantTenantComparison[],
+): MultiTenantChatJob["summary"] {
+  return comparisons.reduce(
+    (summary, tenant) => ({
+      tenantsScanned: summary.tenantsScanned + 1,
+      failedTenants:
+        summary.failedTenants +
+        (["failed", "expired", "missing-scopes", "throttled"].includes(tenant.status)
+          ? 1
+          : 0),
+      skippedTenants: summary.skippedTenants + (tenant.status === "skipped" ? 1 : 0),
+      staleTenants: summary.staleTenants + (tenant.status === "stale" ? 1 : 0),
+      windowsDevices: summary.windowsDevices + tenant.windowsDevices,
+      compliant: summary.compliant + tenant.compliant,
+      nonCompliant: summary.nonCompliant + tenant.nonCompliant,
+      unknown: summary.unknown + tenant.unknown,
+    }),
+    emptyMultiTenantSummary(),
+  );
+}
+
+function buildMultiTenantDossierMarkdown(input: {
+  prompt: string;
+  providerName: string;
+  model?: string;
+  generatedAt: string;
+  summary: MultiTenantChatJob["summary"];
+  comparisons: MultiTenantTenantComparison[];
+  rows: MultiTenantDeviceRow[];
+}): string {
+  const lines = [
+    "# Multi-tenant Intune Chat dossier",
+    "",
+    `Generated: ${input.generatedAt}`,
+    `Provider: ${input.providerName}${input.model ? ` · ${input.model}` : ""}`,
+    `Query: ${input.prompt}`,
+    "",
+    "## Summary",
+    "",
+    `- Tenants scanned: ${input.summary.tenantsScanned}`,
+    `- Failed tenants: ${input.summary.failedTenants}`,
+    `- Stale tenants: ${input.summary.staleTenants}`,
+    `- Windows devices: ${input.summary.windowsDevices}`,
+    `- Compliant: ${input.summary.compliant}`,
+    `- Non-compliant: ${input.summary.nonCompliant}`,
+    `- Unknown: ${input.summary.unknown}`,
+    "",
+    "## Tenant Comparison",
+    "",
+    "| Tenant | Status | Windows | Compliant | Non-compliant | Unknown | Last refresh |",
+    "| --- | --- | ---: | ---: | ---: | ---: | --- |",
+  ];
+  for (const tenant of input.comparisons) {
+    lines.push(
+      `| ${tenant.tenantName} | ${tenant.status} | ${tenant.windowsDevices} | ${tenant.compliant} | ${tenant.nonCompliant} | ${tenant.unknown} | ${tenant.lastRefresh ?? "unknown"} |`,
+    );
+  }
+  lines.push("", "## Device Rows", "");
+  lines.push("| Tenant | Device | Compliance | OS | OS version | Last sync | Owner |");
+  lines.push("| --- | --- | --- | --- | --- | --- | --- |");
+  for (const row of input.rows) {
+    lines.push(
+      `| ${row.tenantName} | ${row.deviceName} | ${row.complianceState} | ${row.operatingSystem} | ${row.osVersion ?? ""} | ${row.lastSyncDateTime ?? ""} | ${row.owner ?? ""} |`,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function summarizeMultiTenantResult(
+  summary: MultiTenantChatJob["summary"],
+  comparisons: MultiTenantTenantComparison[],
+): string {
+  const caveats = comparisons
+    .filter((tenant) => tenant.status !== "ready")
+    .map((tenant) => `${tenant.tenantName}: ${tenant.status}`);
+  const caveatText =
+    caveats.length > 0
+      ? ` Caveats: ${caveats.join("; ")}.`
+      : " No tenant failures were recorded.";
+  return `Across ${summary.tenantsScanned} tenant${summary.tenantsScanned === 1 ? "" : "s"}, cached Intune data shows ${summary.windowsDevices} Windows devices: ${summary.compliant} compliant, ${summary.nonCompliant} non-compliant, and ${summary.unknown} unknown.${caveatText}`;
+}
+
+function assertConversationTenant(
+  conversation: IntuneChatConversation,
+  activeTenantId: string,
+): void {
+  if (conversation.scopeKind === "multi-tenant") {
+    throw new Error(
+      "This is a multi-tenant result conversation. Start a new active-tenant conversation for follow-up prompts.",
+    );
+  }
+  if (conversation.tenantId && conversation.tenantId !== activeTenantId) {
+    throw new Error(
+      "This conversation belongs to a different tenant. Switch to that tenant or start a new conversation.",
+    );
+  }
+}
+
+function newestString(values: (string | undefined)[]): string | undefined {
+  return values.filter((value): value is string => Boolean(value)).sort().at(-1);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function readPlannedChatRows(

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openadminos/desktop",
   "private": true,
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Open-source, local-first agents for Microsoft 365 admins.",
   "author": {
     "name": "OpenAdminOS",
@@ -26,9 +26,9 @@
   },
   "dependencies": {
     "@microsoft/mxc-sdk": "0.6.1",
-    "@openadminos/agent-sdk": "0.2.4",
-    "@openadminos/connector-whatsapp-web": "0.2.4",
-    "@openadminos/runtime": "0.2.4",
+    "@openadminos/agent-sdk": "0.2.5",
+    "@openadminos/connector-whatsapp-web": "0.2.5",
+    "@openadminos/runtime": "0.2.5",
     "electron-updater": "^6.6.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -10,6 +10,7 @@ const AgentDetail = lazy(() => import("./pages/AgentDetail"));
 const AgentHub = lazy(() => import("./pages/AgentHub"));
 const Activity = lazy(() => import("./pages/Activity"));
 const IntuneChat = lazy(() => import("./pages/IntuneChat"));
+const Workspaces = lazy(() => import("./pages/Workspaces"));
 const Connectors = lazy(() => import("./pages/Connectors"));
 const Settings = lazy(() => import("./pages/Settings"));
 const Onboarding = lazy(() => import("./pages/Onboarding"));
@@ -81,6 +82,7 @@ export default function App() {
           <Route path="/agents/:slug" element={<AgentDetail />} />
           <Route path="/hub" element={<AgentHub />} />
           <Route path="/chat" element={<IntuneChat />} />
+          <Route path="/workspaces" element={<Workspaces />} />
           <Route path="/connectors" element={<Connectors />} />
           <Route path="/activity" element={<Activity />} />
           <Route path="/runs/:id" element={<RunResult />} />

--- a/apps/desktop/src/components/Button.tsx
+++ b/apps/desktop/src/components/Button.tsx
@@ -39,7 +39,7 @@ export function Button({
   return (
     <button
       {...rest}
-      className={`inline-flex items-center justify-center whitespace-nowrap font-medium transition-colors duration-150 disabled:cursor-not-allowed disabled:opacity-50 ${variants[variant]} ${sizes[size]} ${className}`}
+      className={`inline-flex items-center justify-center whitespace-nowrap font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]/70 disabled:cursor-not-allowed disabled:opacity-50 ${variants[variant]} ${sizes[size]} ${className}`}
     >
       {leadingIcon ? (
         <span aria-hidden="true" className="inline-flex shrink-0">

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
   IconActivity,
   IconChat,
   IconConnectors,
+  IconHardDrive,
   IconSettings,
   IconLogo,
   IconCommand,
@@ -108,6 +109,7 @@ export function Sidebar({ onOpenPalette }: { onOpenPalette?: () => void }) {
     },
     { to: "/hub", label: "Agent Hub", icon: <IconHub size={16} /> },
     { to: "/chat", label: "Intune Chat", icon: <IconChat size={16} /> },
+    { to: "/workspaces", label: "Workspaces", icon: <IconHardDrive size={16} /> },
     { to: "/connectors", label: "Connectors", icon: <IconConnectors size={16} /> },
     {
       to: "/activity",

--- a/apps/desktop/src/pages/IntuneChat.tsx
+++ b/apps/desktop/src/pages/IntuneChat.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
 import { useNavigate } from "react-router";
 import { Button } from "../components/Button";
 import { Modal, ModalHeader } from "../components/Modal";
@@ -14,6 +14,7 @@ import {
   IconCheck,
   IconClose,
   IconDownload,
+  IconHardDrive,
   IconPlay,
   IconPlus,
   IconSearch,
@@ -25,14 +26,27 @@ import {
   resolveProviderDefaultModel,
   type GraphCacheStatus,
   type GraphCacheResourceKind,
+  type ImportMultiTenantResultToWorkspacesResult,
   type IntuneChatAgentSuggestion,
   type IntuneChatConversation,
   type IntuneChatMessage,
   type IntuneChatProgressStep,
   type IntuneChatSource,
   type IntuneChatStreamEvent,
+  type MultiTenantChatJob,
+  type MultiTenantChatStreamEvent,
+  type SavedMultiTenantQuery,
+  type TenantRecord,
+  type TenantGroup,
+  type TenantScope,
+  type TenantScopePreflight,
+  type RunMultiTenantChatInput,
   type ProviderId,
   type SendIntuneChatMessageInput,
+  type WorkspaceDetail,
+  type WorkspacePromptContextInput,
+  type WorkspacePromptContextSummary,
+  type WorkspaceSummary,
 } from "../shared/openAdminOS";
 import { copyTextToClipboard } from "../shared/clipboard";
 
@@ -112,14 +126,41 @@ type HostedChatConsentPrompt = {
   providerId: ProviderId;
   providerName: string;
   model?: string;
+  workspaceContext?: WorkspacePromptContextInput;
+  workspaceContextSummary?: WorkspacePromptContextSummary;
 };
 
 type HostedProviderConsentInput = NonNullable<
   SendIntuneChatMessageInput["hostedProviderConsent"]
 >;
 
+type MultiTenantScopeMode = "active" | "selected" | "all";
+
+type MultiTenantFilterState = {
+  tenantId: string;
+  complianceState: string;
+  readiness: string;
+  os: string;
+  staleOnly: boolean;
+};
+
+const defaultMultiTenantFilters: MultiTenantFilterState = {
+  tenantId: "all",
+  complianceState: "all",
+  readiness: "all",
+  os: "all",
+  staleOnly: false,
+};
+
+type HostedBatchConsentPrompt = {
+  preflight: TenantScopePreflight;
+  content: string;
+};
+
+const focusRingClass =
+  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-accent)]";
 const collapsedRailControlClass =
-  "grid h-9 w-9 place-items-center rounded-full text-center leading-none transition-colors";
+  `grid h-9 w-9 place-items-center rounded-full text-center leading-none transition-colors ${focusRingClass}`;
 
 export default function IntuneChat() {
   const navigate = useNavigate();
@@ -144,6 +185,39 @@ export default function IntuneChat() {
   const [hostedConsentPrompt, setHostedConsentPrompt] =
     useState<HostedChatConsentPrompt | null>(null);
   const [rememberHostedConsent, setRememberHostedConsent] = useState(true);
+  const [tenantGroups, setTenantGroups] = useState<TenantGroup[]>([]);
+  const [savedQueries, setSavedQueries] = useState<SavedMultiTenantQuery[]>([]);
+  const [scopeMode, setScopeMode] = useState<MultiTenantScopeMode>("active");
+  const [selectedTenantIds, setSelectedTenantIds] = useState<string[]>([]);
+  const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>([]);
+  const [selectedSavedQueryId, setSelectedSavedQueryId] = useState<string>("");
+  const [multiTenantPreflight, setMultiTenantPreflight] =
+    useState<TenantScopePreflight | null>(null);
+  const [preflightPrompt, setPreflightPrompt] = useState("");
+  const [runningMultiTenant, setRunningMultiTenant] = useState(false);
+  const [activeMultiTenantJob, setActiveMultiTenantJob] =
+    useState<MultiTenantChatJob | null>(null);
+  const [hostedBatchConsentPrompt, setHostedBatchConsentPrompt] =
+    useState<HostedBatchConsentPrompt | null>(null);
+  const [multiTenantJobsByConversationId, setMultiTenantJobsByConversationId] =
+    useState<Record<string, MultiTenantChatJob>>({});
+  const [multiTenantFilters, setMultiTenantFilters] =
+    useState<MultiTenantFilterState>(defaultMultiTenantFilters);
+  const [expandedTenantIds, setExpandedTenantIds] = useState<string[]>([]);
+  const [splitJob, setSplitJob] = useState<MultiTenantChatJob | null>(null);
+  const [splitResult, setSplitResult] =
+    useState<ImportMultiTenantResultToWorkspacesResult | null>(null);
+  const [workspaces, setWorkspaces] = useState<WorkspaceSummary[]>([]);
+  const [attachedWorkspaceId, setAttachedWorkspaceId] = useState("");
+  const [attachedWorkspace, setAttachedWorkspace] = useState<WorkspaceDetail | null>(null);
+  const [selectedWorkspaceEvidenceIds, setSelectedWorkspaceEvidenceIds] = useState<string[]>([]);
+  const [selectedWorkspaceNoteIds, setSelectedWorkspaceNoteIds] = useState<string[]>([]);
+  const [includeWorkspaceInstructions, setIncludeWorkspaceInstructions] = useState(true);
+  const [pinTarget, setPinTarget] = useState<IntuneChatMessage | null>(null);
+  const [pinWorkspaceId, setPinWorkspaceId] = useState("");
+  const [selectedBatchAgentSlug, setSelectedBatchAgentSlug] = useState("");
+  const [batchNotice, setBatchNotice] = useState<string | null>(null);
+  const [groupName, setGroupName] = useState("");
   const [renameTarget, setRenameTarget] = useState<IntuneChatConversation | null>(null);
   const [renameTitle, setRenameTitle] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<IntuneChatConversation | null>(null);
@@ -166,6 +240,115 @@ export default function IntuneChat() {
     provider,
     state.activeModelByProviderId,
   ).model;
+  const workspaceContextSummary = useMemo<WorkspacePromptContextSummary | undefined>(() => {
+    if (!attachedWorkspace) return undefined;
+    const includesInstructions =
+      includeWorkspaceInstructions && Boolean(attachedWorkspace.instructions?.trim());
+    if (
+      !includesInstructions &&
+      selectedWorkspaceEvidenceIds.length === 0 &&
+      selectedWorkspaceNoteIds.length === 0
+    ) {
+      return undefined;
+    }
+    return {
+      workspaceId: attachedWorkspace.id,
+      workspaceTitle: attachedWorkspace.title,
+      tenantId: attachedWorkspace.tenantId,
+      evidenceCount: selectedWorkspaceEvidenceIds.length,
+      noteCount: selectedWorkspaceNoteIds.length,
+      includesInstructions,
+    };
+  }, [
+    attachedWorkspace,
+    includeWorkspaceInstructions,
+    selectedWorkspaceEvidenceIds.length,
+    selectedWorkspaceNoteIds.length,
+  ]);
+
+  const buildWorkspaceContextInput = (): WorkspacePromptContextInput | undefined => {
+    if (!attachedWorkspace || !workspaceContextSummary) return undefined;
+    return {
+      workspaceId: attachedWorkspace.id,
+      ...(selectedWorkspaceEvidenceIds.length > 0
+        ? { evidenceIds: selectedWorkspaceEvidenceIds }
+        : {}),
+      ...(selectedWorkspaceNoteIds.length > 0
+        ? { noteIds: selectedWorkspaceNoteIds }
+        : {}),
+      ...(workspaceContextSummary.includesInstructions ? { includeInstructions: true } : {}),
+    };
+  };
+
+  useEffect(() => {
+    const api = window.openAdminOS;
+    if (!api) return;
+    void Promise.all([
+      api.listTenantGroups(),
+      api.listSavedMultiTenantQueries(),
+    ])
+      .then(([groups, queries]) => {
+        setTenantGroups(groups);
+        setSavedQueries(queries);
+      })
+      .catch((caught) =>
+        setError(caught instanceof Error ? caught.message : String(caught)),
+      );
+  }, []);
+
+  useEffect(() => {
+    const api = window.openAdminOS;
+    if (!api || !state.activeTenantId) {
+      setWorkspaces([]);
+      setAttachedWorkspaceId("");
+      setAttachedWorkspace(null);
+      return;
+    }
+    void api
+      .listWorkspaces(state.activeTenantId)
+      .then((nextWorkspaces) => {
+        setWorkspaces(nextWorkspaces);
+        setAttachedWorkspaceId((current) =>
+          current && nextWorkspaces.some((workspace) => workspace.id === current)
+            ? current
+            : "",
+        );
+      })
+      .catch((caught) =>
+        setError(caught instanceof Error ? caught.message : String(caught)),
+      );
+  }, [state.activeTenantId]);
+
+  useEffect(() => {
+    const api = window.openAdminOS;
+    if (!api || !attachedWorkspaceId) {
+      setAttachedWorkspace(null);
+      setSelectedWorkspaceEvidenceIds([]);
+      setSelectedWorkspaceNoteIds([]);
+      return;
+    }
+    void api
+      .getWorkspace(attachedWorkspaceId)
+      .then((workspace) => {
+        setAttachedWorkspace(workspace ?? null);
+        setSelectedWorkspaceEvidenceIds((current) =>
+          current.filter((id) => workspace?.evidence.some((entry) => entry.id === id)),
+        );
+        setSelectedWorkspaceNoteIds((current) =>
+          current.filter((id) => workspace?.notes.some((entry) => entry.id === id)),
+        );
+      })
+      .catch((caught) =>
+        setError(caught instanceof Error ? caught.message : String(caught)),
+      );
+  }, [attachedWorkspaceId]);
+
+  useEffect(() => {
+    if (scopeMode !== "selected" || selectedTenantIds.length > 0) return;
+    if (state.activeTenantId) {
+      setSelectedTenantIds([state.activeTenantId]);
+    }
+  }, [scopeMode, selectedTenantIds.length, state.activeTenantId]);
 
   const loadShell = async (
     preferredActiveConversationId?: string | null,
@@ -224,13 +407,27 @@ export default function IntuneChat() {
       setMessages([]);
       return;
     }
+    const activeConversation = conversations.find(
+      (conversation) => conversation.id === activeConversationId,
+    );
     void api
       .getIntuneChatMessages(activeConversationId)
-      .then(setMessages)
+      .then(async (nextMessages) => {
+        setMessages(nextMessages);
+        if (activeConversation?.multiTenantJobId) {
+          const job = await api.getMultiTenantChatJob(activeConversation.multiTenantJobId);
+          if (job?.conversationId) {
+            setMultiTenantJobsByConversationId((current) => ({
+              ...current,
+              [job.conversationId!]: job,
+            }));
+          }
+        }
+      })
       .catch((caught) =>
         setError(caught instanceof Error ? caught.message : String(caught)),
       );
-  }, [activeConversationId, sending]);
+  }, [activeConversationId, conversations, sending]);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ block: "end", behavior: "smooth" });
@@ -292,6 +489,12 @@ export default function IntuneChat() {
     setChatProgress(null);
     setProgressAssistantMessageId(null);
     setOptimisticDraft(null);
+    setScopeMode("active");
+    setSelectedSavedQueryId("");
+    setMultiTenantPreflight(null);
+    setPreflightPrompt("");
+    setActiveMultiTenantJob(null);
+    setBatchNotice(null);
   };
 
   const handleStopGeneration = async () => {
@@ -312,7 +515,18 @@ export default function IntuneChat() {
     const content = (contentOverride ?? input).trim();
     const api = window.openAdminOS;
     if (!api || !content || sending) return;
-    if (provider && activeTenant && requiresHostedChatConsent(provider, activeTenant)) {
+    if (shouldUseMultiTenantFlow(content, scopeMode)) {
+      await prepareMultiTenantReview(content);
+      return;
+    }
+    const workspaceContext = buildWorkspaceContextInput();
+    const contextSummary = workspaceContext ? workspaceContextSummary : undefined;
+    if (
+      provider &&
+      activeTenant &&
+      !provider.isLocal &&
+      (requiresHostedChatConsent(provider, activeTenant) || Boolean(workspaceContext))
+    ) {
       setHostedConsentPrompt({
         content,
         ...(conversationIdOverride ? { conversationId: conversationIdOverride } : {}),
@@ -321,6 +535,8 @@ export default function IntuneChat() {
         providerId: provider.id,
         providerName: provider.name,
         ...(activeModel ? { model: activeModel } : {}),
+        ...(workspaceContext ? { workspaceContext } : {}),
+        ...(contextSummary ? { workspaceContextSummary: contextSummary } : {}),
       });
       setRememberHostedConsent(true);
       return;
@@ -329,13 +545,115 @@ export default function IntuneChat() {
       content,
       rememberedHostedProviderConsent(provider, activeTenant),
       conversationIdOverride,
+      workspaceContext,
     );
   };
+
+  const buildTenantScope = (content: string): TenantScope => {
+    if (scopeMode === "all" || detectsAllTenantPrompt(content)) {
+      return {
+        kind: "all",
+        ...(selectedGroupIds.length > 0 ? { groupIds: selectedGroupIds } : {}),
+      };
+    }
+    if (scopeMode === "selected") {
+      return {
+        kind: "selected",
+        tenantIds: selectedTenantIds,
+        ...(selectedGroupIds.length > 0 ? { groupIds: selectedGroupIds } : {}),
+      };
+    }
+    return { kind: "active" };
+  };
+
+  const prepareMultiTenantReview = async (content: string) => {
+    const api = window.openAdminOS;
+    if (!api || runningMultiTenant) return;
+    setError(null);
+    setNotice(null);
+    setMultiTenantPreflight(null);
+    setPreflightPrompt(content);
+    try {
+      const preflight = await api.preflightMultiTenantIntuneChat({
+        prompt: content,
+        tenantScope: buildTenantScope(content),
+        ...(selectedSavedQueryId ? { savedQueryId: selectedSavedQueryId } : {}),
+      });
+      setMultiTenantPreflight(preflight);
+      setInput(content);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  const runMultiTenantQuery = async (
+    consent?: NonNullable<RunMultiTenantChatInput["hostedProviderConsent"]>,
+  ) => {
+    const api = window.openAdminOS;
+    const preflight = multiTenantPreflight;
+    const content = preflightPrompt.trim();
+    if (!api || !preflight || !content || runningMultiTenant) return;
+    if (!preflight.providerIsLocal && !consent) {
+      setHostedBatchConsentPrompt({ preflight, content });
+      return;
+    }
+    setRunningMultiTenant(true);
+    setError(null);
+    setNotice(null);
+    setBatchNotice(null);
+    setActiveMultiTenantJob(null);
+    try {
+      const result = await api.streamMultiTenantIntuneChat(
+        {
+          prompt: content,
+          tenantScope: preflight.tenantScope,
+          savedQueryId: selectedSavedQueryId || undefined,
+          refreshIfStale: true,
+          ...(consent ? { hostedProviderConsent: consent } : {}),
+        },
+        (event: MultiTenantChatStreamEvent) => {
+          if (event.type === "started" || event.type === "progress") {
+            setActiveMultiTenantJob(event.job);
+          }
+          if (event.type === "completed") {
+            setActiveMultiTenantJob(event.result.job);
+          }
+          if (event.type === "cancelled") {
+            setActiveMultiTenantJob(event.job);
+            setNotice("Multi-tenant query stopped.");
+          }
+          if (event.type === "failed") {
+            setError(event.error);
+          }
+        },
+      );
+      if (result.job.conversationId) {
+        setMultiTenantJobsByConversationId((current) => ({
+          ...current,
+          [result.job.conversationId!]: result.job,
+        }));
+        setExpandedTenantIds(result.job.comparisons.slice(0, 1).map((row) => row.tenantId));
+      }
+      setMultiTenantPreflight(null);
+      setPreflightPrompt("");
+      setInput("");
+      setMessages([result.userMessage, result.assistantMessage]);
+      setActiveConversationId(result.conversation.id);
+      await loadShell(result.conversation.id);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setRunningMultiTenant(false);
+      setActiveMultiTenantJob(null);
+    }
+  };
+
 
   const executeSend = async (
     content: string,
     hostedProviderConsent?: HostedProviderConsentInput,
     conversationIdOverride?: string,
+    workspaceContext?: WorkspacePromptContextInput,
   ) => {
     const api = window.openAdminOS;
     if (!api || !content || sending) return;
@@ -390,6 +708,7 @@ export default function IntuneChat() {
           content,
           refreshIfStale: true,
           ...(hostedProviderConsent ? { hostedProviderConsent } : {}),
+          ...(workspaceContext ? { workspaceContext } : {}),
         },
         (event) => {
           if (event.type === "started") {
@@ -523,9 +842,149 @@ export default function IntuneChat() {
         pending.tenantId,
         pending.providerId,
         rememberHostedConsent,
+        pending.workspaceContextSummary,
       ),
       pending.conversationId,
+      pending.workspaceContext,
     );
+  };
+
+  const confirmHostedBatchConsentAndRun = async () => {
+    const prompt = hostedBatchConsentPrompt;
+    if (!prompt) return;
+    setHostedBatchConsentPrompt(null);
+    await runMultiTenantQuery({
+      tenantIds: prompt.preflight.resolvedTenantIds,
+      providerId: prompt.preflight.providerId,
+      acknowledgedAt: new Date().toISOString(),
+      remember: true,
+    });
+  };
+
+  const applySavedQuery = (query: SavedMultiTenantQuery) => {
+    setSelectedSavedQueryId(query.id);
+    setInput(query.prompt);
+    if (query.defaultScope?.kind === "all") {
+      setScopeMode("all");
+    } else if (query.defaultScope?.kind === "selected") {
+      setScopeMode("selected");
+      if (query.defaultScope.tenantIds.length > 0) {
+        setSelectedTenantIds(query.defaultScope.tenantIds);
+      }
+    }
+    window.requestAnimationFrame(() => composerRef.current?.focus());
+  };
+
+  const toggleTenantSelection = (tenantId: string) => {
+    setSelectedTenantIds((current) =>
+      current.includes(tenantId)
+        ? current.filter((id) => id !== tenantId)
+        : [...current, tenantId],
+    );
+  };
+
+  const toggleGroupSelection = (groupId: string) => {
+    setSelectedGroupIds((current) =>
+      current.includes(groupId)
+        ? current.filter((id) => id !== groupId)
+        : [...current, groupId],
+    );
+  };
+
+  const saveCurrentTenantGroup = async () => {
+    const api = window.openAdminOS;
+    if (!api || !groupName.trim()) return;
+    const tenantIds = multiTenantPreflight?.resolvedTenantIds ?? selectedTenantIds;
+    if (tenantIds.length === 0) {
+      setError("Select at least one tenant before saving a group.");
+      return;
+    }
+    try {
+      const group = await api.saveTenantGroup({
+        name: groupName,
+        tenantIds,
+      });
+      setTenantGroups(await api.listTenantGroups());
+      setSelectedGroupIds((current) => [...new Set([...current, group.id])]);
+      setGroupName("");
+      setNotice(`Saved tenant group ${group.name}.`);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  const queueMultiTenantAgentBatch = async () => {
+    const api = window.openAdminOS;
+    const preflight = multiTenantPreflight;
+    if (!api || !preflight || !selectedBatchAgentSlug || runningMultiTenant) return;
+    setError(null);
+    setBatchNotice(null);
+    try {
+      const result = await api.queueMultiTenantAgentBatch({
+        agentSlug: selectedBatchAgentSlug,
+        tenantScope: preflight.tenantScope,
+        savedQueryId: selectedSavedQueryId || undefined,
+        prompt: preflight.prompt,
+      });
+      setBatchNotice(
+        `Queued ${result.runs.length} tenant-pinned run${result.runs.length === 1 ? "" : "s"}.`,
+      );
+      await refresh();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  const exportMultiTenantJob = async (
+    job: MultiTenantChatJob,
+    format: "md" | "json" | "csv",
+  ) => {
+    const api = window.openAdminOS;
+    if (!api) return;
+    const content =
+      format === "json"
+        ? `${JSON.stringify(job, null, 2)}\n`
+        : format === "csv"
+          ? buildDeviceCsv(job)
+          : job.exportDossierMarkdown;
+    const extension = format === "json" ? "json" : format === "csv" ? "csv" : "md";
+    const result = await api.saveTextFile({
+      suggestedName: `${safeFileName(job.prompt)}.${extension}`,
+      content,
+      filters: [
+        {
+          name: format === "json" ? "JSON" : format === "csv" ? "CSV" : "Markdown",
+          extensions: [extension],
+        },
+      ],
+    });
+    if (!result.canceled) {
+      setNotice(result.filePath ? `Exported result to ${result.filePath}.` : "Exported result.");
+    }
+  };
+
+  const importSplitJob = async () => {
+    const api = window.openAdminOS;
+    const job = splitJob;
+    if (!api || !job) return;
+    try {
+      const result = await api.importMultiTenantResultToWorkspaces({
+        jobId: job.id,
+        tenantMappings: job.comparisons
+          .filter((tenant) => tenant.windowsDevices > 0 || tenant.status === "stale")
+          .map((tenant) => ({
+            tenantId: tenant.tenantId,
+            title: `${tenant.tenantName} · ${job.prompt.slice(0, 80)}`,
+          })),
+      });
+      setSplitResult(result);
+      setNotice(
+        `Created ${result.evidence.length} tenant-specific workspace evidence entr${result.evidence.length === 1 ? "y" : "ies"}.`,
+      );
+      await refresh();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
   };
 
   const handleRenameConversation = async () => {
@@ -657,6 +1116,26 @@ export default function IntuneChat() {
     }
   };
 
+  const handleCreateWorkspaceFromConversation = async () => {
+    const api = window.openAdminOS;
+    if (!api || !activeConversation || activeConversation.scopeKind === "multi-tenant") return;
+    setError(null);
+    setNotice(null);
+    try {
+      const workspace = await api.createWorkspace({
+        title: activeConversation.title,
+        ...(activeConversation.tenantId ? { tenantId: activeConversation.tenantId } : {}),
+        conversationId: activeConversation.id,
+      });
+      setNotice(`Created workspace ${workspace.title} and linked this conversation.`);
+      if (activeTenant) {
+        setWorkspaces(await api.listWorkspaces(activeTenant.id));
+      }
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
   const handleCopyMessage = async (message: IntuneChatMessage) => {
     const text = message.content.trim();
     if (!text) return;
@@ -670,6 +1149,52 @@ export default function IntuneChat() {
         setCopiedMessageId(null);
         copiedClearTimerRef.current = null;
       }, 1600);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  const handlePinMessageToWorkspace = async () => {
+    const api = window.openAdminOS;
+    const message = pinTarget;
+    const workspaceId = pinWorkspaceId || workspaces[0]?.id;
+    if (!api || !message || !workspaceId || !activeTenant) return;
+    setError(null);
+    setNotice(null);
+    try {
+      const workspace = workspaces.find((entry) => entry.id === workspaceId);
+      const evidence = await api.pinWorkspaceEvidence({
+        workspaceId,
+        tenantId: activeTenant.id,
+        title: `Chat answer · ${formatDateTime(message.createdAt)}`,
+        sourceType: "chat-message",
+        sourceRef: {
+          conversationId: message.conversationId,
+          messageId: message.id,
+        },
+        content: {
+          role: message.role,
+          content: message.content,
+          sources: message.sources ?? [],
+          agentSuggestions: message.agentSuggestions ?? [],
+        },
+        ...(message.sources?.[0]?.refreshedAt
+          ? {
+              freshness: {
+                resource: message.sources[0].resource,
+                refreshedAt: message.sources[0].refreshedAt,
+                rowCount: message.sources[0].rows,
+                cacheStatus: message.sources[0].source,
+              },
+            }
+          : {}),
+      });
+      setNotice(
+        `Pinned evidence to ${workspace?.title ?? "workspace"} as ${evidence.title}.`,
+      );
+      setPinTarget(null);
+      setPinWorkspaceId("");
+      setWorkspaces(await api.listWorkspaces(activeTenant.id));
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : String(caught));
     }
@@ -724,7 +1249,7 @@ export default function IntuneChat() {
       type="button"
       onClick={() => setActiveConversationId(conversation.id)}
       onContextMenu={(event) => openConversationContextMenu(event, conversation)}
-      className={`mb-1 w-full rounded-lg px-3 py-2.5 text-left transition-colors ${
+      className={`mb-1 w-full rounded-lg px-3 py-2.5 text-left transition-colors ${focusRingClass} ${
         activeConversationId === conversation.id
           ? "bg-[var(--color-surface-hover)] text-[var(--color-text)]"
           : "text-[var(--color-text-soft)] hover:bg-[var(--color-surface)] hover:text-[var(--color-text)]"
@@ -795,7 +1320,7 @@ export default function IntuneChat() {
                   title="Hide chat history"
                   aria-label="Hide chat history"
                   onClick={() => setSidebarCollapsed(true)}
-                  className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface)] hover:text-[var(--color-text)]"
+                  className={`flex h-7 w-7 items-center justify-center rounded-md text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface)] hover:text-[var(--color-text)] ${focusRingClass}`}
                 >
                   <IconArrowLeft size={13} />
                 </button>
@@ -976,6 +1501,17 @@ export default function IntuneChat() {
           <div className="flex shrink-0 items-center gap-2">
             {activeConversation && (
               <>
+                {activeConversation.scopeKind !== "multi-tenant" && (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    leadingIcon={<IconHardDrive size={12} />}
+                    disabled={sending}
+                    onClick={() => void handleCreateWorkspaceFromConversation()}
+                  >
+                    Workspace
+                  </Button>
+                )}
                 <Button
                   size="sm"
                   variant="ghost"
@@ -1023,7 +1559,30 @@ export default function IntuneChat() {
 
         <div className="min-h-0 flex-1 overflow-y-auto">
           <div className="mx-auto flex min-h-full w-full max-w-[860px] flex-col px-6 py-8">
-            {displayedMessages.length === 0 ? (
+            {multiTenantPreflight ? (
+              <div className="flex flex-1 flex-col justify-center gap-6 py-8">
+                <ScopeReviewCard
+                  preflight={multiTenantPreflight}
+                  progressJob={activeMultiTenantJob}
+                  groupName={groupName}
+                  onGroupNameChange={setGroupName}
+                  onSaveGroup={() => void saveCurrentTenantGroup()}
+                  onCancel={() => {
+                    setMultiTenantPreflight(null);
+                    setPreflightPrompt("");
+                    setActiveMultiTenantJob(null);
+                    setBatchNotice(null);
+                  }}
+                  onRun={() => void runMultiTenantQuery()}
+                  running={runningMultiTenant}
+                  installedAgents={state.installedAgents}
+                  selectedBatchAgentSlug={selectedBatchAgentSlug}
+                  onSelectedBatchAgentSlugChange={setSelectedBatchAgentSlug}
+                  onQueueBatch={() => void queueMultiTenantAgentBatch()}
+                  batchNotice={batchNotice}
+                />
+              </div>
+            ) : displayedMessages.length === 0 ? (
               chatProgress ? (
                 <div className="flex flex-1 flex-col justify-center gap-6 py-16">
                   <ChatProgressCard progress={chatProgress} />
@@ -1036,23 +1595,57 @@ export default function IntuneChat() {
               )
             ) : (
               <div className="flex flex-1 flex-col gap-6">
-                {displayedMessages.map((message) => (
-                <ChatMessageBubble
-                    key={message.id}
-                    message={message}
-                    progress={message.id === progressAssistantMessageId ? chatProgress : null}
-                    copied={message.id === copiedMessageId}
-                    runningAgentSlug={runningAgentSlug}
-                    regenerateDisabled={
-                      sending ||
-                      !previousUserPromptForMessage(displayedMessages, message)
-                    }
-                    onCopy={() => void handleCopyMessage(message)}
-                    onEditPrompt={() => handleEditPrompt(message)}
-                    onRegenerate={() => void handleRegenerateResponse(message)}
-                    onRunAgent={handleRunAgent}
-                  />
-                ))}
+                {displayedMessages.map((message) => {
+                  const job = multiTenantJobsByConversationId[message.conversationId];
+                  return (
+                    <div key={message.id} className="space-y-4">
+                      <ChatMessageBubble
+                        message={message}
+                        progress={message.id === progressAssistantMessageId ? chatProgress : null}
+                        copied={message.id === copiedMessageId}
+                        runningAgentSlug={runningAgentSlug}
+                        regenerateDisabled={
+                          sending ||
+                          !previousUserPromptForMessage(displayedMessages, message)
+                        }
+                        onCopy={() => void handleCopyMessage(message)}
+                        onEditPrompt={() => handleEditPrompt(message)}
+                        onRegenerate={() => void handleRegenerateResponse(message)}
+                        onRunAgent={handleRunAgent}
+                        pinDisabled={
+                          !activeTenant ||
+                          activeConversation?.scopeKind === "multi-tenant" ||
+                          workspaces.length === 0 ||
+                          message.status !== "completed"
+                        }
+                        onPin={() => {
+                          setPinTarget(message);
+                          setPinWorkspaceId(attachedWorkspaceId || workspaces[0]?.id || "");
+                        }}
+                      />
+                      {message.role === "assistant" && job && (
+                        <MultiTenantResultArtifact
+                          job={job}
+                          filters={multiTenantFilters}
+                          onFiltersChange={setMultiTenantFilters}
+                          expandedTenantIds={expandedTenantIds}
+                          onToggleTenant={(tenantId) =>
+                            setExpandedTenantIds((current) =>
+                              current.includes(tenantId)
+                                ? current.filter((id) => id !== tenantId)
+                                : [...current, tenantId],
+                            )
+                          }
+                          onExport={(format) => void exportMultiTenantJob(job, format)}
+                          onSplit={() => {
+                            setSplitJob(job);
+                            setSplitResult(null);
+                          }}
+                        />
+                      )}
+                    </div>
+                  );
+                })}
                 {sending && chatProgress && !progressMessageVisible && (
                   <ChatProgressCard progress={chatProgress} />
                 )}
@@ -1074,6 +1667,46 @@ export default function IntuneChat() {
                 {notice}
               </div>
             )}
+            <MultiTenantComposerControls
+              scopeMode={scopeMode}
+              onScopeModeChange={setScopeMode}
+              tenants={state.tenants}
+              activeTenantId={state.activeTenantId}
+              selectedTenantIds={selectedTenantIds}
+              onToggleTenant={toggleTenantSelection}
+              tenantGroups={tenantGroups}
+              selectedGroupIds={selectedGroupIds}
+              onToggleGroup={toggleGroupSelection}
+              savedQueries={savedQueries}
+              selectedSavedQueryId={selectedSavedQueryId}
+              onSavedQuery={applySavedQuery}
+              disabled={sending || runningMultiTenant}
+            />
+            <WorkspaceContextControls
+              workspaces={workspaces}
+              workspace={attachedWorkspace}
+              attachedWorkspaceId={attachedWorkspaceId}
+              onWorkspaceChange={setAttachedWorkspaceId}
+              selectedEvidenceIds={selectedWorkspaceEvidenceIds}
+              onToggleEvidence={(id) =>
+                setSelectedWorkspaceEvidenceIds((current) =>
+                  current.includes(id)
+                    ? current.filter((entry) => entry !== id)
+                    : [...current, id],
+                )
+              }
+              selectedNoteIds={selectedWorkspaceNoteIds}
+              onToggleNote={(id) =>
+                setSelectedWorkspaceNoteIds((current) =>
+                  current.includes(id)
+                    ? current.filter((entry) => entry !== id)
+                    : [...current, id],
+                )
+              }
+              includeInstructions={includeWorkspaceInstructions}
+              onIncludeInstructionsChange={setIncludeWorkspaceInstructions}
+              disabled={sending || runningMultiTenant}
+            />
             <div className="intune-chat-composer rounded-xl bg-[var(--color-bg-raised)] p-2 ring-1 ring-[var(--color-border)] focus-within:ring-[var(--color-accent)]">
               <textarea
                 ref={composerRef}
@@ -1094,9 +1727,11 @@ export default function IntuneChat() {
               />
               <div className="flex items-center justify-between gap-3 px-1 pb-1">
                 <div className="truncate text-[11px] text-[var(--color-text-muted)]">
-                  {provider?.isLocal
-                    ? "Tenant context stays on this device with the selected local provider."
-                    : "Retrieved tenant context is sent to the selected hosted provider."}
+                  {workspaceContextSummary
+                    ? `Workspace context selected: ${workspaceContextSummary.evidenceCount} evidence, ${workspaceContextSummary.noteCount} notes.`
+                    : provider?.isLocal
+                      ? "Tenant context stays on this device with the selected local provider."
+                      : "Retrieved tenant context is sent to the selected hosted provider."}
                 </div>
                 {sending ? (
                   <Button
@@ -1129,6 +1764,31 @@ export default function IntuneChat() {
         onRememberChange={setRememberHostedConsent}
         onClose={() => setHostedConsentPrompt(null)}
         onConfirm={() => void confirmHostedConsentAndSend()}
+      />
+      <HostedBatchConsentModal
+        prompt={hostedBatchConsentPrompt}
+        onClose={() => setHostedBatchConsentPrompt(null)}
+        onConfirm={() => void confirmHostedBatchConsentAndRun()}
+      />
+      <SplitToWorkspacesModal
+        job={splitJob}
+        result={splitResult}
+        onClose={() => {
+          setSplitJob(null);
+          setSplitResult(null);
+        }}
+        onConfirm={() => void importSplitJob()}
+      />
+      <PinMessageToWorkspaceModal
+        message={pinTarget}
+        workspaces={workspaces}
+        selectedWorkspaceId={pinWorkspaceId}
+        onWorkspaceChange={setPinWorkspaceId}
+        onClose={() => {
+          setPinTarget(null);
+          setPinWorkspaceId("");
+        }}
+        onConfirm={() => void handlePinMessageToWorkspace()}
       />
       <RenameConversationModal
         conversation={renameTarget}
@@ -1205,6 +1865,1022 @@ function previousUserPromptForMessage(
   return null;
 }
 
+function MultiTenantComposerControls({
+  scopeMode,
+  onScopeModeChange,
+  tenants,
+  activeTenantId,
+  selectedTenantIds,
+  onToggleTenant,
+  tenantGroups,
+  selectedGroupIds,
+  onToggleGroup,
+  savedQueries,
+  selectedSavedQueryId,
+  onSavedQuery,
+  disabled,
+}: {
+  scopeMode: MultiTenantScopeMode;
+  onScopeModeChange: (mode: MultiTenantScopeMode) => void;
+  tenants: TenantRecord[];
+  activeTenantId?: string;
+  selectedTenantIds: string[];
+  onToggleTenant: (tenantId: string) => void;
+  tenantGroups: TenantGroup[];
+  selectedGroupIds: string[];
+  onToggleGroup: (groupId: string) => void;
+  savedQueries: SavedMultiTenantQuery[];
+  selectedSavedQueryId: string;
+  onSavedQuery: (query: SavedMultiTenantQuery) => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="mb-3 rounded-xl bg-[var(--color-bg-raised)] p-3 ring-1 ring-[var(--color-border-soft)]">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+          Scope
+        </span>
+        {(["active", "selected", "all"] as const).map((mode) => (
+          <button
+            key={mode}
+            type="button"
+            disabled={disabled}
+            onClick={() => onScopeModeChange(mode)}
+            className={`h-7 rounded-md px-2.5 text-[11.5px] transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${focusRingClass} ${
+              scopeMode === mode
+                ? "bg-[var(--color-accent-soft)] text-[var(--color-accent)] ring-1 ring-[var(--color-accent)]/30"
+                : "bg-[var(--color-bg)] text-[var(--color-text-muted)] ring-1 ring-[var(--color-border-soft)] hover:text-[var(--color-text)]"
+            }`}
+          >
+            {mode === "active"
+              ? "Active tenant"
+              : mode === "selected"
+                ? "Selected tenants"
+                : "All connected tenants"}
+          </button>
+        ))}
+        <div className="ml-auto min-w-[180px]">
+          <select
+            value={selectedSavedQueryId}
+            disabled={disabled}
+            onChange={(event) => {
+              const query = savedQueries.find((entry) => entry.id === event.target.value);
+              if (query) onSavedQuery(query);
+            }}
+            className="h-7 w-full rounded-md bg-[var(--color-bg)] px-2 text-[11.5px] text-[var(--color-text-soft)] outline-none ring-1 ring-[var(--color-border-soft)] focus:ring-[var(--color-accent)]"
+            aria-label="Saved multi-tenant query"
+          >
+            <option value="">Saved queries</option>
+            {savedQueries.map((query) => (
+              <option key={query.id} value={query.id}>
+                {query.title}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      {scopeMode === "selected" && (
+        <div className="mt-3 grid gap-2 md:grid-cols-2">
+          <div>
+            <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+              Tenants
+            </div>
+            <div className="flex max-h-20 flex-wrap gap-1.5 overflow-y-auto pr-1">
+              {tenants.map((tenant) => (
+                <button
+                  key={tenant.id}
+                  type="button"
+                  disabled={disabled}
+                  onClick={() => onToggleTenant(tenant.id)}
+                  className={`rounded-md px-2 py-1 text-[11px] transition-colors ${focusRingClass} ${
+                    selectedTenantIds.includes(tenant.id)
+                      ? "bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
+                      : tenant.id === activeTenantId
+                        ? "bg-[var(--color-surface)] text-[var(--color-text-soft)] ring-1 ring-[var(--color-border-soft)]"
+                        : "bg-[var(--color-bg)] text-[var(--color-text-muted)] ring-1 ring-[var(--color-border-soft)]"
+                  } disabled:cursor-not-allowed disabled:opacity-50`}
+                >
+                  {tenant.displayName}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div>
+            <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+              Groups
+            </div>
+            <div className="flex max-h-20 flex-wrap gap-1.5 overflow-y-auto pr-1">
+              {tenantGroups.length === 0 ? (
+                <span className="text-[11px] text-[var(--color-text-muted)]">
+                  Groups can be saved during scope review.
+                </span>
+              ) : (
+                tenantGroups.map((group) => (
+                  <button
+                    key={group.id}
+                    type="button"
+                    disabled={disabled}
+                    onClick={() => onToggleGroup(group.id)}
+                    className={`rounded-md px-2 py-1 text-[11px] transition-colors ${focusRingClass} ${
+                      selectedGroupIds.includes(group.id)
+                        ? "bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
+                        : "bg-[var(--color-bg)] text-[var(--color-text-muted)] ring-1 ring-[var(--color-border-soft)]"
+                    } disabled:cursor-not-allowed disabled:opacity-50`}
+                  >
+                    {group.name}
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WorkspaceContextControls({
+  workspaces,
+  workspace,
+  attachedWorkspaceId,
+  onWorkspaceChange,
+  selectedEvidenceIds,
+  onToggleEvidence,
+  selectedNoteIds,
+  onToggleNote,
+  includeInstructions,
+  onIncludeInstructionsChange,
+  disabled,
+}: {
+  workspaces: WorkspaceSummary[];
+  workspace: WorkspaceDetail | null;
+  attachedWorkspaceId: string;
+  onWorkspaceChange: (id: string) => void;
+  selectedEvidenceIds: string[];
+  onToggleEvidence: (id: string) => void;
+  selectedNoteIds: string[];
+  onToggleNote: (id: string) => void;
+  includeInstructions: boolean;
+  onIncludeInstructionsChange: (include: boolean) => void;
+  disabled: boolean;
+}) {
+  if (workspaces.length === 0) return null;
+  const hasAttachment =
+    Boolean(workspace) &&
+    (selectedEvidenceIds.length > 0 ||
+      selectedNoteIds.length > 0 ||
+      (includeInstructions && Boolean(workspace?.instructions?.trim())));
+  return (
+    <div className="mb-3 rounded-xl bg-[var(--color-bg-raised)] p-3 ring-1 ring-[var(--color-border-soft)]">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+          Workspace context
+        </span>
+        <select
+          value={attachedWorkspaceId}
+          disabled={disabled}
+          onChange={(event) => onWorkspaceChange(event.target.value)}
+          className="h-7 min-w-[220px] rounded-md bg-[var(--color-bg)] px-2 text-[11.5px] text-[var(--color-text-soft)] outline-none ring-1 ring-[var(--color-border-soft)] focus:ring-[var(--color-accent)] disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label="Attach workspace context"
+        >
+          <option value="">No workspace attached</option>
+          {workspaces.map((entry) => (
+            <option key={entry.id} value={entry.id}>
+              {entry.title}
+            </option>
+          ))}
+        </select>
+        {hasAttachment && <Pill tone="accent">Attached</Pill>}
+        {!attachedWorkspaceId && (
+          <div className="flex flex-wrap gap-1.5">
+            {workspaces.slice(0, 3).map((entry) => (
+              <button
+                key={entry.id}
+                type="button"
+                disabled={disabled}
+                onClick={() => onWorkspaceChange(entry.id)}
+                className="rounded-md bg-[var(--color-bg)] px-2 py-1 text-[11px] text-[var(--color-text-muted)] ring-1 ring-[var(--color-border-soft)] transition-colors hover:text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-accent)] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {entry.title}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+      {workspace && (
+        <div className="mt-3 grid gap-3 lg:grid-cols-3">
+          <div className="rounded-lg bg-[var(--color-bg)] p-2 ring-1 ring-[var(--color-border-soft)]">
+            <label className="flex cursor-pointer items-start gap-2 text-[11.5px] leading-5 text-[var(--color-text-soft)]">
+              <input
+                type="checkbox"
+                checked={includeInstructions && Boolean(workspace.instructions?.trim())}
+                disabled={disabled || !workspace.instructions?.trim()}
+                onChange={(event) => onIncludeInstructionsChange(event.target.checked)}
+                className="mt-1 h-3.5 w-3.5 accent-[var(--color-accent)]"
+              />
+              <span>
+                Instructions
+                <span className="block text-[10.5px] text-[var(--color-text-muted)]">
+                  {workspace.instructions?.trim()
+                    ? "Include workspace instructions"
+                    : "No instructions saved"}
+                </span>
+              </span>
+            </label>
+          </div>
+          <div className="rounded-lg bg-[var(--color-bg)] p-2 ring-1 ring-[var(--color-border-soft)]">
+            <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+              Evidence
+            </div>
+            <div className="max-h-20 space-y-1 overflow-y-auto pr-1">
+              {workspace.evidence.length === 0 ? (
+                <span className="text-[11px] text-[var(--color-text-muted)]">
+                  No evidence pinned
+                </span>
+              ) : (
+                workspace.evidence.slice(0, 12).map((entry) => (
+                  <label
+                    key={entry.id}
+                    className="flex cursor-pointer items-center gap-2 text-[11.5px] text-[var(--color-text-soft)]"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedEvidenceIds.includes(entry.id)}
+                      disabled={disabled}
+                      onChange={() => onToggleEvidence(entry.id)}
+                      className="h-3.5 w-3.5 accent-[var(--color-accent)]"
+                    />
+                    <span className="min-w-0 truncate">{entry.title}</span>
+                  </label>
+                ))
+              )}
+            </div>
+          </div>
+          <div className="rounded-lg bg-[var(--color-bg)] p-2 ring-1 ring-[var(--color-border-soft)]">
+            <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+              Notes
+            </div>
+            <div className="max-h-20 space-y-1 overflow-y-auto pr-1">
+              {workspace.notes.length === 0 ? (
+                <span className="text-[11px] text-[var(--color-text-muted)]">
+                  No notes saved
+                </span>
+              ) : (
+                workspace.notes.slice(0, 12).map((note) => (
+                  <label
+                    key={note.id}
+                    className="flex cursor-pointer items-center gap-2 text-[11.5px] text-[var(--color-text-soft)]"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedNoteIds.includes(note.id)}
+                      disabled={disabled}
+                      onChange={() => onToggleNote(note.id)}
+                      className="h-3.5 w-3.5 accent-[var(--color-accent)]"
+                    />
+                    <span className="min-w-0 truncate">{note.content}</span>
+                  </label>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ScopeReviewCard({
+  preflight,
+  progressJob,
+  groupName,
+  onGroupNameChange,
+  onSaveGroup,
+  onCancel,
+  onRun,
+  running,
+  installedAgents,
+  selectedBatchAgentSlug,
+  onSelectedBatchAgentSlugChange,
+  onQueueBatch,
+  batchNotice,
+}: {
+  preflight: TenantScopePreflight;
+  progressJob: MultiTenantChatJob | null;
+  groupName: string;
+  onGroupNameChange: (value: string) => void;
+  onSaveGroup: () => void;
+  onCancel: () => void;
+  onRun: () => void;
+  running: boolean;
+  installedAgents: { slug: string; name: string; mode: "read" | "write" }[];
+  selectedBatchAgentSlug: string;
+  onSelectedBatchAgentSlugChange: (slug: string) => void;
+  onQueueBatch: () => void;
+  batchNotice: string | null;
+}) {
+  const blocked = preflight.tenants.filter((tenant) =>
+    ["expired", "missing-scopes", "throttled", "failed"].includes(tenant.status),
+  );
+  const selectedBatchAgent = installedAgents.find(
+    (agent) => agent.slug === selectedBatchAgentSlug,
+  );
+  return (
+    <div className="mx-auto w-full max-w-[920px] rounded-xl bg-[var(--color-bg-raised)] ring-1 ring-[var(--color-border-soft)]">
+      <div className="border-b border-[var(--color-border-soft)] px-4 py-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <div className="text-[12px] font-semibold text-[var(--color-text)]">
+              Review multi-tenant scope
+            </div>
+            <div className="mt-1 text-[11px] text-[var(--color-text-muted)]">
+              {preflight.resolvedTenantIds.length} tenant{preflight.resolvedTenantIds.length === 1 ? "" : "s"} · {preflight.providerName}
+              {preflight.model ? ` · ${preflight.model}` : ""}
+            </div>
+          </div>
+          <Pill tone={preflight.providerIsLocal ? "success" : "warning"}>
+            {preflight.providerIsLocal ? "Local provider" : "Hosted confirmation required"}
+          </Pill>
+        </div>
+        <div className="mt-3 rounded-lg bg-[var(--color-bg)] px-3 py-2 text-[12px] leading-5 text-[var(--color-text-soft)] ring-1 ring-[var(--color-border-soft)]">
+          {preflight.prompt}
+        </div>
+      </div>
+      <div className="grid gap-3 p-4 lg:grid-cols-[1fr_260px]">
+        <div className="min-w-0 overflow-hidden rounded-lg ring-1 ring-[var(--color-border-soft)]">
+          <table className="w-full table-fixed text-left text-[12px]">
+            <thead className="bg-[var(--color-bg)] text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">
+              <tr>
+                <th className="px-3 py-2">Tenant</th>
+                <th className="w-28 px-3 py-2">Readiness</th>
+                <th className="w-36 px-3 py-2">Freshness</th>
+                <th className="px-3 py-2">Recovery</th>
+              </tr>
+            </thead>
+            <tbody>
+              {preflight.tenants.map((tenant) => (
+                <tr key={tenant.tenantId} className="border-t border-[var(--color-border-soft)]">
+                  <td className="min-w-0 px-3 py-2">
+                    <div className="truncate font-medium text-[var(--color-text)]" title={tenant.tenantName}>
+                      {tenant.tenantName}
+                    </div>
+                    <div className="truncate font-mono text-[10.5px] text-[var(--color-text-muted)]">
+                      {tenant.username ?? tenant.tenantId}
+                    </div>
+                  </td>
+                  <td className="px-3 py-2">
+                    <ReadinessPill status={tenant.status} />
+                  </td>
+                  <td className="px-3 py-2 text-[11px] text-[var(--color-text-muted)]">
+                    {tenant.cacheFreshness ? formatDateTime(tenant.cacheFreshness) : "No cache"}
+                  </td>
+                  <td className="px-3 py-2 text-[11px] leading-5 text-[var(--color-text-muted)]">
+                    {tenant.recovery}
+                    {tenant.missingScopes.length > 0 && (
+                      <div className="mt-1 font-mono text-[10px] text-[var(--color-warning)]">
+                        {tenant.missingScopes.slice(0, 2).join(", ")}
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div className="space-y-3">
+          {progressJob && (
+            <div className="rounded-lg bg-[var(--color-bg)] p-3 ring-1 ring-[var(--color-border-soft)]">
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <div className="text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+                  Run progress
+                </div>
+                <Pill tone={progressJob.status === "partial" ? "warning" : "accent"}>
+                  {progressJob.status}
+                </Pill>
+              </div>
+              <div className="space-y-1.5">
+                {progressJob.progress.map((entry) => (
+                  <div
+                    key={entry.tenantId}
+                    className="flex items-center justify-between gap-2 rounded-md bg-[var(--color-bg-raised)] px-2 py-1.5 text-[11px] ring-1 ring-[var(--color-border-soft)]"
+                  >
+                    <span className="min-w-0 truncate text-[var(--color-text-soft)]">
+                      {entry.tenantName}
+                    </span>
+                    <span className="shrink-0 font-mono text-[10px] text-[var(--color-text-muted)]">
+                      {entry.status}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          <div className="rounded-lg bg-[var(--color-bg)] p-3 ring-1 ring-[var(--color-border-soft)]">
+            <div className="text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+              Resources
+            </div>
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {preflight.resources.map((resource) => (
+                <Pill key={resource}>{chatResourceLabel(resource)}</Pill>
+              ))}
+            </div>
+          </div>
+          <div className="rounded-lg bg-[var(--color-bg)] p-3 ring-1 ring-[var(--color-border-soft)]">
+            <div className="text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+              Save group
+            </div>
+            <div className="mt-2 flex gap-2">
+              <input
+                value={groupName}
+                onChange={(event) => onGroupNameChange(event.target.value)}
+                placeholder="Tenant group name"
+                className="min-w-0 flex-1 rounded-md bg-[var(--color-bg-raised)] px-2 text-[12px] text-[var(--color-text)] outline-none ring-1 ring-[var(--color-border-soft)] focus:ring-[var(--color-accent)]"
+              />
+              <Button size="sm" variant="secondary" disabled={!groupName.trim()} onClick={onSaveGroup}>
+                Save
+              </Button>
+            </div>
+          </div>
+          <div className="rounded-lg bg-[var(--color-bg)] p-3 ring-1 ring-[var(--color-border-soft)]">
+            <div className="text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+              Agent batch
+            </div>
+            <div className="mt-2 flex gap-2">
+              <select
+                value={selectedBatchAgentSlug}
+                onChange={(event) => onSelectedBatchAgentSlugChange(event.target.value)}
+                disabled={running || installedAgents.length === 0}
+                className="min-w-0 flex-1 rounded-md bg-[var(--color-bg-raised)] px-2 text-[12px] text-[var(--color-text)] outline-none ring-1 ring-[var(--color-border-soft)] focus:ring-[var(--color-accent)] disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label="Agent to queue for selected tenants"
+              >
+                <option value="">Select agent</option>
+                {installedAgents.map((agent) => (
+                  <option key={agent.slug} value={agent.slug}>
+                    {agent.name} · {agent.mode}
+                  </option>
+                ))}
+              </select>
+              <Button
+                size="sm"
+                variant="secondary"
+                disabled={!selectedBatchAgentSlug || running || !preflight.canRun}
+                onClick={onQueueBatch}
+              >
+                Queue
+              </Button>
+            </div>
+            <p className="mt-2 text-[11px] leading-5 text-[var(--color-text-muted)]">
+              Queues one tenant-pinned run per ready tenant.
+              {selectedBatchAgent?.mode === "write"
+                ? " Write runs still pause for per-run typed confirmation."
+                : " Read runs start with the normal run history."}
+            </p>
+            {batchNotice && (
+              <div className="mt-2 rounded-md bg-[var(--color-success-soft)] px-2 py-1.5 text-[11px] text-[var(--color-success)] ring-1 ring-[var(--color-success)]/25">
+                {batchNotice}
+              </div>
+            )}
+          </div>
+          {blocked.length > 0 && (
+            <div className="rounded-lg bg-[var(--color-warning-soft)] p-3 text-[11.5px] leading-5 text-[var(--color-warning)] ring-1 ring-[var(--color-warning)]/25">
+              {blocked.length} tenant{blocked.length === 1 ? "" : "s"} will be skipped unless recovered.
+            </div>
+          )}
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={onCancel} disabled={running}>
+              Cancel
+            </Button>
+            <Button variant="primary" onClick={onRun} disabled={!preflight.canRun || running}>
+              {running ? "Running" : "Run read-only query"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ReadinessPill({ status }: { status: string }) {
+  const tone =
+    status === "ready"
+      ? "success"
+      : status === "stale"
+        ? "warning"
+        : status === "skipped"
+          ? "default"
+          : "danger";
+  return <Pill tone={tone}>{statusLabel(status)}</Pill>;
+}
+
+function MultiTenantResultArtifact({
+  job,
+  filters,
+  onFiltersChange,
+  expandedTenantIds,
+  onToggleTenant,
+  onExport,
+  onSplit,
+}: {
+  job: MultiTenantChatJob;
+  filters: MultiTenantFilterState;
+  onFiltersChange: (filters: MultiTenantFilterState) => void;
+  expandedTenantIds: string[];
+  onToggleTenant: (tenantId: string) => void;
+  onExport: (format: "md" | "json" | "csv") => void;
+  onSplit: () => void;
+}) {
+  const filteredRows = job.deviceRows.filter((row) => {
+    if (filters.tenantId !== "all" && row.tenantId !== filters.tenantId) return false;
+    if (
+      filters.complianceState !== "all" &&
+      normalizeComplianceLabel(row.complianceState) !== filters.complianceState
+    ) {
+      return false;
+    }
+    if (filters.os !== "all" && row.operatingSystem !== filters.os) return false;
+    if (filters.staleOnly && !row.stale) return false;
+    return true;
+  });
+  const visibleComparisons = job.comparisons.filter((comparison) => {
+    if (filters.tenantId !== "all" && comparison.tenantId !== filters.tenantId) return false;
+    if (filters.readiness !== "all" && comparison.status !== filters.readiness) return false;
+    return true;
+  });
+  const osOptions = [...new Set(job.deviceRows.map((row) => row.operatingSystem))].sort();
+  return (
+    <div className="relative left-1/2 w-[min(100%,calc(100vw-380px))] -translate-x-1/2 rounded-xl bg-[var(--color-bg-raised)] ring-1 ring-[var(--color-border-soft)]">
+      <div className="border-b border-[var(--color-border-soft)] p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <div className="text-[12px] font-semibold text-[var(--color-text)]">
+              Multi-tenant result
+            </div>
+            <div className="mt-1 text-[11px] text-[var(--color-text-muted)]">
+              {job.providerName}{job.model ? ` · ${job.model}` : ""} · {formatDateTime(job.updatedAt)}
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button size="sm" variant="ghost" onClick={() => onExport("csv")}>
+              CSV
+            </Button>
+            <Button size="sm" variant="ghost" onClick={() => onExport("json")}>
+              JSON
+            </Button>
+            <Button size="sm" variant="ghost" onClick={() => onExport("md")}>
+              Dossier
+            </Button>
+            <Button size="sm" variant="secondary" leadingIcon={<IconHardDrive size={12} />} onClick={onSplit}>
+              Split to Workspaces
+            </Button>
+          </div>
+        </div>
+        <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+          <SummaryTile label="Tenants" value={job.summary.tenantsScanned} />
+          <SummaryTile label="Windows devices" value={job.summary.windowsDevices} />
+          <SummaryTile label="Compliant" value={job.summary.compliant} tone="success" />
+          <SummaryTile label="Non-compliant" value={job.summary.nonCompliant} tone="danger" />
+        </div>
+        {job.progress.length > 0 && (
+          <div className="mt-3 grid gap-2 lg:grid-cols-2">
+            {job.progress.map((entry) => (
+              <div
+                key={entry.tenantId}
+                className="flex min-w-0 items-start justify-between gap-3 rounded-lg bg-[var(--color-bg)] px-3 py-2 ring-1 ring-[var(--color-border-soft)]"
+              >
+                <div className="min-w-0">
+                  <div className="truncate text-[11.5px] font-medium text-[var(--color-text)]" title={entry.tenantName}>
+                    {entry.tenantName}
+                  </div>
+                  {entry.detail && (
+                    <div className="mt-0.5 truncate text-[10.5px] text-[var(--color-text-muted)]" title={entry.detail}>
+                      {entry.detail}
+                    </div>
+                  )}
+                </div>
+                <Pill
+                  tone={
+                    entry.status === "ready"
+                      ? "success"
+                      : entry.status === "failed"
+                        ? "danger"
+                        : entry.status === "skipped"
+                          ? "default"
+                          : "warning"
+                  }
+                >
+                  {statusLabel(entry.status)}
+                </Pill>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="border-b border-[var(--color-border-soft)] p-3">
+        <div className="flex flex-wrap gap-2">
+          <ArtifactSelect
+            label="Tenant"
+            value={filters.tenantId}
+            onChange={(tenantId) => onFiltersChange({ ...filters, tenantId })}
+            options={[
+              { value: "all", label: "All tenants" },
+              ...job.comparisons.map((tenant) => ({
+                value: tenant.tenantId,
+                label: tenant.tenantName,
+              })),
+            ]}
+          />
+          <ArtifactSelect
+            label="Readiness"
+            value={filters.readiness}
+            onChange={(readiness) => onFiltersChange({ ...filters, readiness })}
+            options={[
+              { value: "all", label: "All readiness" },
+              { value: "ready", label: "Ready" },
+              { value: "stale", label: "Stale" },
+              { value: "failed", label: "Failed" },
+              { value: "skipped", label: "Skipped" },
+            ]}
+          />
+          <ArtifactSelect
+            label="Compliance"
+            value={filters.complianceState}
+            onChange={(complianceState) => onFiltersChange({ ...filters, complianceState })}
+            options={[
+              { value: "all", label: "All compliance" },
+              { value: "compliant", label: "Compliant" },
+              { value: "non-compliant", label: "Non-compliant" },
+              { value: "unknown", label: "Unknown" },
+            ]}
+          />
+          <ArtifactSelect
+            label="OS"
+            value={filters.os}
+            onChange={(os) => onFiltersChange({ ...filters, os })}
+            options={[
+              { value: "all", label: "All OS" },
+              ...osOptions.map((os) => ({ value: os, label: os })),
+            ]}
+          />
+          <label className="inline-flex h-8 items-center gap-2 rounded-md bg-[var(--color-bg)] px-2 text-[11.5px] text-[var(--color-text-soft)] ring-1 ring-[var(--color-border-soft)]">
+            <input
+              type="checkbox"
+              checked={filters.staleOnly}
+              onChange={(event) => onFiltersChange({ ...filters, staleOnly: event.target.checked })}
+              className="h-3.5 w-3.5 accent-[var(--color-accent)]"
+            />
+            Stale only
+          </label>
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-[880px] w-full text-left text-[12px]">
+          <thead className="bg-[var(--color-bg)] text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">
+            <tr>
+              <th className="sticky left-0 z-10 bg-[var(--color-bg)] px-3 py-2" aria-sort="ascending">Tenant</th>
+              <th className="px-3 py-2">Status</th>
+              <th className="px-3 py-2 text-right">Windows</th>
+              <th className="px-3 py-2 text-right">Compliant</th>
+              <th className="px-3 py-2 text-right">Non-compliant</th>
+              <th className="px-3 py-2 text-right">Unknown</th>
+              <th className="px-3 py-2">Last refresh</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visibleComparisons.map((tenant) => {
+              const tenantRows = filteredRows.filter((row) => row.tenantId === tenant.tenantId);
+              const expanded = expandedTenantIds.includes(tenant.tenantId);
+              return (
+                <Fragment key={tenant.tenantId}>
+                  <tr className="border-t border-[var(--color-border-soft)]">
+                    <td className="sticky left-0 z-10 bg-[var(--color-bg-raised)] px-3 py-2">
+                      <button
+                        type="button"
+                        onClick={() => onToggleTenant(tenant.tenantId)}
+                        className={`inline-flex max-w-[240px] items-center gap-1.5 truncate text-left font-medium text-[var(--color-text)] hover:text-[var(--color-accent)] ${focusRingClass}`}
+                        aria-expanded={expanded}
+                      >
+                        {expanded ? <IconChevronDown size={12} /> : <IconChevronRight size={12} />}
+                        <span className="truncate" title={tenant.tenantName}>
+                          {tenant.tenantName}
+                        </span>
+                      </button>
+                    </td>
+                    <td className="px-3 py-2"><ReadinessPill status={tenant.status} /></td>
+                    <td className="px-3 py-2 text-right font-mono tabular-nums">{tenant.windowsDevices}</td>
+                    <td className="px-3 py-2 text-right font-mono tabular-nums text-[var(--color-success)]">{tenant.compliant}</td>
+                    <td className="px-3 py-2 text-right font-mono tabular-nums text-[var(--color-danger)]">{tenant.nonCompliant}</td>
+                    <td className="px-3 py-2 text-right font-mono tabular-nums">{tenant.unknown}</td>
+                    <td className="px-3 py-2 text-[11px] text-[var(--color-text-muted)]">
+                      {tenant.lastRefresh ? formatDateTime(tenant.lastRefresh) : "Unknown"}
+                    </td>
+                  </tr>
+                  {expanded && (
+                    <tr>
+                      <td colSpan={7} className="bg-[var(--color-bg)] px-3 py-3">
+                        <DeviceRowsTable rows={tenantRows} />
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function SummaryTile({
+  label,
+  value,
+  tone = "default",
+}: {
+  label: string;
+  value: number;
+  tone?: "default" | "success" | "danger";
+}) {
+  const toneClass =
+    tone === "success"
+      ? "text-[var(--color-success)]"
+      : tone === "danger"
+        ? "text-[var(--color-danger)]"
+        : "text-[var(--color-text)]";
+  return (
+    <div className="rounded-lg bg-[var(--color-bg)] px-3 py-2 ring-1 ring-[var(--color-border-soft)]">
+      <div className="text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+        {label}
+      </div>
+      <div className={`mt-1 font-mono text-[18px] font-semibold tabular-nums ${toneClass}`}>
+        {value.toLocaleString()}
+      </div>
+    </div>
+  );
+}
+
+function ArtifactSelect({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: { value: string; label: string }[];
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label className="inline-flex h-8 items-center gap-2 rounded-md bg-[var(--color-bg)] px-2 text-[11.5px] text-[var(--color-text-muted)] ring-1 ring-[var(--color-border-soft)]">
+      <span>{label}</span>
+      <select
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="h-6 min-w-[120px] bg-transparent text-[var(--color-text-soft)] outline-none"
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function DeviceRowsTable({ rows }: { rows: MultiTenantChatJob["deviceRows"] }) {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-lg bg-[var(--color-bg-raised)] px-3 py-3 text-[12px] text-[var(--color-text-muted)] ring-1 ring-[var(--color-border-soft)]">
+        No device rows match the current filters.
+      </div>
+    );
+  }
+  return (
+    <div className="overflow-x-auto rounded-lg ring-1 ring-[var(--color-border-soft)]">
+      <table className="min-w-[920px] w-full text-left text-[11.5px]">
+        <thead className="bg-[var(--color-bg-raised)] text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">
+          <tr>
+            <th className="px-3 py-2" aria-sort="none">Device</th>
+            <th className="px-3 py-2">Compliance</th>
+            <th className="px-3 py-2">OS</th>
+            <th className="px-3 py-2">Version</th>
+            <th className="px-3 py-2">Last sync</th>
+            <th className="px-3 py-2">Owner</th>
+            <th className="px-3 py-2">Freshness</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.slice(0, 250).map((row) => (
+            <tr key={`${row.tenantId}:${row.deviceId ?? row.deviceName}`} className="border-t border-[var(--color-border-soft)]">
+              <td className="max-w-[220px] truncate px-3 py-2 text-[var(--color-text)]" title={row.deviceName}>
+                {row.deviceName}
+              </td>
+              <td className="px-3 py-2">
+                <Pill tone={complianceTone(row.complianceState)}>
+                  {normalizeComplianceLabel(row.complianceState)}
+                </Pill>
+              </td>
+              <td className="px-3 py-2 text-[var(--color-text-soft)]">{row.operatingSystem}</td>
+              <td className="px-3 py-2 font-mono text-[var(--color-text-muted)]">{row.osVersion ?? "unknown"}</td>
+              <td className="px-3 py-2 text-[var(--color-text-muted)]">
+                {row.lastSyncDateTime ? formatDateTime(row.lastSyncDateTime) : "unknown"}
+              </td>
+              <td className="max-w-[220px] truncate px-3 py-2 text-[var(--color-text-muted)]" title={row.owner}>
+                {row.owner ?? "unknown"}
+              </td>
+              <td className="px-3 py-2 text-[var(--color-text-muted)]">
+                {row.sourceRefreshedAt ? formatDateTime(row.sourceRefreshedAt) : "unknown"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {rows.length > 250 && (
+        <div className="border-t border-[var(--color-border-soft)] px-3 py-2 text-[11px] text-[var(--color-text-muted)]">
+          Showing first 250 matching rows. Export the dossier for the full local result.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HostedBatchConsentModal({
+  prompt,
+  onClose,
+  onConfirm,
+}: {
+  prompt: HostedBatchConsentPrompt | null;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Modal open={Boolean(prompt)} onClose={onClose} size="lg">
+      <ModalHeader
+        title="Send multi-tenant context to hosted provider"
+        subtitle={prompt?.preflight.providerName ?? "Hosted provider"}
+        badge={<Pill tone="warning">Hosted batch</Pill>}
+        onClose={onClose}
+      />
+      <div className="space-y-4 p-6">
+        <div className="rounded-lg bg-[var(--color-warning-soft)] px-4 py-3 text-[12px] leading-relaxed text-[var(--color-warning)] ring-1 ring-[var(--color-warning)]/25">
+          Retrieved context from {prompt?.preflight.resolvedTenantIds.length ?? 0} tenant
+          {(prompt?.preflight.resolvedTenantIds.length ?? 0) === 1 ? "" : "s"} will be sent to {prompt?.preflight.providerName}.
+        </div>
+        <div className="max-h-52 overflow-y-auto rounded-lg bg-[var(--color-bg-raised)] ring-1 ring-[var(--color-border-soft)]">
+          {prompt?.preflight.tenants.map((tenant) => (
+            <div key={tenant.tenantId} className="flex items-center justify-between gap-3 border-b border-[var(--color-border-soft)] px-3 py-2 last:border-b-0">
+              <div className="min-w-0">
+                <div className="truncate text-[12px] font-medium text-[var(--color-text)]">
+                  {tenant.tenantName}
+                </div>
+                <div className="truncate font-mono text-[10px] text-[var(--color-text-muted)]">
+                  {tenant.username ?? tenant.tenantId}
+                </div>
+              </div>
+              <ReadinessPill status={tenant.status} />
+            </div>
+          ))}
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={onConfirm}>
+            Confirm batch
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function SplitToWorkspacesModal({
+  job,
+  result,
+  onClose,
+  onConfirm,
+}: {
+  job: MultiTenantChatJob | null;
+  result: ImportMultiTenantResultToWorkspacesResult | null;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  const tenants =
+    job?.comparisons.filter((tenant) => tenant.windowsDevices > 0 || tenant.status === "stale") ??
+    [];
+  return (
+    <Modal open={Boolean(job)} onClose={onClose} size="lg">
+      <ModalHeader
+        title="Split result to Workspaces"
+        subtitle="One tenant-specific evidence entry per workspace"
+        badge={<Pill tone="accent">Single-tenant evidence</Pill>}
+        onClose={onClose}
+      />
+      <div className="space-y-4 p-6">
+        <div className="rounded-lg bg-[var(--color-bg-raised)] px-4 py-3 text-[12px] leading-5 text-[var(--color-text-soft)] ring-1 ring-[var(--color-border-soft)]">
+          This does not create a mixed-tenant workspace. Each row below becomes local evidence for that tenant only.
+        </div>
+        <div className="overflow-hidden rounded-lg ring-1 ring-[var(--color-border-soft)]">
+          {tenants.map((tenant) => (
+            <div key={tenant.tenantId} className="grid grid-cols-[1fr_auto_auto] gap-3 border-b border-[var(--color-border-soft)] px-3 py-2 text-[12px] last:border-b-0">
+              <div className="min-w-0">
+                <div className="truncate font-medium text-[var(--color-text)]">{tenant.tenantName}</div>
+                <div className="text-[10.5px] text-[var(--color-text-muted)]">
+                  New workspace evidence · {tenant.windowsDevices} Windows devices
+                </div>
+              </div>
+              <ReadinessPill status={tenant.status} />
+              <span className="font-mono text-[11px] text-[var(--color-text-muted)]">
+                {tenant.lastRefresh ? formatDateTime(tenant.lastRefresh) : "no cache"}
+              </span>
+            </div>
+          ))}
+        </div>
+        {result && (
+          <div className="rounded-lg bg-[var(--color-success-soft)] px-3 py-2 text-[12px] text-[var(--color-success)] ring-1 ring-[var(--color-success)]/25">
+            Created {result.evidence.length} evidence entr{result.evidence.length === 1 ? "y" : "ies"} across {result.workspaces.length} workspace{result.workspaces.length === 1 ? "" : "s"}.
+          </div>
+        )}
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" onClick={onClose}>
+            Close
+          </Button>
+          <Button variant="primary" disabled={tenants.length === 0 || Boolean(result)} onClick={onConfirm}>
+            Create evidence
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function PinMessageToWorkspaceModal({
+  message,
+  workspaces,
+  selectedWorkspaceId,
+  onWorkspaceChange,
+  onClose,
+  onConfirm,
+}: {
+  message: IntuneChatMessage | null;
+  workspaces: WorkspaceSummary[];
+  selectedWorkspaceId: string;
+  onWorkspaceChange: (workspaceId: string) => void;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Modal open={Boolean(message)} onClose={onClose} size="md">
+      <ModalHeader
+        title="Pin answer to workspace"
+        subtitle="Creates tenant-scoped evidence from this chat answer"
+        badge={<Pill tone="accent">Workspace evidence</Pill>}
+        onClose={onClose}
+      />
+      <div className="space-y-4 p-6">
+        <div className="rounded-lg bg-[var(--color-bg-raised)] px-4 py-3 text-[12px] leading-5 text-[var(--color-text-soft)] ring-1 ring-[var(--color-border-soft)]">
+          This stores the answer and visible sources in the selected workspace. Multi-tenant answers must be split into tenant-specific workspace evidence first.
+        </div>
+        <label className="block">
+          <span className="text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+            Workspace
+          </span>
+          <select
+            value={selectedWorkspaceId}
+            onChange={(event) => onWorkspaceChange(event.target.value)}
+            className="mt-2 h-9 w-full rounded-md bg-[var(--color-bg-raised)] px-2 text-[12.5px] text-[var(--color-text)] outline-none ring-1 ring-[var(--color-border-soft)] focus:ring-[var(--color-accent)]"
+            aria-label="Workspace for pinned chat answer"
+          >
+            {workspaces.map((workspace) => (
+              <option key={workspace.id} value={workspace.id}>
+                {workspace.title}
+              </option>
+            ))}
+          </select>
+        </label>
+        {message && (
+          <div className="max-h-36 overflow-y-auto rounded-lg bg-[var(--color-bg)] p-3 text-[12px] leading-5 text-[var(--color-text-muted)] ring-1 ring-[var(--color-border-soft)]">
+            {message.content.slice(0, 600)}
+            {message.content.length > 600 ? "..." : ""}
+          </div>
+        )}
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            disabled={!selectedWorkspaceId || workspaces.length === 0}
+            onClick={onConfirm}
+          >
+            Pin answer
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
 function HostedChatConsentModal({
   prompt,
   remember,
@@ -1236,6 +2912,12 @@ function HostedChatConsentModal({
           <ConsentFact label="Provider" value={prompt?.providerName ?? "Hosted provider"} />
           <ConsentFact label="Model" value={prompt?.model ?? "Provider default"} />
           <ConsentFact label="Stored data" value="Chat history and Graph cache stay local" />
+          {prompt?.workspaceContextSummary && (
+            <ConsentFact
+              label="Workspace"
+              value={`${prompt.workspaceContextSummary.workspaceTitle} · ${prompt.workspaceContextSummary.evidenceCount} evidence · ${prompt.workspaceContextSummary.noteCount} notes`}
+            />
+          )}
         </div>
         <div className="rounded-lg bg-[var(--color-bg-raised)] p-4 ring-1 ring-[var(--color-border-soft)]">
           <div className="flex items-start gap-3">
@@ -1251,6 +2933,9 @@ function HostedChatConsentModal({
                 and answer instructions are sent to the hosted provider for this
                 response. Raw cache tables, chat history storage, and self-training
                 files remain on this device.
+                {prompt?.workspaceContextSummary
+                  ? " Selected workspace evidence, notes, and instructions are included in this response prompt."
+                  : ""}
               </p>
             </div>
           </div>
@@ -1412,7 +3097,7 @@ function ConversationContextMenu({
         type="button"
         role="menuitem"
         onClick={onDelete}
-        className="flex w-full items-center justify-between px-3 py-2 text-left text-[12.5px] text-[var(--color-danger)] transition-colors hover:bg-[var(--color-danger-soft)]"
+        className={`flex w-full items-center justify-between px-3 py-2 text-left text-[12.5px] text-[var(--color-danger)] transition-colors hover:bg-[var(--color-danger-soft)] ${focusRingClass}`}
       >
         Delete conversation
       </button>
@@ -1441,12 +3126,14 @@ function createHostedProviderConsent(
   tenantId: string,
   providerId: ProviderId,
   remember: boolean,
+  workspaceContext?: WorkspacePromptContextSummary,
 ): HostedProviderConsentInput {
   return {
     tenantId,
     providerId,
     acknowledgedAt: new Date().toISOString(),
     ...(remember ? { remember: true } : {}),
+    ...(workspaceContext ? { workspaceContext } : {}),
   };
 }
 
@@ -1682,7 +3369,7 @@ function EmptyChat({
             <button
               key={group.label}
               onClick={() => setActiveGroup(group.label)}
-              className={`rounded-lg px-3 py-1.5 text-[11.5px] transition-colors ${
+              className={`rounded-lg px-3 py-1.5 text-[11.5px] transition-colors ${focusRingClass} ${
                 activeGroup === group.label
                   ? "bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
                   : "bg-[var(--color-bg-raised)] text-[var(--color-text-muted)] ring-1 ring-[var(--color-border-soft)] hover:text-[var(--color-text)]"
@@ -1698,7 +3385,7 @@ function EmptyChat({
               key={prompt}
               disabled={disabled}
               onClick={() => onPrompt(prompt)}
-              className="rounded-xl bg-[var(--color-bg-raised)] px-4 py-3 text-[13px] text-[var(--color-text-soft)] ring-1 ring-[var(--color-border-soft)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-50"
+              className={`rounded-xl bg-[var(--color-bg-raised)] px-4 py-3 text-[13px] text-[var(--color-text-soft)] ring-1 ring-[var(--color-border-soft)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-50 ${focusRingClass}`}
             >
               {prompt}
             </button>
@@ -1719,6 +3406,8 @@ function ChatMessageBubble({
   onEditPrompt,
   onRegenerate,
   onRunAgent,
+  pinDisabled,
+  onPin,
 }: {
   message: IntuneChatMessage;
   progress: ChatProgressState | null;
@@ -1733,6 +3422,8 @@ function ChatMessageBubble({
     conversationId: string,
     messageId: string,
   ) => Promise<void>;
+  pinDisabled: boolean;
+  onPin: () => void;
 }) {
   const isUser = message.role === "user";
   return (
@@ -1807,7 +3498,7 @@ function ChatMessageBubble({
             aria-label={isUser ? "Copy prompt" : "Copy response"}
             disabled={message.content.trim().length === 0}
             onClick={onCopy}
-            className="inline-flex h-6 items-center gap-1 rounded-md px-1.5 transition-colors hover:bg-[var(--color-surface)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-40"
+            className={`inline-flex h-6 items-center gap-1 rounded-md px-1.5 transition-colors hover:bg-[var(--color-surface)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-40 ${focusRingClass}`}
           >
             <IconCopy size={11} />
             <span>{copied ? "Copied" : "Copy"}</span>
@@ -1818,22 +3509,34 @@ function ChatMessageBubble({
               title="Edit and resend prompt"
               aria-label="Edit and resend prompt"
               onClick={onEditPrompt}
-              className="inline-flex h-6 items-center rounded-md px-1.5 transition-colors hover:bg-[var(--color-surface)] hover:text-[var(--color-text)]"
+              className={`inline-flex h-6 items-center rounded-md px-1.5 transition-colors hover:bg-[var(--color-surface)] hover:text-[var(--color-text)] ${focusRingClass}`}
             >
               Edit
             </button>
           )}
           {!isUser && !progress && (
-            <button
-              type="button"
-              title="Regenerate response"
-              aria-label="Regenerate response"
-              disabled={regenerateDisabled}
-              onClick={onRegenerate}
-              className="inline-flex h-6 items-center rounded-md px-1.5 transition-colors hover:bg-[var(--color-surface)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              Regenerate
-            </button>
+            <>
+              <button
+                type="button"
+                title="Pin response to workspace"
+                aria-label="Pin response to workspace"
+                disabled={pinDisabled}
+                onClick={onPin}
+                className="inline-flex h-6 items-center rounded-md px-1.5 transition-colors hover:bg-[var(--color-surface)] hover:text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-accent)] disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Pin answer
+              </button>
+              <button
+                type="button"
+                title="Regenerate response"
+                aria-label="Regenerate response"
+                disabled={regenerateDisabled}
+                onClick={onRegenerate}
+                className={`inline-flex h-6 items-center rounded-md px-1.5 transition-colors hover:bg-[var(--color-surface)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-40 ${focusRingClass}`}
+              >
+                Regenerate
+              </button>
+            </>
           )}
         </div>
       </div>
@@ -2058,6 +3761,66 @@ function capExportContent(content: string): string {
   const maxLength = 1_900_000;
   if (content.length <= maxLength) return content;
   return `${content.slice(0, maxLength)}\n\n_Export truncated by OpenAdminOS because it exceeded the local save limit._\n`;
+}
+
+function detectsAllTenantPrompt(prompt: string): boolean {
+  return /\b(all tenants|every tenant|every connected tenant|all customers|all clients|across tenants|from every tenant)\b/i.test(prompt);
+}
+
+function shouldUseMultiTenantFlow(prompt: string, scopeMode: MultiTenantScopeMode): boolean {
+  return scopeMode !== "active" || detectsAllTenantPrompt(prompt);
+}
+
+function statusLabel(status: string): string {
+  return status
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function normalizeComplianceLabel(value: string): "compliant" | "non-compliant" | "unknown" {
+  const normalized = value.toLowerCase().replace(/[\s_]+/g, "-");
+  if (normalized === "compliant") return "compliant";
+  if (normalized === "noncompliant" || normalized === "non-compliant") {
+    return "non-compliant";
+  }
+  return "unknown";
+}
+
+function complianceTone(value: string): "success" | "danger" | "warning" {
+  const normalized = normalizeComplianceLabel(value);
+  if (normalized === "compliant") return "success";
+  if (normalized === "non-compliant") return "danger";
+  return "warning";
+}
+
+function buildDeviceCsv(job: MultiTenantChatJob): string {
+  const header = [
+    "tenant",
+    "device",
+    "compliance",
+    "operating_system",
+    "os_version",
+    "last_sync",
+    "owner",
+    "source_refreshed_at",
+  ];
+  const rows = job.deviceRows.map((row) => [
+    row.tenantName,
+    row.deviceName,
+    row.complianceState,
+    row.operatingSystem,
+    row.osVersion ?? "",
+    row.lastSyncDateTime ?? "",
+    row.owner ?? "",
+    row.sourceRefreshedAt ?? "",
+  ]);
+  return `${[header, ...rows].map((row) => row.map(csvCell).join(",")).join("\n")}\n`;
+}
+
+function csvCell(value: string): string {
+  if (!/[",\n]/.test(value)) return value;
+  return `"${value.replace(/"/g, '""')}"`;
 }
 
 function safeFileName(value: string): string {

--- a/apps/desktop/src/pages/Workspaces.tsx
+++ b/apps/desktop/src/pages/Workspaces.tsx
@@ -1,0 +1,707 @@
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { Button } from "../components/Button";
+import { Modal, ModalHeader } from "../components/Modal";
+import { Pill } from "../components/Pill";
+import {
+  IconChat,
+  IconChevronRight,
+  IconDownload,
+  IconHardDrive,
+  IconPlus,
+  IconSearch,
+  IconStar,
+} from "../components/icons";
+import { useAppState } from "../state";
+import type {
+  IntuneChatConversation,
+  RunRecord,
+  WorkspaceDetail,
+  WorkspaceSummary,
+} from "../shared/openAdminOS";
+
+const focusRingClass =
+  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-accent)]";
+
+export default function Workspaces() {
+  const { state } = useAppState();
+  const [workspaces, setWorkspaces] = useState<WorkspaceSummary[]>([]);
+  const [activeWorkspaceId, setActiveWorkspaceId] = useState<string | null>(null);
+  const [detail, setDetail] = useState<WorkspaceDetail | null>(null);
+  const [conversations, setConversations] = useState<IntuneChatConversation[]>([]);
+  const [search, setSearch] = useState("");
+  const [notice, setNotice] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [createTitle, setCreateTitle] = useState("");
+  const [createTenantId, setCreateTenantId] = useState(state.activeTenantId ?? "");
+  const [noteText, setNoteText] = useState("");
+  const [instructions, setInstructions] = useState("");
+  const [selectedConversationId, setSelectedConversationId] = useState("");
+  const [selectedRunId, setSelectedRunId] = useState("");
+
+  const loadWorkspaces = async (preferredId?: string | null) => {
+    const api = window.openAdminOS;
+    if (!api) return;
+    const [nextWorkspaces, nextConversations] = await Promise.all([
+      api.listWorkspaces(),
+      api.listIntuneChatConversations(),
+    ]);
+    setWorkspaces(nextWorkspaces);
+    setConversations(nextConversations);
+    const nextId =
+      preferredId !== undefined
+        ? preferredId
+        : activeWorkspaceId && nextWorkspaces.some((workspace) => workspace.id === activeWorkspaceId)
+          ? activeWorkspaceId
+          : nextWorkspaces[0]?.id ?? null;
+    setActiveWorkspaceId(nextId);
+    if (nextId) {
+      const nextDetail = await api.getWorkspace(nextId);
+      setDetail(nextDetail ?? null);
+      setInstructions(nextDetail?.instructions ?? "");
+    } else {
+      setDetail(null);
+      setInstructions("");
+    }
+  };
+
+  useEffect(() => {
+    void loadWorkspaces().catch((caught) =>
+      setError(caught instanceof Error ? caught.message : String(caught)),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.activeTenantId]);
+
+  useEffect(() => {
+    const api = window.openAdminOS;
+    if (!api || !activeWorkspaceId) return;
+    void api
+      .getWorkspace(activeWorkspaceId)
+      .then((nextDetail) => {
+        setDetail(nextDetail ?? null);
+        setInstructions(nextDetail?.instructions ?? "");
+      })
+      .catch((caught) =>
+        setError(caught instanceof Error ? caught.message : String(caught)),
+      );
+  }, [activeWorkspaceId]);
+
+  const filteredWorkspaces = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    if (!needle) return workspaces;
+    return workspaces.filter((workspace) =>
+      `${workspace.title} ${workspace.tenantName ?? ""}`.toLowerCase().includes(needle),
+    );
+  }, [search, workspaces]);
+
+  const tenantRuns = useMemo(() => {
+    if (!detail) return [];
+    return state.runs.filter((run) => !run.tenantId || run.tenantId === detail.tenantId);
+  }, [detail, state.runs]);
+
+  const tenantConversations = useMemo(() => {
+    if (!detail) return [];
+    return conversations.filter(
+      (conversation) =>
+        conversation.scopeKind !== "multi-tenant" &&
+        (!conversation.tenantId || conversation.tenantId === detail.tenantId),
+    );
+  }, [conversations, detail]);
+
+  const handleCreate = async () => {
+    const api = window.openAdminOS;
+    if (!api || !createTitle.trim()) return;
+    setError(null);
+    try {
+      const workspace = await api.createWorkspace({
+        title: createTitle,
+        tenantId: createTenantId || undefined,
+      });
+      setCreateOpen(false);
+      setCreateTitle("");
+      setNotice(`Created workspace ${workspace.title}.`);
+      await loadWorkspaces(workspace.id);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  const handleAddNote = async () => {
+    const api = window.openAdminOS;
+    if (!api || !detail || !noteText.trim()) return;
+    try {
+      await api.addWorkspaceNote(detail.id, noteText);
+      setNoteText("");
+      await loadWorkspaces(detail.id);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  const handleSaveInstructions = async () => {
+    const api = window.openAdminOS;
+    if (!api || !detail) return;
+    try {
+      const updated = await api.updateWorkspace(detail.id, { instructions });
+      setDetail(updated);
+      setNotice("Workspace instructions saved locally.");
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  const handleExport = async () => {
+    const api = window.openAdminOS;
+    if (!api || !detail) return;
+    try {
+      const markdown = await api.exportWorkspaceDossier(detail.id);
+      const result = await api.saveTextFile({
+        suggestedName: `${safeFileName(detail.title)}.md`,
+        content: markdown,
+        filters: [{ name: "Markdown", extensions: ["md"] }],
+      });
+      if (!result.canceled) {
+        setNotice(result.filePath ? `Exported workspace to ${result.filePath}.` : "Exported workspace.");
+      }
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  const handleArchive = async () => {
+    const api = window.openAdminOS;
+    if (!api || !detail) return;
+    try {
+      await api.archiveWorkspace(detail.id);
+      setNotice("Workspace archived. Chat history, run history, and Graph cache were not deleted.");
+      await loadWorkspaces(null);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  const handleDelete = async () => {
+    const api = window.openAdminOS;
+    if (!api || !detail) return;
+    try {
+      await api.deleteWorkspace(detail.id);
+      setDeleteOpen(false);
+      setNotice("Workspace metadata deleted locally. Underlying chats, runs, and cache were left intact.");
+      await loadWorkspaces(null);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  const handleLinkConversation = async () => {
+    const api = window.openAdminOS;
+    if (!api || !detail || !selectedConversationId) return;
+    try {
+      await api.linkWorkspaceConversation(detail.id, selectedConversationId);
+      setSelectedConversationId("");
+      await loadWorkspaces(detail.id);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  const handleLinkRun = async () => {
+    const api = window.openAdminOS;
+    if (!api || !detail || !selectedRunId) return;
+    try {
+      await api.linkWorkspaceRun(detail.id, selectedRunId);
+      setSelectedRunId("");
+      await loadWorkspaces(detail.id);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 overflow-hidden bg-[var(--color-bg)]">
+      <aside className="flex w-[320px] shrink-0 flex-col border-r border-[var(--color-border-soft)] bg-[var(--color-sidebar-solid)]">
+        <div className="border-b border-[var(--color-border-soft)] px-4 py-4">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <div className="text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+                Workspaces
+              </div>
+              <div className="mt-1 text-[13px] text-[var(--color-text-soft)]">
+                Single-tenant investigations
+              </div>
+            </div>
+            <Button
+              size="sm"
+              variant="secondary"
+              leadingIcon={<IconPlus size={12} />}
+              onClick={() => {
+                setCreateTenantId(state.activeTenantId ?? state.tenants[0]?.id ?? "");
+                setCreateOpen(true);
+              }}
+            >
+              New
+            </Button>
+          </div>
+          <div className="relative mt-3">
+            <IconSearch
+              size={13}
+              className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--color-text-muted)]"
+            />
+            <input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search workspaces"
+              className="h-8 w-full rounded-md bg-[var(--color-bg-raised)] pl-8 pr-2 text-[12px] text-[var(--color-text)] outline-none ring-1 ring-[var(--color-border-soft)] placeholder:text-[var(--color-text-muted)] focus:ring-[var(--color-accent)]"
+            />
+          </div>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto p-2">
+          {filteredWorkspaces.length === 0 ? (
+            <div className="rounded-lg px-3 py-5 text-[12px] leading-5 text-[var(--color-text-muted)]">
+              No workspaces yet. Create one from an investigation, split a multi-tenant result, or start with a note.
+            </div>
+          ) : (
+            filteredWorkspaces.map((workspace) => (
+              <button
+                key={workspace.id}
+                type="button"
+                onClick={() => setActiveWorkspaceId(workspace.id)}
+                className={`mb-1 w-full rounded-lg px-3 py-2.5 text-left transition-colors ${focusRingClass} ${
+                  activeWorkspaceId === workspace.id
+                    ? "bg-[var(--color-surface-hover)] text-[var(--color-text)]"
+                    : "text-[var(--color-text-soft)] hover:bg-[var(--color-surface)] hover:text-[var(--color-text)]"
+                }`}
+              >
+                <div className="flex items-center gap-2">
+                  <IconHardDrive size={13} className="text-[var(--color-accent)]" />
+                  <span className="min-w-0 flex-1 truncate text-[12.5px] font-medium">
+                    {workspace.title}
+                  </span>
+                  <IconChevronRight size={11} />
+                </div>
+                <div className="mt-1 truncate text-[10.5px] text-[var(--color-text-muted)]">
+                  {workspace.tenantName ?? workspace.tenantId}
+                </div>
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  <MiniStat label="evidence" value={workspace.evidenceCount} />
+                  <MiniStat label="chats" value={workspace.conversationCount} />
+                  <MiniStat label="runs" value={workspace.runCount} />
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+      </aside>
+
+      <section className="flex min-w-0 flex-1 flex-col">
+        <header className="flex h-14 shrink-0 items-center justify-between gap-4 border-b border-[var(--color-border-soft)] px-6">
+          <div className="min-w-0">
+            <div className="truncate text-[13px] font-medium text-[var(--color-text)]">
+              {detail?.title ?? "No workspace selected"}
+            </div>
+            <div className="mt-0.5 truncate text-[11px] text-[var(--color-text-muted)]">
+              {detail
+                ? `${detail.tenantName ?? detail.tenantId} · updated ${formatDateTime(detail.updatedAt)}`
+                : "Workspace evidence stays local and tenant-scoped."}
+            </div>
+          </div>
+          {detail && (
+            <div className="flex shrink-0 gap-2">
+              <Button size="sm" variant="ghost" leadingIcon={<IconDownload size={12} />} onClick={() => void handleExport()}>
+                Export
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => void handleArchive()}>
+                Archive
+              </Button>
+              <Button size="sm" variant="danger" onClick={() => setDeleteOpen(true)}>
+                Delete
+              </Button>
+            </div>
+          )}
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+          {error && (
+            <div className="mb-3 rounded-lg bg-[var(--color-danger-soft)] px-3 py-2 text-[12px] text-[var(--color-danger)] ring-1 ring-[var(--color-danger)]/25">
+              {error}
+            </div>
+          )}
+          {notice && (
+            <div className="mb-3 rounded-lg bg-[var(--color-success-soft)] px-3 py-2 text-[12px] text-[var(--color-success)] ring-1 ring-[var(--color-success)]/25">
+              {notice}
+            </div>
+          )}
+          {!detail ? (
+            <EmptyWorkspaceState onCreate={() => setCreateOpen(true)} />
+          ) : (
+            <div className="grid gap-4 xl:grid-cols-[1fr_320px]">
+              <div className="min-w-0 space-y-4">
+                <WorkspaceSection
+                  title="Pinned evidence"
+                  badge={`${detail.evidence.length}`}
+                >
+                  {detail.evidence.length === 0 ? (
+                    <EmptyInline text="Evidence pinned from chat, runs, and split multi-tenant results appears here." />
+                  ) : (
+                    <div className="grid gap-2">
+                      {detail.evidence.map((evidence) => (
+                        <div key={evidence.id} className="rounded-lg bg-[var(--color-bg-raised)] p-3 ring-1 ring-[var(--color-border-soft)]">
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <div className="min-w-0">
+                              <div className="truncate text-[12.5px] font-medium text-[var(--color-text)]">
+                                {evidence.title}
+                              </div>
+                              <div className="mt-0.5 text-[10.5px] text-[var(--color-text-muted)]">
+                                {evidence.sourceType} · {formatDateTime(evidence.createdAt)}
+                              </div>
+                            </div>
+                            <Pill tone={evidence.freshness?.cacheStatus === "stale" ? "warning" : "default"}>
+                              {evidence.freshness?.refreshedAt
+                                ? formatDateTime(evidence.freshness.refreshedAt)
+                                : "freshness unknown"}
+                            </Pill>
+                          </div>
+                          <pre className="mt-3 max-h-48 overflow-auto rounded-md bg-[var(--color-bg)] p-3 font-mono text-[10.5px] leading-5 text-[var(--color-text-muted)] ring-1 ring-[var(--color-border-soft)]">
+                            {JSON.stringify(evidence.content, null, 2)}
+                          </pre>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </WorkspaceSection>
+
+                <WorkspaceSection title="Notes" badge={`${detail.notes.length}`}>
+                  <div className="flex gap-2">
+                    <textarea
+                      value={noteText}
+                      onChange={(event) => setNoteText(event.target.value)}
+                      placeholder="Add a local investigation note"
+                      className="min-h-20 flex-1 resize-y rounded-lg bg-[var(--color-bg-raised)] px-3 py-2 text-[12.5px] text-[var(--color-text)] outline-none ring-1 ring-[var(--color-border-soft)] placeholder:text-[var(--color-text-muted)] focus:ring-[var(--color-accent)]"
+                    />
+                    <Button variant="secondary" disabled={!noteText.trim()} onClick={() => void handleAddNote()}>
+                      Add
+                    </Button>
+                  </div>
+                  <div className="mt-3 grid gap-2">
+                    {detail.notes.length === 0 ? (
+                      <EmptyInline text="No notes recorded for this workspace." />
+                    ) : (
+                      detail.notes.map((note) => (
+                        <div key={note.id} className="rounded-lg bg-[var(--color-bg-raised)] px-3 py-2 ring-1 ring-[var(--color-border-soft)]">
+                          <div className="text-[12.5px] leading-5 text-[var(--color-text-soft)]">
+                            {note.content}
+                          </div>
+                          <div className="mt-1 text-[10.5px] text-[var(--color-text-muted)]">
+                            {formatDateTime(note.updatedAt)}
+                          </div>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </WorkspaceSection>
+              </div>
+
+              <div className="space-y-4">
+                <WorkspaceSection title="Linked context" badge={`${detail.links.length}`}>
+                  <div className="space-y-3">
+                    <LinkPicker
+                      label="Conversation"
+                      value={selectedConversationId}
+                      onChange={setSelectedConversationId}
+                      options={tenantConversations.map((conversation) => ({
+                        value: conversation.id,
+                        label: conversation.title,
+                      }))}
+                      onLink={() => void handleLinkConversation()}
+                    />
+                    <LinkPicker
+                      label="Run"
+                      value={selectedRunId}
+                      onChange={setSelectedRunId}
+                      options={tenantRuns.map((run) => ({
+                        value: run.id,
+                        label: runTitle(run),
+                      }))}
+                      onLink={() => void handleLinkRun()}
+                    />
+                    {detail.links.length === 0 ? (
+                      <EmptyInline text="No linked chats or agent runs." />
+                    ) : (
+                      detail.links.map((link) => (
+                        <div key={link.id} className="flex items-center gap-2 rounded-lg bg-[var(--color-bg-raised)] px-3 py-2 ring-1 ring-[var(--color-border-soft)]">
+                          {link.type === "conversation" ? <IconChat size={13} /> : <IconStar size={13} />}
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate text-[12px] text-[var(--color-text)]">{link.title}</div>
+                            <div className="text-[10.5px] text-[var(--color-text-muted)]">{link.type}</div>
+                          </div>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </WorkspaceSection>
+
+                <WorkspaceSection title="Local instructions">
+                  <textarea
+                    value={instructions}
+                    onChange={(event) => setInstructions(event.target.value)}
+                    placeholder="Approved local instructions for this workspace"
+                    className="min-h-40 w-full resize-y rounded-lg bg-[var(--color-bg-raised)] px-3 py-2 text-[12.5px] leading-5 text-[var(--color-text)] outline-none ring-1 ring-[var(--color-border-soft)] placeholder:text-[var(--color-text-muted)] focus:ring-[var(--color-accent)]"
+                  />
+                  <div className="mt-2 flex items-center justify-between gap-3">
+                    <div className="text-[10.5px] leading-4 text-[var(--color-text-muted)]">
+                      Instructions affect explicit prompt context only. They cannot add scopes or bypass confirmation.
+                    </div>
+                    <Button size="sm" variant="secondary" onClick={() => void handleSaveInstructions()}>
+                      Save
+                    </Button>
+                  </div>
+                </WorkspaceSection>
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <CreateWorkspaceModal
+        open={createOpen}
+        title={createTitle}
+        tenantId={createTenantId}
+        tenants={state.tenants}
+        onTitleChange={setCreateTitle}
+        onTenantChange={setCreateTenantId}
+        onClose={() => setCreateOpen(false)}
+        onConfirm={() => void handleCreate()}
+      />
+      <DeleteWorkspaceModal
+        open={deleteOpen}
+        workspace={detail}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={() => void handleDelete()}
+      />
+    </div>
+  );
+}
+
+function WorkspaceSection({
+  title,
+  badge,
+  children,
+}: {
+  title: string;
+  badge?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="rounded-lg bg-[var(--color-bg)] p-3 ring-1 ring-[var(--color-border-soft)]">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div className="text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+          {title}
+        </div>
+        {badge && <Pill>{badge}</Pill>}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function MiniStat({ label, value }: { label: string; value: number }) {
+  return (
+    <span className="rounded bg-[var(--color-bg-raised)] px-1.5 py-0.5 font-mono text-[10px] text-[var(--color-text-muted)]">
+      {value} {label}
+    </span>
+  );
+}
+
+function EmptyWorkspaceState({ onCreate }: { onCreate: () => void }) {
+  return (
+    <div className="flex min-h-[420px] items-center justify-center">
+      <div className="max-w-[520px] text-center">
+        <div className="mx-auto flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--color-accent-soft)] text-[var(--color-accent)]">
+          <IconHardDrive size={20} />
+        </div>
+        <h1 className="mt-5 text-[22px] font-semibold tracking-tight text-[var(--color-text)]">
+          No workspace selected
+        </h1>
+        <p className="mt-2 text-[13px] leading-6 text-[var(--color-text-soft)]">
+          Workspaces keep tenant-specific evidence, notes, linked chats, runs, and local instructions together.
+        </p>
+        <div className="mt-5">
+          <Button variant="primary" leadingIcon={<IconPlus size={13} />} onClick={onCreate}>
+            Create workspace
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyInline({ text }: { text: string }) {
+  return (
+    <div className="rounded-lg bg-[var(--color-bg-raised)] px-3 py-3 text-[12px] text-[var(--color-text-muted)] ring-1 ring-[var(--color-border-soft)]">
+      {text}
+    </div>
+  );
+}
+
+function LinkPicker({
+  label,
+  value,
+  options,
+  onChange,
+  onLink,
+}: {
+  label: string;
+  value: string;
+  options: { value: string; label: string }[];
+  onChange: (value: string) => void;
+  onLink: () => void;
+}) {
+  return (
+    <div className="flex gap-2">
+      <select
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="min-w-0 flex-1 rounded-md bg-[var(--color-bg-raised)] px-2 text-[12px] text-[var(--color-text-soft)] outline-none ring-1 ring-[var(--color-border-soft)] focus:ring-[var(--color-accent)]"
+        aria-label={`Link ${label}`}
+      >
+        <option value="">Link {label.toLowerCase()}</option>
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      <Button size="sm" variant="secondary" disabled={!value} onClick={onLink}>
+        Link
+      </Button>
+    </div>
+  );
+}
+
+function CreateWorkspaceModal({
+  open,
+  title,
+  tenantId,
+  tenants,
+  onTitleChange,
+  onTenantChange,
+  onClose,
+  onConfirm,
+}: {
+  open: boolean;
+  title: string;
+  tenantId: string;
+  tenants: { id: string; displayName: string }[];
+  onTitleChange: (title: string) => void;
+  onTenantChange: (tenantId: string) => void;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Modal open={open} onClose={onClose} size="md">
+      <ModalHeader title="Create workspace" subtitle="Single-tenant local investigation" onClose={onClose} />
+      <div className="space-y-4 p-6">
+        <label className="block">
+          <span className="text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+            Title
+          </span>
+          <input
+            value={title}
+            onChange={(event) => onTitleChange(event.target.value)}
+            autoFocus
+            className="mt-2 h-10 w-full rounded-lg bg-[var(--color-bg-raised)] px-3 text-[13px] text-[var(--color-text)] outline-none ring-1 ring-[var(--color-border-soft)] focus:ring-[var(--color-accent)]"
+          />
+        </label>
+        <label className="block">
+          <span className="text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+            Tenant
+          </span>
+          <select
+            value={tenantId}
+            onChange={(event) => onTenantChange(event.target.value)}
+            className="mt-2 h-10 w-full rounded-lg bg-[var(--color-bg-raised)] px-3 text-[13px] text-[var(--color-text)] outline-none ring-1 ring-[var(--color-border-soft)] focus:ring-[var(--color-accent)]"
+          >
+            {tenants.map((tenant) => (
+              <option key={tenant.id} value={tenant.id}>
+                {tenant.displayName}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className="rounded-lg bg-[var(--color-bg-raised)] px-3 py-2 text-[12px] leading-5 text-[var(--color-text-muted)] ring-1 ring-[var(--color-border-soft)]">
+          Workspaces cannot mix tenant evidence. Multi-tenant chat results must be split into tenant-specific evidence entries.
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="primary" disabled={!title.trim() || !tenantId} onClick={onConfirm}>
+            Create
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function DeleteWorkspaceModal({
+  open,
+  workspace,
+  onClose,
+  onConfirm,
+}: {
+  open: boolean;
+  workspace: WorkspaceDetail | null;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Modal open={open} onClose={onClose} size="md">
+      <ModalHeader
+        title="Delete workspace metadata"
+        subtitle={workspace?.title ?? "Workspace"}
+        badge={<Pill tone="danger">Local delete</Pill>}
+        onClose={onClose}
+      />
+      <div className="space-y-4 p-6">
+        <div className="rounded-lg bg-[var(--color-danger-soft)] px-4 py-3 text-[12px] leading-5 text-[var(--color-danger)] ring-1 ring-[var(--color-danger)]/25">
+          This removes workspace notes, pinned evidence, local instructions, and links. Chat history, run history, tenant configuration, Graph cache, connector audit records, and self-training records are left intact.
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={onConfirm}>
+            Delete metadata
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function runTitle(run: RunRecord): string {
+  return `${run.agentSlug} · ${run.status}`;
+}
+
+function formatDateTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function safeFileName(value: string): string {
+  const cleaned = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+  return cleaned || "workspace";
+}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -788,6 +788,94 @@ decision. Electron main validates that acknowledgement against the active tenant
 and provider before creating chat messages, refreshing Graph cache resources, or
 building the hosted LLM prompt.
 
+Intune Chat supports multi-tenant read questions as a separate explicit mode
+from normal active-tenant chat. The default scope remains the active tenant. If
+the prompt asks for "all tenants", "every connected tenant", or similar MSP
+language, the composer surfaces a scope review before any Graph refresh or model
+prompt is built. The review names the selected tenants, required Graph resource
+kinds, cache freshness, missing scopes, expired sessions, provider trust, and
+whether any tenant will be skipped. The admin can choose the active tenant,
+selected tenants, or all connected tenants; "all connected tenants" is never
+implied silently by merely having multiple tenants connected.
+
+Tenant groups are local shortcuts for common MSP slices such as "All customers",
+"Pilot tenants", or "EU tenants". A group is not a new tenant boundary and it
+does not grant broader access; it resolves to explicit tenant ids in the scope
+review before any Graph refresh or model prompt is built. Saved multi-tenant
+queries are local prompt templates with declared resource hints and optional
+scope hints. They can prefill the composer for common investigations, but the
+admin can edit the prompt and must still approve the resolved tenant scope.
+
+Multi-tenant chat is read-only aggregation. It can answer questions like
+"List all compliant and non-compliant Windows devices from every connected
+tenant" by refreshing or reading each tenant's local Graph cache, computing the
+counts and device rows deterministically, and then asking the selected model to
+summarize the bounded result. The table/export is the source of truth; the LLM
+explains the findings and caveats. Multi-tenant chat must not perform Graph
+writes, connector delivery, or agent side effects directly. When a prompt maps
+to an agent workflow across tenants, OpenAdminOS creates a multi-tenant job that
+queues one normal tenant-pinned `RunRecord` per tenant rather than one run that
+spans tenants. Write agents require per-tenant review and typed confirmation;
+there is no "confirm all tenants" destructive shortcut.
+
+Before a multi-tenant run starts, Electron main performs a readiness preflight
+for every resolved tenant. The preflight reports whether each tenant is ready,
+expired, missing delegated scopes, stale, recently throttled, blocked by hosted
+provider consent, skipped, or failed. The UI shows recovery actions beside the
+affected tenant, such as reconnecting the tenant, granting missing scopes,
+refreshing cache, or removing the tenant from the run. A skipped or failed tenant
+must be visible in the final answer and export; it cannot disappear from the
+scope silently.
+
+The multi-tenant visual flow is:
+
+1. **Scope review** in the assistant response slot before work starts: tenant
+   checklist, resolved group membership, selected resources, readiness,
+   freshness, scopes, provider/model, and a "Run read-only query" action.
+2. **Per-tenant progress** while the job runs: each tenant row shows queued,
+   refreshing cache, reading local cache, building result, skipped, failed, or
+   ready. Refreshes run with bounded concurrency so one throttled tenant does not
+   block the whole UI.
+3. **Aggregate answer** with compact summary tiles for tenants scanned, failed
+   tenants, Windows devices, compliant, non-compliant, unknown, and stale-data
+   caveats.
+4. **Tenant comparison table** with columns such as tenant, Windows devices,
+   compliant, non-compliant, unknown, last refresh, and status.
+5. **Expandable tenant detail** for device rows, filtered by tenant, compliance
+   state, OS version, and last sync. Export actions are local and explicit
+   (`CSV`, `Markdown`, or `JSON`).
+
+Multi-tenant result tables include filters for tenant, readiness, compliance
+state, operating system, stale data, failed tenants, and skipped tenants. The
+admin can export a compact local dossier that includes the original query,
+resolved tenant scope, saved-query id if used, provider/model, cache freshness,
+skipped/failed tenants, summary counts, comparison table, and detail rows.
+Dossiers are local files, not connector sends, background uploads, or telemetry.
+They may be reopened from multi-tenant job history while clearly showing whether
+the underlying cache has become stale.
+
+Multi-tenant chat uses an "answer artifact" layout for table-heavy results. The
+normal prose answer keeps the readable chat measure, but the result artifact can
+span the available conversation column so comparison tables, filters, and export
+actions do not feel cramped. The table keeps the tenant column visible, supports
+keyboard sorting/filtering, uses text plus icons rather than color alone for
+readiness/compliance state, and allows horizontal overflow inside the artifact
+instead of widening the whole page. Long tenant names, device names, and policy
+names truncate with accessible full-value disclosure. The saved-query picker and
+tenant scope selector live near the composer/header as compact controls; they do
+not replace the assistant-slot scope review, which remains the final checkpoint
+before work starts. Result filters, expanded tenant rows, and selected saved
+query are persisted in the local multi-tenant job state so reopening the result
+restores the investigation context.
+
+Hosted-provider confirmation for multi-tenant chat names every selected tenant
+or shows a counted tenant list with expandable details, names the provider and
+model, and states that retrieved context from those tenants will be sent to the
+hosted provider. Remembered hosted-provider consent remains scoped by
+tenant/provider; a multi-tenant send may proceed only for tenants with remembered
+consent or a fresh batch acknowledgement. Local-provider sends keep Graph data,
+prompts, answer packs, and exports on the device.
+
 The chat page should behave like a focused chat product, not an operations
 dashboard: history on the left, the active conversation and composer in the
 center, and only compact tenant/provider/freshness cues in the chat header.
@@ -821,12 +909,47 @@ cache rows, and self-training event/suggestion counts. Clearing all chat history
 uses an explicit product modal and removes only local conversations, messages,
 and chat tool-call records.
 
-Claude-style Projects are a useful reference, but the OpenAdminOS version should
-be tenant-scoped investigative workspaces rather than generic project folders:
-pinned Graph evidence, relevant agent runs, notes, approved local instructions,
-and source freshness for a specific tenant problem. This is deferred beyond the
-first v0.2.2 chat pass. TODO(ugur): decide the public naming and route shape for
-these workspaces before implementation.
+Claude-style Projects are a useful reference, but the OpenAdminOS version is
+called **Workspaces**. Workspaces are tenant-scoped investigation containers, not
+generic project folders. A workspace holds pinned Graph evidence, linked chat
+conversations, relevant agent runs, local notes, approved local instructions,
+and source freshness for a specific tenant problem. Workspaces stay local-first:
+with a local provider, workspace notes, pinned evidence, chat context, and prompt
+overlays stay on the device; with a hosted provider, any workspace context sent
+to the model follows the same explicit hosted-provider confirmation rules as
+Intune Chat. Workspaces is a top-level primary navigation item at `/workspaces`,
+placed directly after Intune Chat. Intune Chat, Activity, and Run Detail expose
+contextual add/link/pin actions into Workspaces. Workspaces remain
+single-tenant; multi-tenant Intune Chat results can export locally or create/link
+separate tenant-specific workspace evidence, but a single workspace must not mix
+tenant evidence in v0.2.5. The split-to-workspaces action shows a review screen
+with one row per tenant, the target workspace or new workspace name, the evidence
+row count, and freshness. Confirming writes separate local evidence bundles only
+to matching tenant workspaces; cancelling leaves the multi-tenant result
+unchanged.
+
+The Workspaces layout is a dense two-pane investigation surface: a workspace
+list/search pane on the left and the selected workspace detail on the right. The
+detail view groups notes, pinned evidence, linked conversations, linked runs, and
+workspace-local instructions into clear sections without nesting cards inside
+cards or becoming a project board. On narrower desktop widths, the list can
+collapse to preserve evidence reading width, but the global sidebar and status
+strip remain visible. Workspace filters, selected section, and expanded evidence
+groups restore when the admin returns to a workspace.
+
+v0.2.5 ships the read-only multi-tenant Intune Chat path, single-tenant
+Workspace storage/linking, separate multi-tenant progress streaming IPC,
+tenant-pinned agent batch records, chat-answer pinning into Workspaces, and
+explicit workspace context attachment in the chat composer. Cross-tenant agent
+batches never create a mixed-tenant execution context: Electron main queues one
+normal `RunRecord` per ready tenant. Write agents still move through the normal
+per-run plan review and typed confirmation flow, with no "confirm all tenants"
+shortcut. Workspace context attachment is opt-in per prompt and can include
+selected evidence, notes, and workspace instructions only after the UI shows the
+included items. When a hosted provider is active, the confirmation also names
+the attached workspace, tenant, provider, model, evidence count, note count, and
+whether instructions are included before any workspace context enters the model
+prompt.
 
 #### Graph cache
 
@@ -1338,6 +1461,8 @@ Registry QA is expected to run cleanly for bundled agents. When the upstream Mic
 | `08-tenant-switcher.html` | Multi-tenant management | ✅ Done |
 | `09-registry.html` | Community agent registry browse | ⏳ TODO |
 | `10-empty-states.html` | First-time user empty states | ⏳ TODO |
+| `11-multi-tenant-chat.html` | Multi-tenant Intune Chat scope review and result artifact | ✅ Done |
+| `12-workspaces.html` | Single-tenant Workspaces investigation surface | ✅ Done |
 
 When implementing screens in production code, port the design tokens from `_design.css` to the production app's theme system (Tailwind config or CSS variables in the global stylesheet). Build the components listed in §3 as proper React components, not as one-off implementations per screen.
 

--- a/docs/gitbook/features/multi-tenant-intune-chat.md
+++ b/docs/gitbook/features/multi-tenant-intune-chat.md
@@ -1,0 +1,35 @@
+# Multi-tenant Intune Chat
+
+Multi-tenant Intune Chat is for read-only MSP-style investigations across connected tenants. The default chat scope remains the active tenant. When a prompt asks for all tenants, every connected tenant, selected tenants, or all customers, OpenAdminOS opens a scope review before it refreshes Graph cache data or builds a model prompt.
+
+The scope review shows the resolved tenant list, selected tenant groups, planned Graph resources, cache freshness, provider and model, missing scopes, expired sessions, throttling warnings, and any tenant that will be skipped. Tenant groups are local shortcuts only; they expand into explicit tenant ids before the run starts.
+
+## Saved queries
+
+Saved queries prefill common read-only investigations, including Windows compliance, stale Windows devices, BitLocker gaps, risky sign-ins, and Conditional Access gaps. They do not silently broaden the scope. You can edit the prompt and must still review the selected tenants before running.
+
+## Result artifacts
+
+For Windows compliance prompts, OpenAdminOS computes tenant counts and device rows deterministically from the local Graph cache. The assistant summary explains the result, but the table and export are the source of truth.
+
+The result artifact includes:
+
+- Tenant readiness and progress.
+- Summary counts for tenants, failed tenants, Windows devices, compliant devices, non-compliant devices, unknown devices, and stale data.
+- Tenant comparison rows.
+- Expandable device rows with tenant, device name, compliance state, OS, OS version, last sync, owner, and source freshness.
+- Filters for tenant, readiness, compliance state, OS, and stale data.
+
+One expired, throttled, or failed tenant does not fail the whole answer. Failed and skipped tenants stay visible in the result and in exported dossiers.
+
+## Exports and Workspaces
+
+Exports are explicit local file saves. Multi-tenant results can be exported as CSV, JSON, or a Markdown dossier containing the original query, resolved tenant scope, provider/model, freshness, skipped tenants, summary, and detail rows.
+
+Multi-tenant results can also be split into Workspaces. This creates or links separate tenant-specific evidence entries. A single Workspace cannot contain mixed-tenant evidence.
+
+## Hosted providers
+
+With a local provider, tenant data, prompts, answer packs, and exports stay on the device. With a hosted provider, OpenAdminOS requires a fresh batch confirmation naming the selected tenants and provider before retrieved tenant context is sent to that provider.
+
+Multi-tenant chat never performs Graph writes or connector delivery. Cross-tenant agent batches queue one normal tenant-pinned run per ready tenant. Write agents still require per-run plan review and typed confirmation; there is no confirm-all-tenants shortcut.

--- a/docs/gitbook/features/workspaces.md
+++ b/docs/gitbook/features/workspaces.md
@@ -1,0 +1,33 @@
+# Workspaces
+
+Workspaces are local, tenant-scoped investigation containers. They keep pinned evidence, linked Intune Chat conversations, linked agent runs, notes, and workspace-local instructions together for one tenant problem.
+
+Workspaces are not multi-tenant projects. A workspace belongs to one tenant. Multi-tenant Intune Chat results can be exported locally or split into separate tenant-specific workspace evidence, but one workspace cannot mix evidence from multiple tenants.
+
+## What a Workspace Stores
+
+A workspace can contain:
+
+- Pinned evidence from Graph cache rows, chat answers, run results, or split multi-tenant results.
+- Notes written by the admin.
+- Links to existing chat conversations.
+- Links to existing agent runs.
+- Local instructions for explicit prompt/context composition.
+
+Linked chats and runs are not copied into a second store. Deleting a workspace removes workspace metadata, notes, pins, and links only. It does not delete tenant configuration, chat history, run history, Graph cache, connector audit records, or self-training records.
+
+## Evidence Freshness
+
+Pinned evidence keeps source metadata when available: tenant, resource kind, refreshed time, row count, cache/live status, and source reference. This makes stale evidence visible instead of treating an old cache row as current.
+
+## Local Instructions
+
+Workspace instructions are local text scoped to the workspace tenant. They cannot add Graph scopes, change an agent from read to write, alter connector delivery, or bypass write confirmation.
+
+Workspace context is explicit. OpenAdminOS shows selected evidence, notes, and instructions before they are attached to a prompt. If a hosted provider is active, the hosted-provider confirmation names the workspace, tenant, provider, model, and included context before anything is sent.
+
+## Export and Deletion
+
+Workspace export creates a local Markdown dossier with notes, linked context, pinned evidence metadata, run links, and freshness. It does not upload anything.
+
+Archiving or deleting a workspace only changes local workspace records. The underlying chats, runs, tenant connection, Graph cache, and connector audit history remain intact.

--- a/docs/mockups/11-multi-tenant-chat.html
+++ b/docs/mockups/11-multi-tenant-chat.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>OpenAdminOS - Multi-tenant Intune Chat</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="_design.css">
+<style>
+.main { background: var(--bg-0); min-width: 0; display: grid; grid-template-columns: 260px minmax(0, 1fr); }
+.rail { border-right: 1px solid var(--border); background: var(--bg-1); padding: 16px; overflow: hidden; }
+.rail h2, .content h1 { font-size: 14px; font-weight: 600; margin-bottom: 10px; }
+.search { width: 100%; background: var(--bg-2); border: 1px solid var(--border); border-radius: 6px; color: var(--text-0); padding: 8px 10px; font: inherit; margin-bottom: 14px; }
+.chat-row { border: 1px solid transparent; border-radius: 6px; padding: 10px; margin-bottom: 8px; color: var(--text-1); }
+.chat-row.active { background: var(--accent-bg); border-color: rgba(0, 212, 255, 0.22); color: var(--text-0); }
+.chat-title { font-size: 12px; font-weight: 600; margin-bottom: 3px; }
+.chat-meta, .muted { font-size: 11px; color: var(--text-2); }
+.content { min-width: 0; display: flex; flex-direction: column; overflow: hidden; }
+.chat-header { height: 58px; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; padding: 0 18px; }
+.scope-controls { display: flex; align-items: center; gap: 8px; }
+.pill, .button { border: 1px solid var(--border); background: var(--bg-2); color: var(--text-1); border-radius: 6px; font-size: 11px; padding: 6px 9px; display: inline-flex; align-items: center; gap: 6px; }
+.pill.accent { color: var(--accent); border-color: rgba(0, 212, 255, 0.28); background: var(--accent-bg); }
+.pill.warn { color: var(--warning); border-color: rgba(251, 191, 36, 0.25); background: rgba(251, 191, 36, 0.08); }
+.button.primary { color: var(--bg-0); background: var(--accent); border-color: var(--accent); font-weight: 600; }
+.messages { flex: 1; overflow: auto; padding: 22px 24px; }
+.message { max-width: 760px; margin: 0 auto 16px; }
+.message.user { display: flex; justify-content: flex-end; }
+.bubble { border: 1px solid var(--border); background: var(--bg-1); border-radius: 8px; padding: 12px 14px; color: var(--text-1); }
+.user .bubble { background: var(--bg-2); color: var(--text-0); max-width: 560px; }
+.review-card, .artifact { max-width: 1040px; margin: 0 auto 18px; background: var(--bg-1); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+.card-head { padding: 14px 16px; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.card-title { font-size: 13px; font-weight: 600; }
+.card-sub { color: var(--text-2); font-size: 11px; margin-top: 2px; }
+.review-grid { display: grid; grid-template-columns: 1.15fr 0.85fr; gap: 14px; padding: 16px; }
+.tenant-list { display: grid; gap: 8px; }
+.tenant-line { display: grid; grid-template-columns: 1fr auto; gap: 12px; padding: 9px 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg-2); }
+.tenant-name-line { font-weight: 600; font-size: 12px; }
+.status { font-family: 'JetBrains Mono', monospace; font-size: 10px; text-transform: uppercase; letter-spacing: .08em; }
+.status.ready { color: var(--success); }
+.status.stale, .status.running { color: var(--warning); }
+.status.failed { color: var(--danger); }
+.scope-box { border: 1px solid var(--border); border-radius: 6px; background: var(--bg-2); padding: 12px; }
+.scope-box + .scope-box { margin-top: 10px; }
+.kv { display: grid; grid-template-columns: 128px 1fr; gap: 8px; font-size: 11px; padding: 4px 0; }
+.kv span:first-child { color: var(--text-2); }
+.tiles { display: grid; grid-template-columns: repeat(6, minmax(110px, 1fr)); gap: 8px; padding: 14px 16px; border-bottom: 1px solid var(--border); }
+.tile { background: var(--bg-2); border: 1px solid var(--border); border-radius: 6px; padding: 10px; }
+.tile-value { font-size: 18px; font-weight: 700; }
+.tile-label { font-size: 10px; color: var(--text-2); text-transform: uppercase; letter-spacing: .08em; font-family: 'JetBrains Mono', monospace; }
+.artifact-toolbar { padding: 12px 16px; display: flex; align-items: center; gap: 8px; border-bottom: 1px solid var(--border); }
+.artifact-toolbar .search { width: 220px; margin: 0; padding: 6px 8px; }
+.table-wrap { overflow: auto; max-height: 300px; }
+table { width: 100%; border-collapse: collapse; min-width: 860px; }
+th, td { padding: 10px 12px; border-bottom: 1px solid var(--border); text-align: left; font-size: 12px; }
+th { color: var(--text-2); font-size: 10px; text-transform: uppercase; letter-spacing: .08em; font-family: 'JetBrains Mono', monospace; position: sticky; top: 0; background: var(--bg-1); }
+td:first-child, th:first-child { position: sticky; left: 0; background: var(--bg-1); }
+.device-detail { background: var(--bg-2); color: var(--text-1); }
+.side-states { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; padding: 0 16px 16px; }
+.state-card { border: 1px solid var(--border); background: var(--bg-2); border-radius: 6px; padding: 12px; min-height: 92px; }
+.composer { border-top: 1px solid var(--border); padding: 12px 18px; background: var(--bg-1); }
+.composer-controls { display: flex; gap: 8px; margin-bottom: 8px; flex-wrap: wrap; }
+.input-row { display: grid; grid-template-columns: 1fr auto; gap: 8px; }
+.prompt { background: var(--bg-2); border: 1px solid var(--border); border-radius: 6px; color: var(--text-0); padding: 11px 12px; font: inherit; min-height: 42px; }
+@media (max-width: 1050px) {
+  .main { grid-template-columns: 1fr; }
+  .rail { display: none; }
+  .review-grid { grid-template-columns: 1fr; }
+  .tiles, .side-states { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 720px) {
+  .app { grid-template-columns: 1fr; }
+  .sidebar { display: none; }
+  .titlebar-title { text-align: left; }
+  .titlebar-status { display: none; }
+  .content { overflow: auto; }
+  .chat-header {
+    height: auto;
+    min-height: 58px;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px;
+  }
+  .scope-controls,
+  .artifact-toolbar,
+  .composer-controls {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+  .messages { padding: 16px 12px; }
+  .card-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .tiles,
+  .side-states {
+    grid-template-columns: 1fr;
+  }
+  .artifact-toolbar .search { width: 100%; }
+  .kv { grid-template-columns: 1fr; }
+  .input-row { grid-template-columns: 1fr; }
+  .prompt { width: 100%; }
+}
+</style>
+</head>
+<body>
+<div class="app">
+  <div class="titlebar">
+    <div class="traffic-lights"><div class="dot red"></div><div class="dot yellow"></div><div class="dot green"></div></div>
+    <div class="titlebar-title">OpenAdminOS - multi-tenant Intune Chat</div>
+    <div class="titlebar-status"><span class="pulse"></span> Local-only</div>
+  </div>
+  <aside class="sidebar">
+    <div class="brand"><div class="brand-mark">O</div><div><div class="brand-name">OpenAdminOS</div><div class="brand-sub">public preview</div></div></div>
+    <div class="nav-section">
+      <div class="nav-label">// Primary</div>
+      <div class="nav-item">Agents</div>
+      <div class="nav-item active">Intune Chat <span class="nav-badge">MT</span></div>
+      <div class="nav-item">Workspaces</div>
+      <div class="nav-item">Activity</div>
+    </div>
+    <div class="tenant-switcher"><div class="tenant-avatar">C</div><div class="tenant-info"><div class="tenant-name">Contoso</div><div class="tenant-id">active tenant</div></div></div>
+  </aside>
+  <main class="main">
+    <section class="rail">
+      <h2>Conversations</h2>
+      <input class="search" value="compliance" aria-label="Search conversations">
+      <div class="chat-row active"><div class="chat-title">Windows compliance across tenants</div><div class="chat-meta">Multi-tenant result - partial</div></div>
+      <div class="chat-row"><div class="chat-title">Autopilot failures</div><div class="chat-meta">Contoso - 19 min ago</div></div>
+      <div class="chat-row"><div class="chat-title">BitLocker gaps</div><div class="chat-meta">Pilot tenants - yesterday</div></div>
+    </section>
+    <section class="content">
+      <header class="chat-header">
+        <div>
+          <h1>Intune Chat</h1>
+          <div class="muted">Read-only aggregation. Workspaces remain single-tenant.</div>
+        </div>
+        <div class="scope-controls">
+          <span class="pill accent">Scope: all connected tenants</span>
+          <span class="pill">Saved query: Windows compliance</span>
+          <span class="pill">Ollama - local</span>
+        </div>
+      </header>
+      <div class="messages">
+        <div class="message user"><div class="bubble">List all compliant and all non-compliant Windows devices from every connected tenant.</div></div>
+        <section class="review-card">
+          <div class="card-head">
+            <div><div class="card-title">Scope review before run</div><div class="card-sub">No tenant cache refresh or model prompt starts until this review is approved.</div></div>
+            <button class="button primary">Run read-only query</button>
+          </div>
+          <div class="review-grid">
+            <div class="tenant-list">
+              <div class="tenant-line"><div><div class="tenant-name-line">Contoso</div><div class="muted">managedDevices fresh 3 min ago</div></div><div class="status ready">Ready</div></div>
+              <div class="tenant-line"><div><div class="tenant-name-line">Fabrikam</div><div class="muted">cache stale; will refresh managedDevices</div></div><div class="status stale">Stale</div></div>
+              <div class="tenant-line"><div><div class="tenant-name-line">Northwind</div><div class="muted">last Graph request returned 429</div></div><div class="status failed">Skipped</div></div>
+            </div>
+            <div>
+              <div class="scope-box">
+                <div class="kv"><span>Resolved group</span><span>Pilot tenants - 3 tenants</span></div>
+                <div class="kv"><span>Resources</span><span>Intune managed devices</span></div>
+                <div class="kv"><span>Provider</span><span>Ollama / llama3.1 - local-only</span></div>
+                <div class="kv"><span>Write boundary</span><span>No Graph writes or connector sends</span></div>
+              </div>
+              <div class="scope-box">
+                <div class="card-title">Hosted provider variant</div>
+                <div class="card-sub">If Anthropic/OpenAI/Azure is active, this slot becomes a batch confirmation naming every selected tenant and provider/model before prompt construction.</div>
+              </div>
+            </div>
+          </div>
+        </section>
+        <section class="artifact">
+          <div class="card-head">
+            <div><div class="card-title">Windows compliance result</div><div class="card-sub">Table and exports are deterministic from local Graph cache. Assistant prose is explanatory only.</div></div>
+            <div class="scope-controls"><button class="button">Export CSV</button><button class="button">Export dossier</button><button class="button">Split to Workspaces</button></div>
+          </div>
+          <div class="tiles">
+            <div class="tile"><div class="tile-value">3</div><div class="tile-label">Tenants</div></div>
+            <div class="tile"><div class="tile-value">1</div><div class="tile-label">Failed</div></div>
+            <div class="tile"><div class="tile-value">182</div><div class="tile-label">Windows</div></div>
+            <div class="tile"><div class="tile-value">141</div><div class="tile-label">Compliant</div></div>
+            <div class="tile"><div class="tile-value">27</div><div class="tile-label">Non-compliant</div></div>
+            <div class="tile"><div class="tile-value">14</div><div class="tile-label">Unknown</div></div>
+          </div>
+          <div class="artifact-toolbar">
+            <input class="search" value="Windows" aria-label="Filter result rows">
+            <span class="pill">Compliance: all</span><span class="pill warn">Partial result</span><span class="pill">OS: Windows</span>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead><tr><th aria-sort="ascending">Tenant</th><th>Status</th><th>Windows</th><th>Compliant</th><th>Non-compliant</th><th>Unknown</th><th>Last refresh</th></tr></thead>
+              <tbody>
+                <tr><td>Contoso</td><td><span class="status ready">Ready</span></td><td>94</td><td>79</td><td>9</td><td>6</td><td>3 min ago</td></tr>
+                <tr class="device-detail"><td colspan="7">Expanded detail: WIN-11-042 - noncompliant - Windows 11 23H2 - last sync 2026-06-14 08:41 - owner owner@contoso.example</td></tr>
+                <tr><td>Fabrikam</td><td><span class="status stale">Stale</span></td><td>88</td><td>62</td><td>18</td><td>8</td><td>1 hour ago</td></tr>
+                <tr><td>Northwind</td><td><span class="status failed">Failed</span></td><td>0</td><td>0</td><td>0</td><td>0</td><td>429 throttled</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="side-states">
+            <div class="state-card"><div class="card-title">Empty state</div><div class="card-sub">No tenant selected. Choose tenants or use Active tenant.</div></div>
+            <div class="state-card"><div class="card-title">Loading state</div><div class="card-sub">Per-tenant rows show queued, refreshing cache, reading cache, and building result.</div></div>
+            <div class="state-card"><div class="card-title">Narrow width</div><div class="card-sub">History rail collapses; artifact owns horizontal overflow, not the page.</div></div>
+          </div>
+        </section>
+      </div>
+      <footer class="composer">
+        <div class="composer-controls"><span class="pill accent">All tenants</span><span class="pill">Pilot tenants</span><span class="pill">Windows compliance</span></div>
+        <div class="input-row"><textarea class="prompt" aria-label="Intune Chat prompt">List all compliant and all non-compliant Windows devices from every connected tenant.</textarea><button class="button primary">Review scope</button></div>
+      </footer>
+    </section>
+  </main>
+</div>
+</body>
+</html>

--- a/docs/mockups/12-workspaces.html
+++ b/docs/mockups/12-workspaces.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>OpenAdminOS - Workspaces</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="_design.css">
+<style>
+.main { min-width: 0; display: grid; grid-template-columns: 310px minmax(0, 1fr); background: var(--bg-0); }
+.list-pane { background: var(--bg-1); border-right: 1px solid var(--border); padding: 16px; overflow: hidden; }
+.detail-pane { min-width: 0; overflow: auto; padding: 18px 22px 28px; }
+.pane-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
+h1 { font-size: 18px; font-weight: 700; }
+h2 { font-size: 13px; font-weight: 600; margin-bottom: 9px; }
+.sub { color: var(--text-2); font-size: 11px; }
+.card-title { font-size: 13px; font-weight: 600; }
+.search { width: 100%; background: var(--bg-2); border: 1px solid var(--border); border-radius: 6px; color: var(--text-0); padding: 8px 10px; font: inherit; margin: 8px 0 12px; }
+.button, .pill { border: 1px solid var(--border); background: var(--bg-2); color: var(--text-1); border-radius: 6px; font-size: 11px; padding: 6px 9px; display: inline-flex; align-items: center; gap: 6px; }
+.button.primary { color: var(--bg-0); background: var(--accent); border-color: var(--accent); font-weight: 600; }
+.button.danger { color: var(--danger); border-color: rgba(248, 113, 113, .25); background: rgba(248, 113, 113, .08); }
+.pill.accent { color: var(--accent); border-color: rgba(0, 212, 255, .28); background: var(--accent-bg); }
+.pill.ok { color: var(--success); border-color: rgba(74, 222, 128, .24); background: rgba(74, 222, 128, .08); }
+.workspace-row { border: 1px solid var(--border); background: var(--bg-2); border-radius: 8px; padding: 12px; margin-bottom: 10px; }
+.workspace-row.active { border-color: rgba(0, 212, 255, .32); background: var(--accent-bg); }
+.row-top { display: flex; align-items: flex-start; justify-content: space-between; gap: 8px; margin-bottom: 5px; }
+.row-title { font-weight: 600; font-size: 13px; }
+.row-meta { display: flex; gap: 8px; flex-wrap: wrap; color: var(--text-2); font-size: 10px; font-family: 'JetBrains Mono', monospace; }
+.empty-mini { border: 1px dashed var(--border-strong); border-radius: 8px; padding: 16px; color: var(--text-2); background: rgba(255,255,255,.015); margin-top: 14px; }
+.detail-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; border-bottom: 1px solid var(--border); padding-bottom: 16px; margin-bottom: 16px; }
+.detail-title { font-size: 20px; font-weight: 700; margin-bottom: 6px; }
+.head-actions { display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+.sections { display: grid; grid-template-columns: minmax(0, 1.2fr) minmax(320px, .8fr); gap: 16px; align-items: start; }
+.section { border: 1px solid var(--border); background: var(--bg-1); border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+.section-head { padding: 12px 14px; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.section-body { padding: 12px 14px; }
+.evidence-row, .note-row, .link-row { border: 1px solid var(--border); background: var(--bg-2); border-radius: 6px; padding: 11px 12px; margin-bottom: 8px; }
+.evidence-top, .link-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.evidence-title, .note-title { font-size: 12px; font-weight: 600; }
+.evidence-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; margin-top: 9px; }
+.metric { background: var(--bg-3); border: 1px solid var(--border); border-radius: 5px; padding: 8px; }
+.metric strong { display: block; font-size: 16px; }
+.metric span { color: var(--text-2); font-size: 10px; font-family: 'JetBrains Mono', monospace; text-transform: uppercase; letter-spacing: .08em; }
+.note-area { width: 100%; min-height: 84px; resize: vertical; background: var(--bg-2); border: 1px solid var(--border); border-radius: 6px; color: var(--text-0); padding: 10px; font: inherit; }
+.instructions { min-height: 150px; }
+.trust-strip { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 10px 12px; border: 1px solid var(--border); background: var(--bg-2); border-radius: 8px; margin-bottom: 16px; }
+.modal { position: fixed; right: 34px; bottom: 34px; width: 420px; background: var(--bg-1); border: 1px solid var(--border-strong); border-radius: 8px; box-shadow: 0 20px 60px rgba(0,0,0,.45); overflow: hidden; }
+.modal-head { padding: 13px 14px; border-bottom: 1px solid var(--border); }
+.modal-body { padding: 14px; }
+.map-row { display: grid; grid-template-columns: 1fr auto; gap: 10px; padding: 9px 0; border-bottom: 1px solid var(--border); }
+.status { font-family: 'JetBrains Mono', monospace; font-size: 10px; text-transform: uppercase; letter-spacing: .08em; color: var(--success); }
+@media (max-width: 1080px) {
+  .main { grid-template-columns: 1fr; }
+  .list-pane { display: none; }
+  .sections { grid-template-columns: 1fr; }
+  .modal { left: 22px; right: 22px; width: auto; }
+}
+@media (max-width: 720px) {
+  .app { grid-template-columns: 1fr; }
+  .sidebar { display: none; }
+  .titlebar-title { text-align: left; }
+  .titlebar-status { display: none; }
+  .detail-pane { padding: 14px; }
+  .detail-head,
+  .trust-strip {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .head-actions { justify-content: flex-start; }
+  .evidence-top,
+  .link-row,
+  .section-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .evidence-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .modal {
+    bottom: auto;
+    left: auto;
+    margin: 0 14px 14px;
+    position: static;
+    right: auto;
+    width: auto;
+  }
+  .map-row { grid-template-columns: 1fr; }
+}
+</style>
+</head>
+<body>
+<div class="app">
+  <div class="titlebar">
+    <div class="traffic-lights"><div class="dot red"></div><div class="dot yellow"></div><div class="dot green"></div></div>
+    <div class="titlebar-title">OpenAdminOS - Workspaces</div>
+    <div class="titlebar-status"><span class="pulse"></span> Contoso active</div>
+  </div>
+  <aside class="sidebar">
+    <div class="brand"><div class="brand-mark">O</div><div><div class="brand-name">OpenAdminOS</div><div class="brand-sub">public preview</div></div></div>
+    <div class="nav-section">
+      <div class="nav-label">// Primary</div>
+      <div class="nav-item">Agents</div>
+      <div class="nav-item">Intune Chat</div>
+      <div class="nav-item active">Workspaces <span class="nav-badge">4</span></div>
+      <div class="nav-item">Activity</div>
+    </div>
+    <div class="tenant-switcher"><div class="tenant-avatar">C</div><div class="tenant-info"><div class="tenant-name">Contoso</div><div class="tenant-id">single-tenant scope</div></div></div>
+  </aside>
+  <main class="main">
+    <section class="list-pane">
+      <div class="pane-head">
+        <div><h1>Workspaces</h1><div class="sub">Tenant-scoped investigations</div></div>
+        <button class="button primary">New</button>
+      </div>
+      <input class="search" value="compliance" aria-label="Search workspaces">
+      <article class="workspace-row active">
+        <div class="row-top"><div class="row-title">Contoso Windows compliance review</div><span class="pill ok">fresh</span></div>
+        <div class="row-meta"><span>3 pins</span><span>2 chats</span><span>1 run</span><span>updated 4 min</span></div>
+      </article>
+      <article class="workspace-row">
+        <div class="row-top"><div class="row-title">Autopilot ESP failures</div><span class="pill">stale</span></div>
+        <div class="row-meta"><span>5 pins</span><span>1 chat</span><span>0 runs</span><span>updated yesterday</span></div>
+      </article>
+      <article class="workspace-row">
+        <div class="row-top"><div class="row-title">BitLocker exception review</div><span class="pill">active</span></div>
+        <div class="row-meta"><span>1 pin</span><span>0 chats</span><span>2 runs</span><span>updated Jun 12</span></div>
+      </article>
+      <div class="empty-mini">
+        <div class="row-title">Zero-workspace state</div>
+        <div class="sub">Start from Intune Chat, link a run, or create a blank workspace for the active tenant.</div>
+      </div>
+    </section>
+    <section class="detail-pane">
+      <div class="detail-head">
+        <div>
+          <div class="detail-title">Contoso Windows compliance review</div>
+          <div class="sub">Tenant: Contoso - Workspaces never mix tenants. Deleting this workspace keeps chats, runs, tenant config, and Graph cache.</div>
+        </div>
+        <div class="head-actions"><button class="button">Export dossier</button><button class="button">Archive</button><button class="button danger">Delete</button></div>
+      </div>
+      <div class="trust-strip">
+        <div><strong>Local workspace context</strong><div class="sub">Pinned evidence, notes, links, and instructions stay in local SQLite until explicitly exported or attached to a hosted-provider prompt.</div></div>
+        <span class="pill accent">No auto-attach</span>
+      </div>
+      <div class="sections">
+        <div>
+          <section class="section">
+            <div class="section-head"><h2>Pinned evidence</h2><button class="button">Pin from chat</button></div>
+            <div class="section-body">
+              <div class="evidence-row">
+                <div class="evidence-top"><div><div class="evidence-title">Multi-tenant split result - Contoso rows</div><div class="sub">Source: Intune Chat job mtjob_182 - managedDevices - cache refreshed 3 min ago</div></div><span class="pill ok">tenant match</span></div>
+                <div class="evidence-grid">
+                  <div class="metric"><strong>94</strong><span>Windows</span></div>
+                  <div class="metric"><strong>79</strong><span>Compliant</span></div>
+                  <div class="metric"><strong>9</strong><span>Non-compliant</span></div>
+                  <div class="metric"><strong>6</strong><span>Unknown</span></div>
+                </div>
+              </div>
+              <div class="evidence-row">
+                <div class="evidence-top"><div><div class="evidence-title">WIN-11-042 device row</div><div class="sub">Graph cache row - last sync 2026-06-14 08:41 - owner visible in expanded value</div></div><span class="pill">row</span></div>
+              </div>
+            </div>
+          </section>
+          <section class="section">
+            <div class="section-head"><h2>Notes</h2><button class="button primary">Add note</button></div>
+            <div class="section-body">
+              <textarea class="note-area" aria-label="Workspace note">Confirm whether WIN-11-042 belongs to the shared kiosk exception list before any write-agent plan is reviewed.</textarea>
+              <div class="note-row"><div class="note-title">Review owner exceptions</div><div class="sub">Added today. Stored locally with this tenant workspace.</div></div>
+            </div>
+          </section>
+        </div>
+        <div>
+          <section class="section">
+            <div class="section-head"><h2>Linked context</h2><button class="button">Link</button></div>
+            <div class="section-body">
+              <div class="link-row"><div><div class="evidence-title">Chat: Windows compliance across tenants</div><div class="sub">Linked, not copied</div></div><span class="status">Chat</span></div>
+              <div class="link-row"><div><div class="evidence-title">Run: Intune Device Posture Auditor</div><div class="sub">Run history remains in Activity</div></div><span class="status">Run</span></div>
+            </div>
+          </section>
+          <section class="section">
+            <div class="section-head"><h2>Workspace instructions</h2><span class="pill">explicit only</span></div>
+            <div class="section-body">
+              <textarea class="note-area instructions" aria-label="Workspace instructions">Prefer local Graph cache evidence. Do not recommend device retirement until the kiosk exception note is checked. These instructions cannot add scopes or bypass write confirmation.</textarea>
+              <div style="display:flex; justify-content:flex-end; margin-top:10px;"><button class="button primary">Save instructions</button></div>
+            </div>
+          </section>
+          <section class="section">
+            <div class="section-head"><h2>Empty workspace state</h2></div>
+            <div class="section-body"><div class="empty-mini">When a workspace has no evidence, show direct actions: start from Intune Chat, link a run, or add a note. Do not show a marketing hero.</div></div>
+          </section>
+        </div>
+      </div>
+    </section>
+  </main>
+  <aside class="modal" aria-label="Split multi-tenant result review">
+    <div class="modal-head"><div class="card-title">Split result to Workspaces</div><div class="sub">One workspace or evidence bundle per tenant. Mixed-tenant evidence is blocked.</div></div>
+    <div class="modal-body">
+      <div class="map-row"><div><strong>Contoso</strong><div class="sub">Use existing workspace - 94 device rows</div></div><span class="pill ok">match</span></div>
+      <div class="map-row"><div><strong>Fabrikam</strong><div class="sub">Create new workspace - 88 device rows</div></div><span class="pill ok">new</span></div>
+      <div class="map-row"><div><strong>Northwind</strong><div class="sub">No rows; attach failure evidence only</div></div><span class="pill">failed</span></div>
+      <div style="display:flex; justify-content:flex-end; gap:8px; margin-top:14px;"><button class="button">Cancel</button><button class="button primary">Create evidence</button></div>
+    </div>
+  </aside>
+</div>
+</body>
+</html>

--- a/docs/mockups/index.html
+++ b/docs/mockups/index.html
@@ -164,6 +164,22 @@ h1 { font-size: 28px; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 
           <div class="screen-tag">↳ resilience</div>
         </div>
       </a>
+      <a href="11-multi-tenant-chat.html" class="screen-link">
+        <div class="screen-num">11</div>
+        <div class="screen-info">
+          <div class="screen-name">Multi-tenant Intune Chat</div>
+          <div class="screen-desc">Scope review, per-tenant readiness, aggregate result artifact, export, and split-to-workspaces flow.</div>
+          <div class="screen-tag">↳ v0.2.5</div>
+        </div>
+      </a>
+      <a href="12-workspaces.html" class="screen-link">
+        <div class="screen-num">12</div>
+        <div class="screen-info">
+          <div class="screen-name">Workspaces</div>
+          <div class="screen-desc">Single-tenant investigation surface for pinned evidence, linked chats/runs, notes, and local instructions.</div>
+          <div class="screen-tag">↳ v0.2.5</div>
+        </div>
+      </a>
     </div>
   </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openadminos",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openadminos",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -55,13 +55,13 @@
     },
     "apps/desktop": {
       "name": "@openadminos/desktop",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@microsoft/mxc-sdk": "0.6.1",
-        "@openadminos/agent-sdk": "0.2.4",
-        "@openadminos/connector-whatsapp-web": "0.2.4",
-        "@openadminos/runtime": "0.2.4",
+        "@openadminos/agent-sdk": "0.2.5",
+        "@openadminos/connector-whatsapp-web": "0.2.5",
+        "@openadminos/runtime": "0.2.5",
         "electron-updater": "^6.6.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -8502,13 +8502,13 @@
     },
     "packages/agent-sdk": {
       "name": "@openadminos/agent-sdk",
-      "version": "0.2.4"
+      "version": "0.2.5"
     },
     "packages/connector-discord": {
       "name": "@openadminos/connector-discord",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.2.4"
+        "@openadminos/agent-sdk": "0.2.5"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -8521,9 +8521,9 @@
     },
     "packages/connector-outlook": {
       "name": "@openadminos/connector-outlook",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.2.4"
+        "@openadminos/agent-sdk": "0.2.5"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -8536,9 +8536,9 @@
     },
     "packages/connector-signal": {
       "name": "@openadminos/connector-signal",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.2.4"
+        "@openadminos/agent-sdk": "0.2.5"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -8551,9 +8551,9 @@
     },
     "packages/connector-slack": {
       "name": "@openadminos/connector-slack",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.2.4"
+        "@openadminos/agent-sdk": "0.2.5"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -8566,9 +8566,9 @@
     },
     "packages/connector-teams": {
       "name": "@openadminos/connector-teams",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.2.4"
+        "@openadminos/agent-sdk": "0.2.5"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -8580,9 +8580,9 @@
     },
     "packages/connector-whatsapp-web": {
       "name": "@openadminos/connector-whatsapp-web",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.2.4",
+        "@openadminos/agent-sdk": "0.2.5",
         "baileys": "7.0.0-rc13",
         "pino": "^10.1.0",
         "qrcode": "^1.5.4"
@@ -8598,9 +8598,9 @@
     },
     "packages/qa-graph": {
       "name": "@openadminos/qa-graph",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.2.4",
+        "@openadminos/agent-sdk": "0.2.5",
         "ajv": "^8.17.1",
         "js-yaml": "^4.1.1"
       },
@@ -8638,16 +8638,16 @@
     },
     "packages/runtime": {
       "name": "@openadminos/runtime",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@azure/msal-node": "^5.2.1",
-        "@openadminos/agent-sdk": "0.2.4",
-        "@openadminos/connector-discord": "0.2.4",
-        "@openadminos/connector-outlook": "0.2.4",
-        "@openadminos/connector-signal": "0.2.4",
-        "@openadminos/connector-slack": "0.2.4",
-        "@openadminos/connector-teams": "0.2.4",
-        "@openadminos/connector-whatsapp-web": "0.2.4",
+        "@openadminos/agent-sdk": "0.2.5",
+        "@openadminos/connector-discord": "0.2.5",
+        "@openadminos/connector-outlook": "0.2.5",
+        "@openadminos/connector-signal": "0.2.5",
+        "@openadminos/connector-slack": "0.2.5",
+        "@openadminos/connector-teams": "0.2.5",
+        "@openadminos/connector-whatsapp-web": "0.2.5",
         "js-yaml": "^4.1.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openadminos",
   "private": true,
-  "version": "0.2.4",
+  "version": "0.2.5",
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/agent-sdk",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "description": "Shared TypeScript contracts for OpenAdminOS packages.",
   "main": "./dist/index.js",

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -584,6 +584,9 @@ export interface IntuneChatConversation {
   updatedAt: string;
   tenantId?: string;
   pinnedAt?: string;
+  scopeKind?: "single-tenant" | "multi-tenant";
+  tenantScope?: TenantScope;
+  multiTenantJobId?: string;
 }
 
 export interface IntuneChatSource {
@@ -750,7 +753,352 @@ export interface HostedProviderChatConsent {
   providerId: ProviderId;
   acknowledgedAt: string;
   remember?: boolean;
+  workspaceContext?: HostedProviderWorkspaceContextConsent;
 }
+
+export type TenantScope =
+  | { kind: "active" }
+  | { kind: "selected"; tenantIds: string[]; groupIds?: string[] }
+  | { kind: "all"; groupIds?: string[] };
+
+export type TenantReadinessStatus =
+  | "ready"
+  | "expired"
+  | "missing-scopes"
+  | "stale"
+  | "throttled"
+  | "skipped"
+  | "failed";
+
+export interface TenantGroup {
+  id: string;
+  name: string;
+  tenantIds: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SavedMultiTenantQuery {
+  id: string;
+  title: string;
+  prompt: string;
+  resourceHints: GraphCacheResourceKind[];
+  defaultScope?: TenantScope;
+  order: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TenantScopePreflightTenant {
+  tenantId: string;
+  tenantName: string;
+  username?: string;
+  status: TenantReadinessStatus;
+  selected: boolean;
+  cacheFreshness?: string;
+  staleResources: GraphCacheResourceKind[];
+  missingScopes: string[];
+  warnings: string[];
+  recovery: string;
+}
+
+export interface TenantScopePreflight {
+  id: string;
+  prompt: string;
+  tenantScope: TenantScope;
+  resolvedTenantIds: string[];
+  resolvedGroups: TenantGroup[];
+  resources: GraphCacheResourceKind[];
+  providerId: ProviderId;
+  providerName: string;
+  providerIsLocal: boolean;
+  model?: string;
+  generatedAt: string;
+  tenants: TenantScopePreflightTenant[];
+  canRun: boolean;
+}
+
+export interface HostedProviderBatchConsent {
+  tenantIds: string[];
+  providerId: ProviderId;
+  acknowledgedAt: string;
+  remember?: boolean;
+}
+
+export interface PreflightMultiTenantChatInput {
+  prompt: string;
+  tenantScope: TenantScope;
+  savedQueryId?: string;
+}
+
+export interface RunMultiTenantChatInput extends PreflightMultiTenantChatInput {
+  refreshIfStale?: boolean;
+  hostedProviderConsent?: HostedProviderBatchConsent;
+}
+
+export type MultiTenantProgressStatus =
+  | "queued"
+  | "refreshing-cache"
+  | "reading-cache"
+  | "building-result"
+  | "ready"
+  | "skipped"
+  | "failed";
+
+export interface MultiTenantChatTenantProgress {
+  tenantId: string;
+  tenantName: string;
+  status: MultiTenantProgressStatus;
+  detail?: string;
+  updatedAt: string;
+}
+
+export interface MultiTenantDeviceRow {
+  tenantId: string;
+  tenantName: string;
+  deviceId?: string;
+  deviceName: string;
+  complianceState: string;
+  operatingSystem: string;
+  osVersion?: string;
+  lastSyncDateTime?: string;
+  owner?: string;
+  sourceRefreshedAt?: string;
+  stale: boolean;
+}
+
+export interface MultiTenantTenantComparison {
+  tenantId: string;
+  tenantName: string;
+  status: TenantReadinessStatus;
+  windowsDevices: number;
+  compliant: number;
+  nonCompliant: number;
+  unknown: number;
+  lastRefresh?: string;
+  warnings: string[];
+}
+
+export interface MultiTenantChatSummary {
+  tenantsScanned: number;
+  failedTenants: number;
+  skippedTenants: number;
+  staleTenants: number;
+  windowsDevices: number;
+  compliant: number;
+  nonCompliant: number;
+  unknown: number;
+}
+
+export interface MultiTenantChatJob {
+  id: string;
+  conversationId?: string;
+  prompt: string;
+  savedQueryId?: string;
+  tenantScope: TenantScope;
+  resolvedTenantIds: string[];
+  providerId: ProviderId;
+  providerName: string;
+  providerIsLocal: boolean;
+  model?: string;
+  status: "queued" | "running" | "completed" | "partial" | "failed" | "cancelled";
+  createdAt: string;
+  updatedAt: string;
+  preflight: TenantScopePreflight;
+  progress: MultiTenantChatTenantProgress[];
+  summary: MultiTenantChatSummary;
+  comparisons: MultiTenantTenantComparison[];
+  deviceRows: MultiTenantDeviceRow[];
+  assistantText: string;
+  exportDossierMarkdown: string;
+  error?: string;
+}
+
+export interface MultiTenantChatRunResult {
+  job: MultiTenantChatJob;
+  conversation: IntuneChatConversation;
+  userMessage: IntuneChatMessage;
+  assistantMessage: IntuneChatMessage;
+}
+
+export type MultiTenantChatStreamEvent =
+  | {
+      type: "started";
+      job: MultiTenantChatJob;
+    }
+  | {
+      type: "progress";
+      job: MultiTenantChatJob;
+    }
+  | {
+      type: "completed";
+      result: MultiTenantChatRunResult;
+    }
+  | {
+      type: "cancelled";
+      job: MultiTenantChatJob;
+    }
+  | {
+      type: "failed";
+      job?: MultiTenantChatJob;
+      error: string;
+    };
+
+export interface MultiTenantAgentBatch {
+  id: string;
+  agentSlug: string;
+  agentName: string;
+  agentMode: AgentMode;
+  tenantScope: TenantScope;
+  resolvedTenantIds: string[];
+  status:
+    | "queued"
+    | "running"
+    | "awaiting-confirmation"
+    | "completed"
+    | "partial"
+    | "failed"
+    | "cancelled";
+  runIds: string[];
+  createdAt: string;
+  updatedAt: string;
+  preflight: TenantScopePreflight;
+  error?: string;
+}
+
+export interface QueueMultiTenantAgentBatchInput {
+  agentSlug: string;
+  tenantScope: TenantScope;
+  savedQueryId?: string;
+  prompt?: string;
+}
+
+export interface QueueMultiTenantAgentBatchResult {
+  batch: MultiTenantAgentBatch;
+  runs: RunRecord[];
+}
+
+export type WorkspaceStatus = "active" | "archived";
+export type WorkspaceEvidenceSourceType =
+  | "multi-tenant-chat-result"
+  | "chat-message"
+  | "graph-cache-row"
+  | "run-result"
+  | "manual";
+
+export interface WorkspaceSummary {
+  id: string;
+  tenantId: string;
+  tenantName?: string;
+  title: string;
+  status: WorkspaceStatus;
+  evidenceCount: number;
+  conversationCount: number;
+  runCount: number;
+  noteCount: number;
+  freshness?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WorkspaceEvidence {
+  id: string;
+  workspaceId: string;
+  tenantId: string;
+  title: string;
+  sourceType: WorkspaceEvidenceSourceType;
+  sourceRef?: Record<string, unknown>;
+  content: unknown;
+  freshness?: {
+    resource?: GraphCacheResourceKind;
+    refreshedAt?: string;
+    rowCount?: number;
+    cacheStatus?: "cache" | "live" | "stale" | "unknown";
+  };
+  createdAt: string;
+}
+
+export interface WorkspaceNote {
+  id: string;
+  workspaceId: string;
+  tenantId: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WorkspaceLink {
+  id: string;
+  workspaceId: string;
+  tenantId: string;
+  type: "conversation" | "run";
+  refId: string;
+  title: string;
+  createdAt: string;
+}
+
+export interface WorkspaceDetail extends WorkspaceSummary {
+  instructions?: string;
+  evidence: WorkspaceEvidence[];
+  notes: WorkspaceNote[];
+  links: WorkspaceLink[];
+}
+
+export interface CreateWorkspaceInput {
+  tenantId?: string;
+  title: string;
+  instructions?: string;
+  conversationId?: string;
+}
+
+export interface UpdateWorkspaceInput {
+  title?: string;
+  instructions?: string;
+  status?: WorkspaceStatus;
+}
+
+export interface PinWorkspaceEvidenceInput {
+  workspaceId: string;
+  tenantId?: string;
+  title: string;
+  sourceType: WorkspaceEvidenceSourceType;
+  sourceRef?: Record<string, unknown>;
+  content: unknown;
+  freshness?: WorkspaceEvidence["freshness"];
+}
+
+export interface ImportMultiTenantResultToWorkspacesInput {
+  jobId: string;
+  tenantMappings: {
+    tenantId: string;
+    workspaceId?: string;
+    title?: string;
+  }[];
+}
+
+export interface ImportMultiTenantResultToWorkspacesResult {
+  workspaces: WorkspaceSummary[];
+  evidence: WorkspaceEvidence[];
+}
+
+export interface WorkspacePromptContextInput {
+  workspaceId: string;
+  evidenceIds?: string[];
+  noteIds?: string[];
+  includeInstructions?: boolean;
+}
+
+export interface WorkspacePromptContextSummary {
+  workspaceId: string;
+  workspaceTitle: string;
+  tenantId: string;
+  evidenceCount: number;
+  noteCount: number;
+  includesInstructions: boolean;
+}
+
+export interface HostedProviderWorkspaceContextConsent
+  extends WorkspacePromptContextSummary {}
 
 export interface SendIntuneChatMessageInput {
   conversationId?: string;
@@ -766,6 +1114,12 @@ export interface SendIntuneChatMessageInput {
    * remembered local decision is applied for the active tenant/provider pair.
    */
   hostedProviderConsent?: HostedProviderChatConsent;
+  /**
+   * Optional single-tenant workspace evidence/notes/instructions to attach
+   * to this prompt. The host validates that the workspace tenant matches the
+   * active conversation tenant before adding it to the model prompt.
+   */
+  workspaceContext?: WorkspacePromptContextInput;
 }
 
 export interface SendIntuneChatMessageResult {
@@ -1164,6 +1518,28 @@ export interface OpenAdminOSApi {
     onEvent: (event: IntuneChatStreamEvent) => void,
   ): Promise<SendIntuneChatMessageResult>;
   cancelIntuneChatStream(): Promise<void>;
+  listTenantGroups(): Promise<TenantGroup[]>;
+  saveTenantGroup(input: { id?: string; name: string; tenantIds: string[] }): Promise<TenantGroup>;
+  deleteTenantGroup(id: string): Promise<void>;
+  listSavedMultiTenantQueries(): Promise<SavedMultiTenantQuery[]>;
+  preflightMultiTenantIntuneChat(
+    input: PreflightMultiTenantChatInput,
+  ): Promise<TenantScopePreflight>;
+  runMultiTenantIntuneChat(
+    input: RunMultiTenantChatInput,
+  ): Promise<MultiTenantChatRunResult>;
+  streamMultiTenantIntuneChat(
+    input: RunMultiTenantChatInput,
+    onEvent: (event: MultiTenantChatStreamEvent) => void,
+  ): Promise<MultiTenantChatRunResult>;
+  cancelMultiTenantIntuneChatStream(): Promise<void>;
+  listMultiTenantChatJobs(): Promise<MultiTenantChatJob[]>;
+  getMultiTenantChatJob(id: string): Promise<MultiTenantChatJob | undefined>;
+  queueMultiTenantAgentBatch(
+    input: QueueMultiTenantAgentBatchInput,
+  ): Promise<QueueMultiTenantAgentBatchResult>;
+  listMultiTenantAgentBatches(): Promise<MultiTenantAgentBatch[]>;
+  getMultiTenantAgentBatch(id: string): Promise<MultiTenantAgentBatch | undefined>;
   refreshGraphCache(options?: RefreshGraphCacheOptions): Promise<GraphCacheRefreshResult>;
   getGraphCacheStatus(tenantId?: string): Promise<GraphCacheStatus>;
   getGraphCacheRefreshSchedule(tenantId?: string): Promise<GraphCacheRefreshScheduleSettings>;
@@ -1179,6 +1555,24 @@ export interface OpenAdminOSApi {
   approveSelfTrainingSuggestion(id: string): Promise<SelfTrainingSuggestion>;
   rejectSelfTrainingSuggestion(id: string): Promise<SelfTrainingSuggestion>;
   resetSelfTrainingSuggestions(input: ResetSelfTrainingInput): Promise<SelfTrainingSuggestion[]>;
+  listWorkspaces(tenantId?: string): Promise<WorkspaceSummary[]>;
+  getWorkspace(id: string): Promise<WorkspaceDetail | undefined>;
+  createWorkspace(input: CreateWorkspaceInput): Promise<WorkspaceDetail>;
+  updateWorkspace(id: string, input: UpdateWorkspaceInput): Promise<WorkspaceDetail>;
+  archiveWorkspace(id: string): Promise<WorkspaceSummary>;
+  deleteWorkspace(id: string): Promise<void>;
+  addWorkspaceNote(workspaceId: string, content: string): Promise<WorkspaceNote>;
+  updateWorkspaceNote(noteId: string, content: string): Promise<WorkspaceNote>;
+  pinWorkspaceEvidence(input: PinWorkspaceEvidenceInput): Promise<WorkspaceEvidence>;
+  linkWorkspaceConversation(
+    workspaceId: string,
+    conversationId: string,
+  ): Promise<WorkspaceLink>;
+  linkWorkspaceRun(workspaceId: string, runId: string): Promise<WorkspaceLink>;
+  importMultiTenantResultToWorkspaces(
+    input: ImportMultiTenantResultToWorkspacesInput,
+  ): Promise<ImportMultiTenantResultToWorkspacesResult>;
+  exportWorkspaceDossier(id: string): Promise<string>;
   /**
    * Returns every connector registered in the host, with its
    * persisted config and last health-check outcome.

--- a/packages/connector-discord/package.json
+++ b/packages/connector-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-discord",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "type": "module",
   "description": "Discord connector for OpenAdminOS. Sends outbound notification messages through a Discord channel webhook.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.2.4"
+    "@openadminos/agent-sdk": "0.2.5"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-outlook/package.json
+++ b/packages/connector-outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-outlook",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "type": "module",
   "description": "Outlook connector for OpenAdminOS. Sends outbound notification email through Microsoft Graph using the active tenant's delegated MSAL token.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.2.4"
+    "@openadminos/agent-sdk": "0.2.5"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-signal/package.json
+++ b/packages/connector-signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-signal",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "type": "module",
   "description": "Signal connector for OpenAdminOS. Sends outbound notification messages through signal-cli or a local signal-cli REST bridge.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.2.4"
+    "@openadminos/agent-sdk": "0.2.5"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-slack/package.json
+++ b/packages/connector-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-slack",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "type": "module",
   "description": "Slack connector for OpenAdminOS. Sends outbound notification messages through a Slack bot token.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.2.4"
+    "@openadminos/agent-sdk": "0.2.5"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-teams/package.json
+++ b/packages/connector-teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-teams",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "type": "module",
   "description": "Microsoft Teams connector for OpenAdminOS. Posts channel and chat messages via Microsoft Graph using the active tenant's delegated MSAL token.",
@@ -23,7 +23,7 @@
     "typecheck": "npm run build -w @openadminos/agent-sdk && tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.2.4"
+    "@openadminos/agent-sdk": "0.2.5"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-whatsapp-web/package.json
+++ b/packages/connector-whatsapp-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-whatsapp-web",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "type": "module",
   "description": "WhatsApp Web connector for OpenAdminOS. Sends outbound notification messages through a locally linked WhatsApp Web session.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.2.4",
+    "@openadminos/agent-sdk": "0.2.5",
     "baileys": "7.0.0-rc13",
     "pino": "^10.1.0",
     "qrcode": "^1.5.4"

--- a/packages/qa-graph/package.json
+++ b/packages/qa-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/qa-graph",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -14,7 +14,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.2.4",
+    "@openadminos/agent-sdk": "0.2.5",
     "ajv": "^8.17.1",
     "js-yaml": "^4.1.1"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/runtime",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -21,13 +21,13 @@
   },
   "dependencies": {
     "@azure/msal-node": "^5.2.1",
-    "@openadminos/agent-sdk": "0.2.4",
-    "@openadminos/connector-discord": "0.2.4",
-    "@openadminos/connector-outlook": "0.2.4",
-    "@openadminos/connector-signal": "0.2.4",
-    "@openadminos/connector-slack": "0.2.4",
-    "@openadminos/connector-teams": "0.2.4",
-    "@openadminos/connector-whatsapp-web": "0.2.4",
+    "@openadminos/agent-sdk": "0.2.5",
+    "@openadminos/connector-discord": "0.2.5",
+    "@openadminos/connector-outlook": "0.2.5",
+    "@openadminos/connector-signal": "0.2.5",
+    "@openadminos/connector-slack": "0.2.5",
+    "@openadminos/connector-teams": "0.2.5",
+    "@openadminos/connector-whatsapp-web": "0.2.5",
     "js-yaml": "^4.1.1"
   },
   "optionalDependencies": {

--- a/scripts/smoke-intune-chat.mjs
+++ b/scripts/smoke-intune-chat.mjs
@@ -42,9 +42,9 @@ try {
   }
   console.log("[smoke:intune-chat] passed");
 } finally {
-  if (electron && electron.exitCode === null) electron.kill("SIGTERM");
-  if (renderer && renderer.exitCode === null) renderer.kill("SIGTERM");
-  await rm(userDataDir, { recursive: true, force: true });
+  await terminateChild(electron);
+  await terminateChild(renderer);
+  await removeTempDir(userDataDir);
 }
 
 function pipeProcess(child, label) {
@@ -85,6 +85,33 @@ function waitForExit(child, timeoutMs) {
       rejectExit(error);
     });
   });
+}
+
+function terminateChild(child) {
+  if (!child || child.exitCode !== null) return Promise.resolve();
+  return new Promise((resolveTerminate) => {
+    const timeout = setTimeout(() => {
+      if (child.exitCode === null) child.kill("SIGKILL");
+      resolveTerminate();
+    }, 2_000);
+    child.once("exit", () => {
+      clearTimeout(timeout);
+      resolveTerminate();
+    });
+    child.kill("SIGTERM");
+  });
+}
+
+async function removeTempDir(path) {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      await rm(path, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (error?.code !== "ENOTEMPTY" || attempt === 4) throw error;
+      await delay(150 * (attempt + 1));
+    }
+  }
 }
 
 function delay(ms) {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,116 @@
+# v0.2.5 — Workspaces + multi-tenant Intune Chat
+
+**Status: implemented and verified.** Follow-up release after v0.2.4. The theme is making OpenAdminOS better for MSP-style investigation without weakening tenant boundaries: Intune Chat can explicitly answer read-only questions across selected tenants, while Workspaces keep a single tenant problem, its evidence, related conversations, agent runs, notes, and approved local instructions together.
+
+## Product stance
+
+- **Intune Chat supports explicit multi-tenant read aggregation.** The default remains the active tenant; all-tenants or selected-tenants scope requires a visible scope review before Graph refresh or model prompting.
+- **Tenant groups are local shortcuts, not new tenant scopes.** Groups such as "All customers", "Pilot tenants", or "EU tenants" resolve to explicit tenant ids in the scope review before anything runs.
+- **Saved queries are reusable prompts with declared scope hints.** They speed up common MSP investigations without silently broadening tenant access.
+- **Multi-tenant chat is not Workspaces.** Cross-tenant Intune Chat results can be exported locally or split into tenant-specific workspace evidence, but Workspaces remain single-tenant.
+- **The surface is called Workspaces.** Workspaces are tenant-scoped investigation containers, not generic projects.
+- **Workspaces organize evidence; they do not bypass safeguards.** Agent runs still require an active tenant, write agents still pause for confirmation, and hosted providers still require explicit tenant-context confirmation.
+- **Local-first remains literal.** Workspace metadata, notes, pinned evidence, linked chat context, approved instructions, and exports are stored locally in SQLite/userData.
+- **Freshness is part of the object.** Pinned Graph evidence must show source, tenant, row count or object identity where available, cache/live status, and refreshed time.
+- **Workspaces is top-level navigation.** Route Workspaces at `/workspaces`, place it directly after Intune Chat, and use contextual add/link/pin actions from Intune Chat, Activity, and Run Detail.
+- **No silent workspace magic.** A workspace can suggest relevant chats, sources, and agent runs, but it does not secretly attach broad tenant context to prompts.
+
+## Priority 1 — Multi-tenant Intune Chat scope and UI
+
+- [x] **Tenant scope selector** — add an Intune Chat scope control with Active tenant, Selected tenants, and All connected tenants. Active tenant remains the default.
+- [x] **Tenant groups** — add local tenant groups that can be selected in the scope control and expanded into explicit tenant checklists during scope review.
+- [x] **Saved query gallery** — add a compact saved-query picker for common multi-tenant investigations such as Windows compliance, stale devices, BitLocker gaps, risky sign-ins, and Conditional Access gaps.
+- [x] **Prompt scope detection** — detect phrases such as "all tenants", "every connected tenant", and "all customers" and open scope review instead of silently using the active tenant.
+- [x] **Scope readiness preflight** — before a multi-tenant run starts, classify each selected tenant as ready, expired, missing scopes, stale, throttled, or skipped, with a visible recovery path.
+- [x] **Scope review panel** — render tenant checklist, resolved group membership, resource kinds, cache freshness, missing scopes, expired sessions, provider/model, and skipped-tenant warnings before any multi-tenant work starts.
+- [x] **Per-tenant progress card** — show queued, refreshing cache, reading local cache, building result, skipped, failed, or ready for each selected tenant inside the assistant response slot.
+- [x] **Aggregate result view** — render summary tiles and a tenant comparison table for multi-tenant answers. For the Windows compliance prompt, show tenants scanned, Windows devices, compliant, non-compliant, unknown, failed tenants, and stale-data caveats.
+- [x] **Answer artifact layout** — let table-heavy multi-tenant results span the conversation column while keeping prose at readable chat width; keep tenant columns visible and contain horizontal overflow inside the artifact.
+- [x] **Expandable tenant detail** — let admins expand a tenant row to inspect device-level rows with tenant, device name, compliance state, OS, OS version, last sync, owner, and source freshness.
+- [x] **Result filters** — filter multi-tenant result tables by tenant, readiness, compliance state, OS, stale data, and failed/skipped tenants.
+- [x] **Local exports and dossiers** — export multi-tenant results as CSV, Markdown, JSON, or a local dossier that includes query text, tenant scope, provider, freshness, skipped tenants, summary, and detail rows. Exports are explicit local file saves, not connector sends or background uploads.
+- [x] **Split to workspaces** — from a multi-tenant result, create/link separate tenant-specific workspace evidence entries without creating a mixed-tenant workspace.
+- [x] **Hosted-provider batch confirmation** — when a hosted provider is active, confirmation names every selected tenant or shows an expandable tenant list and states that retrieved context from those tenants will be sent to the provider.
+
+## Priority 2 — Multi-tenant host support
+
+- [x] **TenantScope contract** — add a chat input scope shape for active, selected tenant ids, and all connected tenants. Validate selected tenant ids in Electron main.
+- [x] **Tenant group store** — persist local tenant groups with id, name, tenant ids, updated time, and no tenant data beyond membership metadata.
+- [x] **Saved query store** — persist saved query templates with title, prompt text, resource hints, default scope hint, and local-only ordering metadata.
+- [x] **Separate multi-tenant stream IPC** — add a distinct multi-tenant chat stream path instead of overloading the existing single-active-tenant chat send.
+- [x] **Conversation tenant guard** — block appending to a single-tenant conversation when the active tenant no longer matches the conversation tenant; offer to switch tenant or start a new conversation.
+- [x] **Multi-tenant conversation marker** — store multi-tenant chat conversations with explicit scope metadata so history/search can badge them separately from tenant-scoped chats.
+- [x] **Scope preflight service** — compute readiness before execution, including account/session state, required delegated scopes, cache freshness, and recent throttle/failure signals.
+- [x] **Deterministic cross-tenant query helpers** — add SQL helpers for grouped read-only questions such as Windows device compliance by tenant, using cached `tenant_id`, `operating_system`, and `compliance_state`.
+- [x] **Graph cache fan-out** — refresh selected tenants with bounded concurrency and per-tenant failure state. One throttled or expired tenant must not fail the whole answer.
+- [x] **Multi-tenant chat job records** — introduce a local job record for cross-tenant chat queries, including preflight state, resolved tenant ids, saved-query id when used, export artifacts, and run duration.
+- [x] **Cross-tenant agent batch records** — agent batches queue one normal tenant-pinned `RunRecord` per tenant.
+- [x] **Write safety boundary** — multi-tenant chat never applies writes.
+- [x] **Cross-tenant write-agent confirmation** — write-agent batches require per-tenant plan review and typed confirmation; no "confirm all tenants" destructive action.
+
+## Priority 3 — Workspace data model and host APIs
+
+- [x] **Workspace schema migrations** — add local tables for workspaces, linked conversations, pinned evidence, linked agent runs, notes, and workspace-local instructions. Keep tenant id scoped on every row.
+- [x] **Workspace CRUD IPC** — create, rename, archive/delete, list, and load workspaces through validated Electron main IPC. Renderer must not write SQLite directly.
+- [x] **Evidence pinning contract** — define a compact, non-secret evidence reference shape for Graph cache rows, answer-pack sources, chat messages, and run result sections.
+- [x] **Split-result import** — accept tenant-specific evidence bundles created from a multi-tenant Intune Chat result and attach only the matching tenant's rows to each workspace.
+- [x] **Local deletion semantics** — deleting a workspace removes workspace metadata, notes, pins, and links only; it must not delete chat history, run history, tenant config, Graph cache, or connector audit records.
+- [x] **Export format** — export a workspace-local Markdown or JSON dossier with notes, linked chats, pinned evidence metadata, run links, and freshness. Tenant data stays local unless the admin exports it explicitly. Multi-tenant exports are handled by Intune Chat, not Workspaces.
+
+## Priority 4 — Workspaces UI
+
+- [x] **Workspaces route/shell** — add Workspaces as a top-level primary navigation item at `/workspaces`, placed directly after Intune Chat.
+- [x] **Workspace list** — show active tenant, workspace title, updated time, pinned evidence count, linked conversations, linked runs, and freshness state.
+- [x] **Workspace detail** — layout with notes, pinned evidence, linked chat conversations, linked agent runs, and local instructions. Keep the screen dense and operational, not a card-heavy project board.
+- [x] **Adaptive workspace panes** — use a two-pane list/detail layout that can collapse the workspace list at narrower desktop widths without hiding the global sidebar or status strip.
+- [x] **Create from chat** — allow creating a workspace from an Intune Chat conversation and linking the current conversation without copying messages into a second store.
+- [x] **Create from multi-tenant result** — allow creating one workspace per selected tenant from a multi-tenant Intune Chat result, with a review screen that shows the tenant-to-workspace mapping before writing local records.
+- [x] **Pin from chat answer** — allow pinning an answer, source, or source detail into the current workspace with freshness metadata.
+- [x] **Link run to workspace** — allow adding an existing run result to a workspace from Run Detail/Activity and from chat-started agent runs.
+- [x] **Empty states** — add designed zero-workspace and empty-workspace states with direct actions: start from Intune Chat, link a run, or add a note.
+
+## Priority 5 — Workspace-aware prompting
+
+- [x] **Explicit context attachment** — the composer can attach selected workspace evidence or notes to a prompt. It must show what will be included before send.
+- [x] **Hosted-provider confirmation integration** — when workspace context is attached and a hosted provider is active, the confirmation names the workspace, tenant, provider, model, and included context.
+- [x] **Workspace instructions storage** — allow approved local instructions per workspace. These cannot add Graph scopes, change agent mode, alter connector egress, or bypass confirmation.
+- [x] **Workspace instructions prompt composition** — apply workspace instructions only through explicit prompt/context attachment.
+- [x] **Suggestion hooks** — suggest relevant workspaces from matching tenant, conversation title, pinned source kind, or linked run, but never auto-attach context.
+
+## Priority 6 — Verification and docs
+
+- [x] **Host tests** — cover tenant groups, saved queries, multi-tenant scope validation, readiness preflight, per-tenant cache fan-out, partial failures, deterministic aggregation, dossier export, workspace schema migrations, CRUD, split-result import, deletion boundaries, evidence pinning, and export generation.
+- [x] **Renderer tests/smoke** — run a saved multi-tenant Windows compliance query from Intune Chat; review readiness; create a workspace from chat; split a multi-tenant result into tenant workspaces; pin a source; link a run; export the workspace; and delete the workspace without deleting underlying chat/run records.
+- [x] **UX mockups** — add `docs/mockups/11-multi-tenant-chat.html` and `docs/mockups/12-workspaces.html` before implementation, covering empty, loading, partial failure, hosted-provider, export, split-to-workspaces, and narrow-width states.
+- [x] **Accessibility and state review** — verify keyboard access, visible focus, `aria-sort` for sortable tables, icon labels, text+icon status indicators, persisted filters/expanded rows, and long-content truncation with accessible full-value disclosure.
+- [x] **Trust copy audit** — verify local/hosted provider copy across multi-tenant Intune Chat, Workspaces, StatusStrip, and export surfaces.
+- [x] **GitBook docs** — add admin-facing documentation for multi-tenant Intune Chat and Workspaces, covering tenant scope, tenant groups, saved queries, readiness preflight, result dossiers, what is stored locally, what can be attached to prompts, and how deletion/export behaves.
+- [x] **CHANGELOG entry** — record multi-tenant Intune Chat and Workspaces scope under `[Unreleased]` as implementation lands.
+
+## Acceptance criteria
+
+1. An admin can ask Intune Chat for compliant and non-compliant Windows devices across all connected tenants and see a scope review before any tenant data is read.
+2. An admin can create local tenant groups and select one during scope review; the UI shows the resolved tenant list before running.
+3. An admin can launch saved multi-tenant queries for common investigations and edit the prompt before send.
+4. The scope preflight shows ready, expired, missing-scope, stale, throttled, failed, and skipped tenants with recovery paths.
+5. The multi-tenant result shows per-tenant progress, partial failures, summary tiles, a tenant comparison table, filters, expandable device rows, and local CSV/Markdown/JSON/dossier export.
+6. A multi-tenant result can be split into separate tenant-specific workspace evidence without creating a mixed-tenant workspace.
+7. Table-heavy multi-tenant answers use a stable answer artifact layout with keyboard sorting/filtering, text+icon state indicators, and no page-level horizontal scroll.
+8. Hosted-provider multi-tenant sends require explicit confirmation for the selected tenants and provider before prompt construction.
+9. Multi-tenant chat never applies writes or connector side effects directly.
+10. Cross-tenant agent batches queue one tenant-pinned `RunRecord` per tenant; write-agent batches require per-tenant typed confirmation.
+11. An admin can create, rename, open, archive/delete, and export a tenant-scoped workspace.
+12. A workspace can link existing tenant-matching chat conversations and agent runs without duplicating or deleting the underlying records.
+13. An admin can pin Graph evidence/source details from a chat answer and see source freshness, tenant, resource kind, and cache/live status.
+14. Workspace notes and instructions are stored locally and scoped to one tenant.
+15. Workspaces do not accept mixed-tenant evidence; multi-tenant chat results can only export locally or be split into tenant-specific workspace evidence.
+16. Prompting with workspace context is explicit: the UI shows the selected evidence/notes before sending.
+17. Hosted-provider sends with attached workspace context require the same explicit confirmation boundary as Intune Chat.
+18. Deleting a workspace does not delete tenant config, chat history, Graph cache, run history, connector audit records, or self-training records.
+19. Workspace export is local and explicit, with no background upload.
+20. Multi-tenant Chat and Workspaces pass a keyboard/focus, narrow-width, long-content, empty-state, loading-state, and partial-failure UX review before release.
+21. `npm run typecheck`, `npm test`, `npm run qa`, and the relevant Electron smoke test pass before release.
+
 # v0.2.2 — Intune Chat + local intelligence foundation
 
 **Status: implemented and smoke-verified; live-tenant pilot run recommended before release.** Follow-up release after v0.2.1. The theme is making OpenAdminOS feel like an operating surface, not only an agent launcher: admins can ask natural-language questions against their own tenant, route repeatable work into installed agents as skills, and optionally approve local self-training suggestions that adapt those agents to their environment.
@@ -36,7 +149,7 @@
 
 ## Future UX follow-ups
 
-- [ ] **Tenant investigation workspaces** — adapt the useful parts of Claude-style Projects into tenant-scoped investigative workspaces with pinned Graph evidence, linked agent runs, notes, approved local instructions, and freshness metadata. TODO(ugur): decide final public naming and route shape before implementation.
+- [x] **Workspaces** — implemented in v0.2.5 as tenant-scoped investigation containers with pinned Graph evidence, linked agent runs, notes, approved local instructions storage, and freshness metadata. Route placement is top-level `/workspaces`, directly after Intune Chat.
 - [ ] **Reusable output panes** — evaluate artifact-like side panes for large generated outputs such as policy comparison reports, remediation plans, and exportable summaries, without sharing tenant data outside the selected provider trust boundary.
 
 ## Priority 3 — Agent-as-skill routing

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openadminos-website",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openadminos-website",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@octokit/rest": "^21.1.1",
         "@t3-oss/env-nextjs": "^0.13.11",
@@ -41,11 +41,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openadminos-website",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

v0.2.5 adds two major surfaces plus the version bump for the release. This is a feature PR; the dated `## [0.2.5]` CHANGELOG roll and the release itself are handled afterward by the `release-prep` workflow.

### Multi-tenant Intune Chat
- Explicit read-only tenant scope selection with local tenant groups and saved queries
- Readiness preflight, hosted-provider batch confirmation, deterministic Windows compliance aggregation, result filters, and local exports
- Streamed multi-tenant chat progress IPC and split-to-workspaces evidence import

### Single-tenant Workspaces
- New top-level `/workspaces` surface with SQLite-backed workspace CRUD
- Pinned evidence, notes, linked chats/runs, local instructions, and Markdown dossier export
- Deletion boundaries leave chats, runs, tenants, and Graph cache intact

### Versioning + docs
- App, all workspace packages, marketing site, and UI-displayed version (`__APP_VERSION__`, shown in Sidebar/StatusStrip/Settings) bumped to `0.2.5`
- SPEC coverage, new mockups `11-multi-tenant-chat.html` / `12-workspaces.html`, and GitBook feature pages
- CHANGELOG entries recorded under `[Unreleased]` (not rolled - `release-prep` dates the `[0.2.5]` section at release time)

## Commits
1. `chat/workspaces:` feature code (electron IPC/preload/state, agent-sdk, UI pages, tests)
2. `docs:` SPEC, mockups, GitBook
3. `chore:` version bumps + CHANGELOG `[Unreleased]`

## Verification
- `npm run typecheck` - passes (incl. desktop `tsc -b` + electron project)
- Desktop unit tests - 44 passed, 0 failed

## Release
After merge: run the `release-prep` workflow for `0.2.5`. It rolls `[Unreleased]` -> dated `[0.2.5]`, opens a `release: v0.2.5` PR; merging that auto-tags `v0.2.5` and `release.yml` publishes the GitHub Release with signed installers and checksums.
