### PR TITLE
docs: update README screenshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to OpenAdminOS are recorded here. Format follows [Keep a Cha
 
 ### Changed
 
+- Updated the README product screenshot to the current Chat-first desktop interface with sourced findings and a matching-agent recommendation.
+
 ### Removed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 [**Download**](https://github.com/OpenAdminOS/OpenAdminOS/releases/latest) · [**Website**](https://openadminos.com) · [**Docs**](docs/SPEC.md) · [**Contributing**](CONTRIBUTING.md) · [**Changelog**](CHANGELOG.md)
 
-![OpenAdminOS desktop app](docs/demo.png)
+![OpenAdminOS Intune Chat with sourced device findings and a matching agent](docs/screenshots/app/chat-transcript.png)
 
 </div>
 


### PR DESCRIPTION
## What changed

- replace the outdated README Agent Hub image with the maintained v0.4 Chat transcript capture
- describe the screenshot accurately for screen-reader users
- record the public-documentation update in the changelog

## Why

The previous hero image showed the older navigation and Agent Hub surface. The new image represents the current Chat-first desktop interface and demonstrates sourced findings plus a matching-agent recommendation.

## Verification

- `npm run docs:check`
- Markdown image target exists
- PNG verified at 1600 × 1000
- `git diff --check`
