### PR TITLE
release: v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to OpenAdminOS are recorded here. Format follows [Keep a Cha
 
 ### Added
 
+### Changed
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.2.5] - 2026-07-04
+
+### Added
+
 - Added v0.2.5 multi-tenant Intune Chat for explicit read-only tenant scope review, local tenant groups, saved queries, readiness preflight, hosted-provider batch confirmation, deterministic Windows compliance aggregation, result filters, local exports, and split-to-workspaces evidence import.
 - Added single-tenant Workspaces as a top-level `/workspaces` surface with local SQLite-backed workspace CRUD, pinned evidence, notes, linked chats, linked runs, local instructions storage, Markdown dossier export, and deletion boundaries that leave chats, runs, tenants, and Graph cache intact.
 - Added multi-tenant chat and Workspaces contracts, validated Electron IPC/preload APIs, mockups `11-multi-tenant-chat.html` and `12-workspaces.html`, GitBook documentation, and focused host tests for partial tenant failures and workspace deletion/split-result boundaries.


### PR DESCRIPTION
Rolls `CHANGELOG [Unreleased]` into a dated `## [0.2.5] - 2026-07-04` section. Versions were already bumped to 0.2.5 in #59, so this is the CHANGELOG roll only (the `release-prep` workflow can't self-bump an already-current version).

When this merges to main, `auto-tag.yml` pushes `v0.2.5` and `release.yml` builds the signed installers and publishes the GitHub Release with these notes + checksums.