### PR TITLE
release: v0.5.1 agent sign-in and cancellation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to OpenAdminOS are recorded here. Format follows [Keep a Cha
 
 - Microsoft sign-in requests now expire after five minutes, including additional permission requests made by agents. The active step explains the browser sign-in wait and how to cancel it. Closing the system browser still requires Cancel run or timeout because browser closure is not reported to the app.
 - Cancel run now interrupts authentication and provider/Graph work and prevents subsequent approved actions. Results from requests already sent remain in the run history; cancellation does not reverse remote changes that already happened.
-- Scheduled agents return actionable sign-in instructions when credentials or permissions need attention, instead of opening an unattended browser and blocking later runs indefinitely.
+- Scheduled agents and their Teams/Outlook notifications return actionable sign-in instructions when credentials or permissions need attention, instead of opening an unattended browser and blocking later runs indefinitely.
 - Restarting the app marks interrupted runs failed with recovery instructions, preserving pending write approvals and avoiding automatic write retries. Provider discovery failures during confirmation leave the plan awaiting approval rather than stranded as running.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to OpenAdminOS are recorded here. Format follows [Keep a Cha
 
 ### Added
 
+- Documented a 14-agent lifecycle audit identifying abandoned Microsoft sign-in waits, ineffective execution cancellation, and related scheduling and persistence gaps; runtime fixes remain outstanding.
 - The landing page shows two testimonials, from Merill Fernando and Ugur Koc, directly under the traction strip so the install and star counts are followed by named admins.
 - The website offers the Windows installer. The landing page's Download for Windows button and a Windows section on the download page resolve to the signed x64 installer from the latest GitHub release, with its SHA-256 hash, the same way the macOS and Linux downloads already did. The structured data now lists Windows as a supported operating system.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,19 @@ All notable changes to OpenAdminOS are recorded here. Format follows [Keep a Cha
 
 ### Added
 
-- Documented a 14-agent lifecycle audit identifying abandoned Microsoft sign-in waits, ineffective execution cancellation, and related scheduling and persistence gaps; runtime fixes remain outstanding.
+### Changed
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.5.1] - 2026-09-06
+
+### Added
+
+- Included a lifecycle audit covering all 14 registry agents, with regression coverage for sign-in, cancellation, scheduling, and interrupted execution.
 - The landing page shows two testimonials, from Merill Fernando and Ugur Koc, directly under the traction strip so the install and star counts are followed by named admins.
 - The website offers the Windows installer. The landing page's Download for Windows button and a Windows section on the download page resolve to the signed x64 installer from the latest GitHub release, with its SHA-256 hash, the same way the macOS and Linux downloads already did. The structured data now lists Windows as a supported operating system.
 
@@ -15,6 +27,11 @@ All notable changes to OpenAdminOS are recorded here. Format follows [Keep a Cha
 ### Removed
 
 ### Fixed
+
+- Microsoft sign-in requests now expire after five minutes, including additional permission requests made by agents. The active step explains the browser sign-in wait and how to cancel it. Closing the system browser still requires Cancel run or timeout because browser closure is not reported to the app.
+- Cancel run now interrupts authentication and provider/Graph work and prevents subsequent approved actions. Results from requests already sent remain in the run history; cancellation does not reverse remote changes that already happened.
+- Scheduled agents return actionable sign-in instructions when credentials or permissions need attention, instead of opening an unattended browser and blocking later runs indefinitely.
+- Restarting the app marks interrupted runs failed with recovery instructions, preserving pending write approvals and avoiding automatic write retries. Provider discovery failures during confirmation leave the plan awaiting approval rather than stranded as running.
 
 ### Security
 

--- a/apps/desktop/electron/connector-confirm-bridge.ts
+++ b/apps/desktop/electron/connector-confirm-bridge.ts
@@ -46,7 +46,9 @@ export function installConnectorConfirmBridge(input: {
  */
 export async function requestConnectorConfirmation(
   info: ConnectorInvocationInfo,
+  signal?: AbortSignal,
 ): Promise<ConfirmationDecision> {
+  signal?.throwIfAborted();
   const window = getMainWindow();
   if (!window || window.isDestroyed()) {
     return { approved: false, reason: "No renderer attached to receive confirmation." };
@@ -72,7 +74,15 @@ export async function requestConnectorConfirmation(
   };
 
   return new Promise<ConfirmationDecision>((resolve) => {
-    pending.set(requestId, { resolve });
+    const finish = (decision: ConfirmationDecision) => {
+      signal?.removeEventListener("abort", abort);
+      pending.delete(requestId);
+      resolve(decision);
+    };
+    const abort = () => finish({ approved: false, reason: "Run cancelled by user." });
+    pending.set(requestId, { resolve: finish });
+    signal?.addEventListener("abort", abort, { once: true });
+    if (signal?.aborted) { abort(); return; }
     window.webContents.send("openadminos:connector-confirm-request", payload);
   });
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6249,6 +6249,7 @@ if (!gotLock) {
           }
         : {}),
     });
+    await store.recoverInterruptedRuns();
     applySandboxedCodeEnabled(await store.getSandboxedCodeEnabled());
     registerIpcHandlers();
     void store.processPendingRunDeliveries();

--- a/apps/desktop/electron/run-auth.test.ts
+++ b/apps/desktop/electron/run-auth.test.ts
@@ -32,3 +32,31 @@ it("scheduled Graph access fails with recovery instructions without opening Micr
     assert.equal(browserCalls, 0);
   } finally { store.close(); await rm(dir, { recursive: true, force: true }); }
 });
+
+it("scheduled Teams and Outlook deliveries never open an unattended sign-in", async () => {
+  const { RunDeliveryService } = await import("./run-delivery.js");
+  let browserCalls = 0;
+  const run = { id: "scheduled", agentSlug: "test", status: "completed", trigger: "schedule",
+    queuedAt: new Date().toISOString(), summary: "Test completed", logs: [], steps: [], tenantId: "tenant-1" } as const;
+  const settings = { enabled: true, includeScheduledRuns: true, notifyOnSuccess: true };
+  const host = {
+    read: async () => ({ installedAgents: [{ id: "test", slug: "test", name: "Test", delivery: {
+      teams: { ...settings, useDefaultTarget: true }, outlook: { ...settings, useDefaultRecipients: true },
+    } }], tenants: [{ id: "tenant-1", displayName: "Test", homeAccountId: "test", username: "test@example.com" }],
+    connectors: { teams: { config: { defaultTeamId: "team", defaultChannelId: "channel" } },
+      outlook: { config: { defaultRecipients: "test@example.com" } } }, runs: [],
+    }),
+    getMsalClient: () => ({ getTokenCache: () => ({ getAccountByHomeId: async () => null }) }),
+    openBrowser: async () => { browserCalls += 1; },
+    connectorSecretsFor: () => ({ get: async () => undefined }),
+    appendRunStep: async () => "step", finishRunStep: async () => undefined, appendRunLog: async () => undefined,
+  };
+  const service = new RunDeliveryService(host as unknown as import("./run-delivery.js").RunDeliveryHost);
+  const internal = service as unknown as {
+    deliverRunToTeams(run: unknown): Promise<{ error?: string }>;
+    deliverRunToOutlook(run: unknown): Promise<{ error?: string }>;
+  };
+  assert.match((await internal.deliverRunToTeams(run)).error ?? "", /Scheduled notification needs Microsoft sign-in/);
+  assert.match((await internal.deliverRunToOutlook(run)).error ?? "", /Scheduled notification needs Microsoft sign-in/);
+  assert.equal(browserCalls, 0);
+});

--- a/apps/desktop/electron/run-auth.test.ts
+++ b/apps/desktop/electron/run-auth.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { it } from "node:test";
+import type { RunGraphApi } from "@openadminos/agent-sdk";
+import { AppStateStore } from "./state.js";
+
+it("scheduled Graph access fails with recovery instructions without opening Microsoft sign-in", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "openadminos-scheduled-auth-"));
+  const filePath = join(dir, "state.json");
+  await writeFile(filePath, JSON.stringify({ activeProviderId: "ollama", installedAgents: [], runs: [],
+    activeTenantId: "tenant-1", tenants: [{ id: "tenant-1", displayName: "Test", username: "test@example.com", homeAccountId: "test", addedAt: new Date().toISOString() }] }));
+  let browserCalls = 0;
+  const store = new AppStateStore({ filePath, userDataPath: dir, statsApiUrl: "",
+    tokenStore: { read: async () => "", write: async () => undefined },
+    openBrowser: async () => { browserCalls += 1; },
+  });
+  // Force a missing cached account without contacting Microsoft.
+  Object.defineProperty(store, "msalClientForTenant", { value: () => ({
+    getTokenCache: () => ({ getAccountByHomeId: async () => null }),
+  }) });
+  try {
+    const internal = store as unknown as { buildGraph(tenant: string, scopes: string[], execution: {
+      signal: AbortSignal; allowInteractive: boolean; onAuthRequired(): Promise<void>;
+    }): Promise<{ createGraph(log: () => void): RunGraphApi }> };
+    const selection = await internal.buildGraph("tenant-1", ["Policy.Read.All"], {
+      signal: new AbortController().signal, allowInteractive: false,
+      onAuthRequired: async () => { throw new Error("Interactive flow must not start"); },
+    });
+    await assert.rejects(selection.createGraph(() => undefined).request({ method: "GET", path: "/identity/conditionalAccess/policies" }), /Scheduled run needs Microsoft sign-in/);
+    assert.equal(browserCalls, 0);
+  } finally { store.close(); await rm(dir, { recursive: true, force: true }); }
+});

--- a/apps/desktop/electron/run-delivery.ts
+++ b/apps/desktop/electron/run-delivery.ts
@@ -551,13 +551,20 @@ export class RunDeliveryService {
 
     const client = this.host.getMsalClient();
     const openBrowser = this.host.openBrowser;
+    let scheduledAuthRequired = false;
+    const authRecovery = "Scheduled notification needs Microsoft sign-in or additional permissions. Open Connectors and test the connection before retrying delivery.";
     const tenantSession = createTenantSession({
       client,
       tenantId: tenant.id,
       username: tenant.username,
       homeAccountId: tenant.homeAccountId,
-      acquireInteractive: async (scopes) =>
-        runInteractiveFlow({ client, scopes, openBrowser }),
+      acquireInteractive: async (scopes) => {
+        if (run.trigger === "schedule") {
+          scheduledAuthRequired = true;
+          throw new Error(authRecovery);
+        }
+        return runInteractiveFlow({ client, scopes, openBrowser });
+      },
     });
 
     let instance: Awaited<ReturnType<typeof factory.build>> | undefined;
@@ -615,7 +622,7 @@ export class RunDeliveryService {
       });
       return { retryable: false };
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = scheduledAuthRequired ? authRecovery : error instanceof Error ? error.message : String(error);
       const audit = createDeliveryAuditEntry({
         runId: run.id,
         stepId,
@@ -643,7 +650,7 @@ export class RunDeliveryService {
           connectorAudit: audit as unknown as Record<string, unknown>,
         },
       );
-      return { retryable: true, error: message };
+      return { retryable: !scheduledAuthRequired, error: message };
     } finally {
       await instance?.dispose().catch(() => undefined);
     }
@@ -865,13 +872,20 @@ export class RunDeliveryService {
 
     const client = this.host.getMsalClient();
     const openBrowser = this.host.openBrowser;
+    let scheduledAuthRequired = false;
+    const authRecovery = "Scheduled notification needs Microsoft sign-in or additional permissions. Open Connectors and test the connection before retrying delivery.";
     const tenantSession = createTenantSession({
       client,
       tenantId: tenant.id,
       username: tenant.username,
       homeAccountId: tenant.homeAccountId,
-      acquireInteractive: async (scopes) =>
-        runInteractiveFlow({ client, scopes, openBrowser }),
+      acquireInteractive: async (scopes) => {
+        if (run.trigger === "schedule") {
+          scheduledAuthRequired = true;
+          throw new Error(authRecovery);
+        }
+        return runInteractiveFlow({ client, scopes, openBrowser });
+      },
     });
 
     let instance: Awaited<ReturnType<typeof factory.build>> | undefined;
@@ -931,7 +945,7 @@ export class RunDeliveryService {
       });
       return { retryable: false };
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = scheduledAuthRequired ? authRecovery : error instanceof Error ? error.message : String(error);
       const audit = createDeliveryAuditEntry({
         runId: run.id,
         stepId,
@@ -954,7 +968,7 @@ export class RunDeliveryService {
         connectorId: OUTLOOK_CONNECTOR_ID,
         connectorAudit: audit as unknown as Record<string, unknown>,
       });
-      return { retryable: isRetryableDeliveryError(error), error: message };
+      return { retryable: !scheduledAuthRequired && isRetryableDeliveryError(error), error: message };
     } finally {
       await instance?.dispose().catch(() => undefined);
     }

--- a/apps/desktop/electron/run-lifecycle.test.ts
+++ b/apps/desktop/electron/run-lifecycle.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { RunRecord, AgentSummary, GraphRequestInput } from "@openadminos/agent-sdk";
+import { RunService, type RunPersistedState, type RunServiceHost } from "./runs.js";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+function harness() {
+  let state: RunPersistedState = { activeProviderId: "ollama", installedAgents: [], runs: [], tenants: [] };
+  let tail: Promise<unknown> = Promise.resolve();
+  const entered = deferred();
+  const release = deferred();
+  const requests: GraphRequestInput[] = [];
+  let signal: AbortSignal | undefined;
+  const host = {
+    read: async () => structuredClone(state),
+    write: async (next: RunPersistedState) => { state = structuredClone(next); },
+    serialize: <T>(task: () => Promise<T>): Promise<T> => {
+      const next = tail.then(task); tail = next.catch(() => undefined); return next;
+    },
+    buildGraph: async (_tenant, _scopes, execution) => {
+      signal = execution?.signal;
+      return { tenantId: "test", tenantSession: {} as never, createGraph: () => ({
+        request: async (input: GraphRequestInput) => {
+          requests.push(input); entered.resolve(); await release.promise;
+        },
+      }) as never };
+    },
+    listProviders: async () => { throw new Error("Provider discovery unavailable"); },
+    recordLearningEventSafely: () => undefined,
+    emitStateChanged: () => undefined,
+    notifyRunFinished: () => undefined,
+    enqueueRunDeliveries: async () => undefined,
+    processPendingRunDeliveries: async () => undefined,
+  } satisfies Partial<RunServiceHost>;
+  return { service: new RunService(host as unknown as RunServiceHost), host, entered, release, requests,
+    state: () => state, signal: () => signal };
+}
+async function queue(h: ReturnType<typeof harness>) {
+  return h.service.startRollbackRun({ tenantId: "test", baselineId: "test", requiredScopes: [], manualCount: 0,
+    plan: { summary: "Restore two objects", confirmationPhrase: "ROLLBACK 2 OBJECTS", actions: [0, 1].map((i) => ({
+      id: String(i), kind: "graph-write", label: `Restore ${i}`, severity: "default" as const,
+      request: { method: "PATCH" as const, path: `/test/${i}`, body: {} },
+    })) },
+  });
+}
+async function settle() { await new Promise((resolve) => setTimeout(resolve, 20)); }
+
+describe("run lifecycle", () => {
+  it("stops between approved actions and retains the outcome of the dispatched request", async () => {
+    const h = harness(); const run = await queue(h);
+    await h.service.confirmRun(run.id, "ROLLBACK 2 OBJECTS");
+    await h.entered.promise;
+    await h.service.cancelRun(run.id);
+    assert.equal(h.signal()?.aborted, true);
+    h.release.resolve(); await settle();
+    assert.equal(h.requests.length, 1);
+    const stored = h.state().runs[0]!;
+    assert.equal(stored.status, "cancelled");
+    assert.equal(stored.steps[0]?.status, "completed");
+    assert.match(stored.summary ?? "", /already sent/);
+  });
+
+  it("does not revive a cancellation when a snapshot was queued before cancel finished", async () => {
+    const h = harness(); const run = await queue(h);
+    const cancel = h.service.cancelRun(run.id);
+    const progress = h.service.persistRunSnapshot({ ...run, status: "running" });
+    await Promise.all([cancel, progress]);
+    assert.equal(h.state().runs[0]?.status, "cancelled");
+  });
+
+  it("recovers interrupted work without replaying writes or removing pending approval", async () => {
+    const h = harness(); const pending = await queue(h);
+    const running: RunRecord = { ...pending, id: "interrupted", status: "running", confirmedAt: new Date().toISOString() };
+    await h.host.write({ ...h.state(), runs: [pending, running, { ...pending, id: "queued", status: "queued" }] });
+    await h.service.recoverInterruptedRuns();
+    assert.deepEqual(h.state().runs.map((r) => r.status), ["awaiting-confirmation", "failed", "failed"]);
+    assert.match(h.state().runs[1]?.summary ?? "", /Review the tenant/);
+    assert.equal(h.requests.length, 0);
+  });
+
+  it("leaves approval pending if provider discovery fails before apply", async () => {
+    const h = harness(); const run = await queue(h);
+    const agent = { slug: "write-test", mode: "write" } as AgentSummary;
+    await h.host.write({ ...h.state(), installedAgents: [agent], runs: [{ ...run, origin: undefined, agentSlug: agent.slug }] });
+    await assert.rejects(h.service.confirmRun(run.id, "ROLLBACK 2 OBJECTS"), /Provider discovery/);
+    assert.equal(h.state().runs[0]?.status, "awaiting-confirmation");
+    assert.equal(h.requests.length, 0);
+  });
+});

--- a/apps/desktop/electron/runs.ts
+++ b/apps/desktop/electron/runs.ts
@@ -58,6 +58,7 @@ export interface RunServiceHost {
   buildGraph(
     pinnedTenantId?: string,
     agentScopes?: string[],
+    execution?: { signal: AbortSignal; allowInteractive: boolean; onAuthRequired(): Promise<void> },
   ): Promise<{
     createGraph: (
       log: (
@@ -88,7 +89,7 @@ export interface RunServiceHost {
 }
 
 export class RunService {
-  private readonly cancelledRunIds = new Set<string>();
+  private readonly controllers = new Map<string, AbortController>();
 
   constructor(private readonly host: RunServiceHost) {}
 
@@ -109,6 +110,7 @@ export class RunService {
         return run;
       }
 
+      this.controllers.get(runId)?.abort(new Error("Run cancelled by user."));
       const finishedAt = new Date().toISOString();
       const cancelled: RunRecord = {
         ...run,
@@ -117,7 +119,10 @@ export class RunService {
         // Overwrite any stale in-progress summary (e.g. "X is running.")
         // with an explicit cancellation message. The original summary
         // would otherwise leak into Activity rows long after the cancel.
-        summary: "Cancelled by user.",
+        summary: run.confirmedAt
+          ? "Cancelled by user. Requests already sent may have completed; review the action steps before retrying."
+          : "Cancelled by user.",
+        liveSummary: undefined,
         // Transition any in-flight step to "cancelled" and stop any
         // streaming reasoning indicator. Without this the UI keeps
         // spinning the active step and showing a "streaming" badge
@@ -146,7 +151,7 @@ export class RunService {
       await this.host.write({ ...persisted, runs: nextRuns });
       return cancelled;
     });
-    this.cancelledRunIds.add(runId);
+    this.host.emitStateChanged("run-cancelled", runId);
     return result;
   }
 
@@ -498,6 +503,18 @@ export class RunService {
         throw new Error(`Agent ${run.agentSlug} is not a write agent.`);
       }
 
+      const providers = await this.host.listProviders();
+      const activeProvider =
+        providers.find((provider) => provider.id === persisted.activeProviderId) ??
+        providers[0];
+      const providerId = run.providerId ?? activeProvider?.id ?? persisted.activeProviderId;
+      const model =
+        run.model ??
+        resolveProviderDefaultModel(
+          activeProvider,
+          persisted.activeModelByProviderId,
+        ).model;
+
       const confirmedAt = new Date().toISOString();
       const updated: RunRecord = {
         ...run,
@@ -512,18 +529,6 @@ export class RunService {
           existing.id === runId ? updated : existing,
         ),
       });
-
-      const providers = await this.host.listProviders();
-      const activeProvider =
-        providers.find((provider) => provider.id === persisted.activeProviderId) ??
-        providers[0];
-      const providerId = run.providerId ?? activeProvider?.id ?? persisted.activeProviderId;
-      const model =
-        run.model ??
-        resolveProviderDefaultModel(
-          activeProvider,
-          persisted.activeModelByProviderId,
-        ).model;
 
       return { kind: "agent" as const, agent, providerId, model, updated };
     });
@@ -612,6 +617,47 @@ export class RunService {
     return persisted.runs.find((run) => run.id === id);
   }
 
+  private executionOptions(run: RunRecord, signal: AbortSignal) {
+    return {
+      signal,
+      allowInteractive: run.trigger !== "schedule",
+      onAuthRequired: async () => {
+        const message = "Waiting for Microsoft sign-in. Complete sign-in in your browser, or select Cancel run. This request expires after five minutes.";
+        await this.host.serialize(async () => {
+          signal.throwIfAborted();
+          const state = await this.host.read();
+          await this.host.write({ ...state, runs: state.runs.map((current) =>
+            current.id === run.id && !isTerminalRunStatus(current.status)
+              ? { ...current, summary: message, steps: current.steps.map((step) =>
+                step.status === "running" ? { ...step, detail: message } : step) }
+              : current) });
+        });
+        await this.appendRunLog(run.id, "info", message);
+      },
+    };
+  }
+
+  async recoverInterruptedRuns(): Promise<void> {
+    await this.host.serialize(async () => {
+      const state = await this.host.read();
+      const finishedAt = new Date().toISOString();
+      const runs = state.runs.map((run): RunRecord => {
+        if (!["running", "queued"].includes(run.status) || this.controllers.has(run.id)) return run;
+        const message = run.confirmedAt
+          ? "OpenAdminOS closed during this run. Requests already sent may have completed. Review the tenant before running it again."
+          : "OpenAdminOS closed before this run finished. Run the agent again to retry.";
+        return { ...run, status: "failed", finishedAt, summary: message, error: message,
+          liveSummary: undefined,
+          steps: run.steps.map((step) => ({ ...step,
+            ...(step.status === "running" ? { status: "failed" as const, finishedAt, detail: message } : {}),
+            ...(step.thinking ? { thinking: { ...step.thinking, streaming: false } } : {}),
+          })),
+        };
+      });
+      if (runs.some((run, index) => run !== state.runs[index])) await this.host.write({ ...state, runs });
+    });
+  }
+
   private stampTenant(run: RunRecord, tenantId: string): RunRecord {
     return { ...run, tenantId };
   }
@@ -622,15 +668,20 @@ export class RunService {
     providerId: ProviderId;
     model?: string;
   }): Promise<void> {
+    const controller = new AbortController();
+    this.controllers.set(input.run.id, controller);
     try {
+      if ((await this.getRun(input.run.id))?.status === "cancelled") return;
       const driver = input.agent.mode === "write" ? executePlan : executeRun;
       const baseLlm = await this.host.buildLlm(input.providerId, input.model);
-      const selection = await this.host.buildGraph(input.run.tenantId, input.agent.scopes);
+      const selection = await this.host.buildGraph(input.run.tenantId, input.agent.scopes, this.executionOptions(input.run, controller.signal));
       const overlay = this.host.selfTrainingPromptOverlay(selection.tenantId, input.agent.slug);
       const llm = overlay ? withSelfTrainingOverlay(baseLlm, overlay) : baseLlm;
       const stampedRun = this.stampTenant(input.run, selection.tenantId);
       await this.persistRunSnapshot(stampedRun);
+      controller.signal.throwIfAborted();
       await driver({
+        signal: controller.signal,
         run: stampedRun,
         agent: input.agent,
         providerId: input.providerId,
@@ -640,13 +691,15 @@ export class RunService {
         tenant: selection.tenantSession,
         connectorConfigs: await this.host.readConnectorConfigs(),
         connectorSecretsFor: (connectorId) => this.host.connectorSecretsFor(connectorId),
-        confirmCapability: requestConnectorConfirmation,
+        confirmCapability: (info) => requestConnectorConfirmation(info, controller.signal),
         realWrites: true,
         onProgress: (next) =>
           this.persistRunSnapshot(this.stampTenant(next, selection.tenantId)),
       });
     } catch (error) {
       await this.persistFailedSnapshot(input.run, input.agent, error);
+    } finally {
+      if (this.controllers.get(input.run.id) === controller) this.controllers.delete(input.run.id);
     }
   }
 
@@ -657,12 +710,17 @@ export class RunService {
     model?: string;
     plan: NonNullable<RunRecord["plan"]>;
   }): Promise<void> {
+    const controller = new AbortController();
+    this.controllers.set(input.run.id, controller);
     try {
+      if ((await this.getRun(input.run.id))?.status === "cancelled") return;
       const baseLlm = await this.host.buildLlm(input.providerId, input.model);
-      const selection = await this.host.buildGraph(input.run.tenantId, input.agent.scopes);
+      const selection = await this.host.buildGraph(input.run.tenantId, input.agent.scopes, this.executionOptions(input.run, controller.signal));
       const overlay = this.host.selfTrainingPromptOverlay(selection.tenantId, input.agent.slug);
       const llm = overlay ? withSelfTrainingOverlay(baseLlm, overlay) : baseLlm;
+      controller.signal.throwIfAborted();
       await executeApply({
+        signal: controller.signal,
         run: input.run,
         agent: input.agent,
         providerId: input.providerId,
@@ -673,13 +731,15 @@ export class RunService {
         tenant: selection.tenantSession,
         connectorConfigs: await this.host.readConnectorConfigs(),
         connectorSecretsFor: (connectorId) => this.host.connectorSecretsFor(connectorId),
-        confirmCapability: requestConnectorConfirmation,
+        confirmCapability: (info) => requestConnectorConfirmation(info, controller.signal),
         realWrites: true,
         onProgress: (next) =>
           this.persistRunSnapshot(this.stampTenant(next, selection.tenantId)),
       });
     } catch (error) {
       await this.persistFailedSnapshot(input.run, input.agent, error);
+    } finally {
+      if (this.controllers.get(input.run.id) === controller) this.controllers.delete(input.run.id);
     }
   }
 
@@ -695,19 +755,23 @@ export class RunService {
     const plan = input.run.plan;
     const isRollback = input.run.origin === "baseline-rollback";
     const noun = isRollback ? "Rollback" : "Proposal";
+    const controller = new AbortController();
+    this.controllers.set(input.run.id, controller);
     try {
+      if ((await this.getRun(input.run.id))?.status === "cancelled") return;
       if (!plan) throw new Error(`${noun} run has no plan.`);
       const scopes =
         input.run.rollback?.requiredScopes ??
         input.run.external?.requiredScopes ??
         [];
-      const selection = await this.host.buildGraph(input.run.tenantId, scopes);
+      const selection = await this.host.buildGraph(input.run.tenantId, scopes, this.executionOptions(input.run, controller.signal));
       const graph = selection.createGraph((level, message, metadata) => {
         void this.appendRunLog(input.run.id, level, message, metadata);
       });
       let run = this.stampTenant(input.run, selection.tenantId);
       let applied = 0;
       for (const [index, action] of plan.actions.entries()) {
+        controller.signal.throwIfAborted();
         const startedAt = new Date().toISOString();
         const step = {
           id: `step_rollback_${index}`,
@@ -723,7 +787,9 @@ export class RunService {
           if (!action.request) {
             throw new Error(`${noun} action carries no Graph request.`);
           }
+          controller.signal.throwIfAborted();
           await graph.request({
+            signal: controller.signal,
             method: action.request.method,
             path: action.request.path,
             ...(action.request.body !== undefined
@@ -787,6 +853,8 @@ export class RunService {
         summary: `${noun} failed before any action was applied: ${message}`,
         error: message,
       });
+    } finally {
+      if (this.controllers.get(input.run.id) === controller) this.controllers.delete(input.run.id);
     }
   }
 
@@ -807,16 +875,26 @@ export class RunService {
   }
 
   async persistRunSnapshot(run: RunRecord): Promise<void> {
-    if (this.cancelledRunIds.has(run.id)) {
-      // Run was soft-cancelled: discard further progress snapshots so
-      // the stored state stays in the "cancelled" terminal state even
-      // while background work finishes returning.
-      return Promise.resolve();
-    }
     let deliveryCandidate: RunRecord | undefined;
     await this.host.serialize(async () => {
       const persisted = await this.host.read();
       const previous = persisted.runs.find((existing) => existing.id === run.id);
+      if (previous?.status === "cancelled") {
+        const steps = previous.steps.map((step) => {
+          const incoming = run.steps.find((candidate) => candidate.id === step.id);
+          if (step.status !== "cancelled" || !incoming ||
+              !["completed", "failed"].includes(incoming.status)) return step;
+          if (incoming.status === "failed" && /cancelled/i.test(incoming.detail ?? "")) return { ...step, detail: incoming.detail };
+          return { ...incoming, thinking: incoming.thinking ? { ...incoming.thinking, streaming: false } : undefined };
+        });
+        const logs = [...previous.logs];
+        for (const log of run.logs) if (!logs.some((existing) => existing.id === log.id)) logs.push(log);
+        await this.host.write({ ...persisted, runs: persisted.runs.map((existing) =>
+          existing.id === run.id ? { ...previous, steps, logs } : existing) });
+        return;
+      }
+      if (previous && isTerminalRunStatus(previous.status) && !isTerminalRunStatus(run.status)) return;
+
       const wasTerminal = previous ? isTerminalRunStatus(previous.status) : false;
       const isNowTerminal = isTerminalRunStatus(run.status);
       const nextRun =

--- a/apps/desktop/electron/state.ts
+++ b/apps/desktop/electron/state.ts
@@ -1283,8 +1283,8 @@ export class AppStateStore {
       listProviders: () => host.listProviders(),
       providerCanRun: (provider) => host.providerCanRun(provider),
       buildLlm: (providerId, model) => host.buildLlm(providerId, model),
-      buildGraph: (pinnedTenantId, agentScopes) =>
-        host.buildGraph(pinnedTenantId, agentScopes),
+      buildGraph: (pinnedTenantId, agentScopes, execution) =>
+        host.buildGraph(pinnedTenantId, agentScopes, execution),
       readConnectorConfigs: () => host.readConnectorConfigs(),
       connectorSecretsFor: (connectorId) => host.connectorSecretsFor(connectorId),
       selfTrainingPromptOverlay: (tenantId, agentSlug) =>
@@ -4318,6 +4318,10 @@ Return ONLY the YAML manifest. Do not include any commentary, headings, or markd
     return this.getAppState();
   }
 
+  async recoverInterruptedRuns(): Promise<void> {
+    await this.runService.recoverInterruptedRuns();
+  }
+
   async cancelRun(runId: string): Promise<RunRecord> {
     return this.runService.cancelRun(runId);
   }
@@ -5240,6 +5244,7 @@ Return ONLY the YAML manifest. Do not include any commentary, headings, or markd
   private async buildGraph(
     pinnedTenantId?: string,
     agentScopes?: string[],
+    execution?: { signal: AbortSignal; allowInteractive: boolean; onAuthRequired(): Promise<void> },
   ): Promise<{
     createGraph: (
       log: (
@@ -5269,12 +5274,17 @@ Return ONLY the YAML manifest. Do not include any commentary, headings, or markd
       username: tenant.username,
       homeAccountId: tenant.homeAccountId,
       acquireInteractive: async (scopes) => {
+        execution?.signal.throwIfAborted();
+        if (execution && !execution.allowInteractive) {
+          throw new Error("Scheduled run needs Microsoft sign-in or additional permissions. Run the agent manually and complete sign-in, then retry the schedule.");
+        }
+        await execution?.onAuthRequired();
         // Per-capability incremental consent. Pops a browser sign-in when
         // a connector or agent requests scopes the cached refresh token
         // cannot satisfy. The user re-consents to the additional
         // scopes; subsequent silent acquisitions for the same scope set
         // succeed from cache.
-        return await runInteractiveFlow({ client, scopes, openBrowser });
+        return await runInteractiveFlow({ client, scopes, openBrowser, signal: execution?.signal });
       },
     });
     // When the agent declares Graph scopes, route the tokenProvider
@@ -5295,7 +5305,7 @@ Return ONLY the YAML manifest. Do not include any commentary, headings, or markd
             return result.accessToken;
           };
     return {
-      createGraph: (log) => createGraphAdapter({ tokenProvider, log }),
+      createGraph: (log) => createGraphAdapter({ tokenProvider, log, signal: execution?.signal }),
       tenantId: tenant.id,
       tenantSession,
     };

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openadminos/desktop",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Open-source, local-first agents for Microsoft 365 admins.",
   "author": {
     "name": "OpenAdminOS",
@@ -32,9 +32,9 @@
     "@azure/msal-node": "^5.3.1",
     "@microsoft/mxc-sdk": "0.6.1",
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "@openadminos/agent-sdk": "0.5.0",
-    "@openadminos/connector-whatsapp-web": "0.5.0",
-    "@openadminos/runtime": "0.5.0",
+    "@openadminos/agent-sdk": "0.5.1",
+    "@openadminos/connector-whatsapp-web": "0.5.1",
+    "@openadminos/runtime": "0.5.1",
     "electron-updater": "^6.6.2",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1854,6 +1854,7 @@ Registry QA is expected to run cleanly for bundled agents. When the upstream Mic
 
 ### Systemic concerns to track
 
+- **Agent execution lifecycle (audit 2026-09-06)**: incremental consent currently lacks the timeout/cancellation controls used by tenant setup, and run cancellation suppresses snapshots without stopping execution. Interrupted-run recovery and scheduled reauthentication also need correction. These are implementation gaps, not intended guarantees; see `docs/agent-run-lifecycle-audit.md` for evidence, affected agents, and acceptance checks.
 - **Trust messaging consistency**: single source of truth across all surfaces (see §3)
 - **Hosted-provider flip UX**: the moment an admin switches from local to hosted is the most important UX moment in the app
 - **Documentation surface**: in-app help, web docs, GitHub issues, Discord: needs a coherent answer before launch

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1854,7 +1854,7 @@ Registry QA is expected to run cleanly for bundled agents. When the upstream Mic
 
 ### Systemic concerns to track
 
-- **Agent execution lifecycle (audit 2026-09-06)**: incremental consent currently lacks the timeout/cancellation controls used by tenant setup, and run cancellation suppresses snapshots without stopping execution. Interrupted-run recovery and scheduled reauthentication also need correction. These are implementation gaps, not intended guarantees; see `docs/agent-run-lifecycle-audit.md` for evidence, affected agents, and acceptance checks.
+- **Agent execution lifecycle (v0.5.1)**: all Microsoft interactive sign-ins have a five-minute deadline. Runs explicitly show when Microsoft sign-in is needed; Cancel stops the wait and prevents subsequent work. The system browser does not report window closure, so closing it requires explicit run cancellation or deadline expiry. Scheduled runs fail with manual sign-in instructions instead of opening a browser. Startup marks interrupted queued/running records failed without replaying writes or discarding pending approvals. Cancellation preserves outcomes for requests already dispatched and never implies their remote effects were reversed. See `docs/agent-run-lifecycle-audit.md` for the original findings and regression coverage.
 - **Trust messaging consistency**: single source of truth across all surfaces (see §3)
 - **Hosted-provider flip UX**: the moment an admin switches from local to hosted is the most important UX moment in the app
 - **Documentation surface**: in-app help, web docs, GitHub issues, Discord: needs a coherent answer before launch

--- a/docs/agent-run-lifecycle-audit.md
+++ b/docs/agent-run-lifecycle-audit.md
@@ -1,0 +1,122 @@
+# Agent sign-in and cancellation audit
+
+Date: 2026-09-06. Scope: the 14 repository registry manifests, their shared
+read/plan/apply lifecycle, system apply, authentication, persistence, and scheduling.
+This is an analysis of the current source, not a shipped fix or a live-tenant test.
+
+## Findings
+
+### P1: Cancel records cancellation but does not stop execution
+
+`apps/desktop/electron/runs.ts:95` saves a cancelled snapshot and adds the run ID
+to a set. The set only suppresses progress persistence (`:823`); it is not checked
+by the execution drivers, Graph calls, LLM calls, or action loops. An approved
+write run can therefore continue changing the tenant while its history says
+cancelled. Suppressed snapshots also hide subsequent outcomes from that history.
+
+Affected: every agent's execution; especially `offboarding-agent` and
+`stale-guest-cleanup`, plus baseline rollback and approved external proposals.
+Typed confirmation is still enforced before apply. This finding concerns stopping
+an already approved execution, not bypassing that approval.
+
+Verified with an isolated RunService harness using a two-action rollback and a
+deferred first mocked Graph request. Cancel was awaited before releasing that
+request. The second request still executed, and the persisted run stayed cancelled.
+No Microsoft request was sent. The template apply loop likewise has no stop check
+(`packages/runtime/src/agent-template.ts:679`).
+
+### P1: Abandoned incremental sign-in can wait indefinitely
+
+`apps/desktop/electron/state.ts:5277` calls `runInteractiveFlow` without a signal
+or timeout. The listener only installs its timer if one is supplied
+(`packages/runtime/src/msal.ts:384`). The browser is launched through
+`shell.openExternal` (`apps/desktop/electron/main.ts:6235`), so the app has no
+window-close callback. Closing the tab/window does not return an OAuth result.
+MSAL continues waiting for the loopback authorization response.
+
+The Graph HTTP timeout does not cover this wait: token acquisition occurs before
+its timer starts (`packages/runtime/src/graph-adapter.ts:272`). The first Graph
+step remains running, matching the supplied Conditional Access screenshot.
+Initial tenant setup already supplies an abort signal and a five-minute timeout
+(`apps/desktop/electron/state.ts:4937`), but agent consent does not reuse them.
+Graph-backed connector setup/delivery call sites also omit these controls.
+
+### P2: Scheduled execution can open an unattended sign-in and block later runs
+
+`fireDueSchedules` uses ordinary `startRun` with a schedule trigger
+(`apps/desktop/electron/state.ts:3755`). That trigger does not change the interactive
+fallback in `buildGraph`. A missing permission or expired session can therefore
+open a browser even for background work. Once stuck, the existing in-flight check
+skips future scheduled runs of that agent (`:3744`).
+
+### P2: Stale running records survive application restarts
+
+The persistence reader restores runs unchanged (`apps/desktop/electron/state.ts:5425`);
+no startup reconciliation of interrupted agent runs was found. Execution workers
+and the cancelled-ID set are process-local. A process exit during a run can leave
+a running record without a worker after relaunch, also blocking its schedule.
+Retention explicitly protects these records (`:2108`). This is a source finding;
+a packaged-app restart was not exercised.
+
+### P2: Confirmation can save running before fallible provider discovery
+
+`confirmRun` writes the running state before awaiting `host.listProviders`
+(`apps/desktop/electron/runs.ts:508`). If discovery rejects, the method exits before
+starting `driveApply`, leaving the saved run running with no worker. Resolve the
+required inputs before committing that transition, or persist a terminal failure.
+
+## Agent coverage
+
+Every entry uses the same incremental-consent path. Exposure depends on whether
+silent token acquisition succeeds for the declared scopes, not on the agent name.
+
+| Agent | Mode | Additional apply concern |
+| --- | --- | --- |
+| compliance-overview | read | None |
+| conditional-access-explainer | read | None |
+| dormant-app-registrations | read | None |
+| find-inactive-devices | read | None |
+| intune-device-posture-auditor | read | None |
+| offboarding-agent | write | Approved device retirements continue after Cancel |
+| os-update-posture | read | None |
+| risky-sign-in-triage | read | None |
+| secure-score-prioritizer | read | None |
+| sign-in-failure-explainer | read | None |
+| stale-guest-cleanup | write | Approved guest actions continue after Cancel |
+| tenant-change-audit | read | None |
+| tenant-health-report | read | None |
+| user-license-overview | read | None |
+
+## Recommended correction and acceptance checks
+
+1. Give each execution a cancellation controller propagated through auth, Graph,
+   LLM, and connector work. Check cancellation before each subsequent action.
+   Keep outcomes for already-dispatched writes, whose remote effects cannot be
+   undone by aborting a local request. Do not swallow cancellation in the
+   template loop's per-action failure handler.
+2. Bound every interactive sign-in wait, using the existing setup timeout as the
+   consistency reference. Show that the run is waiting for Microsoft sign-in and
+   offer cancellation. A system-browser close cannot itself be observed through
+   the current launch API, so a timeout and explicit cancellation are necessary.
+3. Make scheduled authentication failure actionable without opening unattended
+   consent windows. Reconcile interrupted runs once at startup without replaying
+   writes or discarding plans awaiting confirmation.
+4. Check terminal-state protection inside the serialized persistence operation,
+   so a previously queued progress snapshot cannot revive a cancelled run.
+5. Add regression coverage for abandoned sign-in, cancellation during token
+   acquisition, late auth success, cancellation between writes, serialized
+   snapshot races, restart recovery, scheduled reauthentication, and provider
+   discovery failure during confirmation.
+
+## Validation
+
+- Existing sign-in listener, run confirmation, and rollback tests: 15 passed.
+- Registry QA: 168 passed, 0 warnings, 0 failures across all 14 agents.
+- Mocked cancellation reproduction: confirmed a second write after cancellation.
+- Existing green tests do not cover the abandoned agent-consent flow or actual
+  cancellation of ongoing execution. Registry QA validates manifest quality,
+  not these lifecycle guarantees.
+
+Installed custom agents and version-pinned manifests in a user's app data were
+not inspected. The shared-runtime findings also apply to them when they use these
+execution paths. No production behavior was changed as part of this audit.

--- a/docs/agent-run-lifecycle-audit.md
+++ b/docs/agent-run-lifecycle-audit.md
@@ -2,7 +2,8 @@
 
 Date: 2026-09-06. Scope: the 14 repository registry manifests, their shared
 read/plan/apply lifecycle, system apply, authentication, persistence, and scheduling.
-This is an analysis of the current source, not a shipped fix or a live-tenant test.
+The findings below describe the audited source at commit `a5fe348`. The v0.5.1
+corrections are recorded below. Verification uses isolated fixtures, not a live tenant.
 
 ## Findings
 
@@ -119,4 +120,39 @@ silent token acquisition succeeds for the declared scopes, not on the agent name
 
 Installed custom agents and version-pinned manifests in a user's app data were
 not inspected. The shared-runtime findings also apply to them when they use these
-execution paths. No production behavior was changed as part of this audit.
+execution paths. The fixes apply in the shared runtime; individual agent manifests do not need updates.
+
+## v0.5.1 corrections
+
+- Each run phase owns a cancellation signal. Cancellation reaches Microsoft
+  sign-in, token waits, Graph requests, provider calls, and step/action boundaries.
+  Template apply stops on cancellation instead of treating it as a per-item error.
+  Connector confirmations are cancelled and later capability invocations are blocked.
+- Microsoft interactive sign-in has a five-minute deadline covering the complete
+  MSAL wait, including callers that omit a timeout. Late authorization results
+  cannot resume cancelled Graph work. The active pipeline step and logs explain
+  the sign-in wait and the Cancel run recovery action.
+- Scheduled runs refuse interactive consent and return instructions to run the
+  agent manually to restore permissions. Startup marks abandoned queued/running
+  records failed, preserves evidence and pending approvals, and never replays writes.
+- Confirmation resolves provider information before persisting its running state.
+- Cancelled state is protected inside serialized persistence. Completed or failed
+  outcomes from already-dispatched actions remain visible without reviving the run.
+
+System-browser closure still cannot be observed through `shell.openExternal`.
+Closing the browser therefore leaves the explicit sign-in wait until the user
+selects Cancel run or the deadline expires. In-flight remote writes may already
+have taken effect when cancellation arrives; cancellation stops subsequent work
+and does not claim to roll those effects back. External connector operations
+already dispatched can finish; their audit outcome remains recorded.
+
+Regression coverage includes default auth timeout, late successful auth after
+cancellation, cancellation during token acquisition, cancellation between template
+and system writes, LLM signal propagation, a queued-snapshot cancellation race,
+startup recovery, scheduled consent refusal, and provider discovery failure.
+
+Local verification of the fixes: 379 backend tests and 93 renderer tests passed,
+along with typecheck, build, 168 registry QA checks, generated-document checks,
+and release compatibility checks. Renderer tests on the local Node 26 runtime
+used `NODE_OPTIONS=--no-experimental-webstorage` so jsdom supplies browser storage;
+CI uses Node 22. No live-tenant sign-in or write was performed.

--- a/docs/agent-run-lifecycle-audit.md
+++ b/docs/agent-run-lifecycle-audit.md
@@ -132,7 +132,8 @@ execution paths. The fixes apply in the shared runtime; individual agent manifes
   MSAL wait, including callers that omit a timeout. Late authorization results
   cannot resume cancelled Graph work. The active pipeline step and logs explain
   the sign-in wait and the Cancel run recovery action.
-- Scheduled runs refuse interactive consent and return instructions to run the
+- Scheduled runs and their Teams/Outlook notifications refuse interactive consent.
+  Agent execution returns instructions to run the
   agent manually to restore permissions. Startup marks abandoned queued/running
   records failed, preserves evidence and pending approvals, and never replays writes.
 - Confirmation resolves provider information before persisting its running state.
@@ -151,7 +152,7 @@ cancellation, cancellation during token acquisition, cancellation between templa
 and system writes, LLM signal propagation, a queued-snapshot cancellation race,
 startup recovery, scheduled consent refusal, and provider discovery failure.
 
-Local verification of the fixes: 379 backend tests and 93 renderer tests passed,
+Local verification of the fixes: 380 backend tests and 93 renderer tests passed,
 along with typecheck, build, 168 registry QA checks, generated-document checks,
 and release compatibility checks. Renderer tests on the local Node 26 runtime
 used `NODE_OPTIONS=--no-experimental-webstorage` so jsdom supplies browser storage;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openadminos",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openadminos",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -55,15 +55,15 @@
     },
     "apps/desktop": {
       "name": "@openadminos/desktop",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^5.3.1",
         "@microsoft/mxc-sdk": "0.6.1",
         "@modelcontextprotocol/sdk": "^1.30.0",
-        "@openadminos/agent-sdk": "0.5.0",
-        "@openadminos/connector-whatsapp-web": "0.5.0",
-        "@openadminos/runtime": "0.5.0",
+        "@openadminos/agent-sdk": "0.5.1",
+        "@openadminos/connector-whatsapp-web": "0.5.1",
+        "@openadminos/runtime": "0.5.1",
         "electron-updater": "^6.6.2",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -9785,13 +9785,13 @@
     },
     "packages/agent-sdk": {
       "name": "@openadminos/agent-sdk",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     "packages/connector-discord": {
       "name": "@openadminos/connector-discord",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.0"
+        "@openadminos/agent-sdk": "0.5.1"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -9804,9 +9804,9 @@
     },
     "packages/connector-outlook": {
       "name": "@openadminos/connector-outlook",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.0"
+        "@openadminos/agent-sdk": "0.5.1"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -9819,9 +9819,9 @@
     },
     "packages/connector-signal": {
       "name": "@openadminos/connector-signal",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.0"
+        "@openadminos/agent-sdk": "0.5.1"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -9834,9 +9834,9 @@
     },
     "packages/connector-slack": {
       "name": "@openadminos/connector-slack",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.0"
+        "@openadminos/agent-sdk": "0.5.1"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -9849,9 +9849,9 @@
     },
     "packages/connector-teams": {
       "name": "@openadminos/connector-teams",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.0"
+        "@openadminos/agent-sdk": "0.5.1"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -9864,9 +9864,9 @@
     },
     "packages/connector-whatsapp-web": {
       "name": "@openadminos/connector-whatsapp-web",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.0",
+        "@openadminos/agent-sdk": "0.5.1",
         "baileys": "7.0.0-rc13",
         "pino": "^10.1.0",
         "qrcode": "^1.5.4"
@@ -9882,9 +9882,9 @@
     },
     "packages/qa-graph": {
       "name": "@openadminos/qa-graph",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.0",
+        "@openadminos/agent-sdk": "0.5.1",
         "ajv": "^8.17.1",
         "js-yaml": "^4.1.1"
       },
@@ -9900,16 +9900,16 @@
     },
     "packages/runtime": {
       "name": "@openadminos/runtime",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@azure/msal-node": "^5.2.1",
-        "@openadminos/agent-sdk": "0.5.0",
-        "@openadminos/connector-discord": "0.5.0",
-        "@openadminos/connector-outlook": "0.5.0",
-        "@openadminos/connector-signal": "0.5.0",
-        "@openadminos/connector-slack": "0.5.0",
-        "@openadminos/connector-teams": "0.5.0",
-        "@openadminos/connector-whatsapp-web": "0.5.0",
+        "@openadminos/agent-sdk": "0.5.1",
+        "@openadminos/connector-discord": "0.5.1",
+        "@openadminos/connector-outlook": "0.5.1",
+        "@openadminos/connector-signal": "0.5.1",
+        "@openadminos/connector-slack": "0.5.1",
+        "@openadminos/connector-teams": "0.5.1",
+        "@openadminos/connector-whatsapp-web": "0.5.1",
         "js-yaml": "^4.1.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openadminos",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/agent-sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "description": "Shared TypeScript contracts for OpenAdminOS packages.",
   "main": "./dist/index.js",

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -3251,6 +3251,8 @@ export interface RunContextOptions {
 }
 
 export interface RunContext {
+  /** Host cancellation. Check before starting additional work. */
+  signal?: AbortSignal;
   agent: AgentDefinition;
   providerId: ProviderId;
   model?: string;

--- a/packages/connector-discord/package.json
+++ b/packages/connector-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-discord",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "description": "Discord connector for OpenAdminOS. Sends outbound notification messages through a Discord channel webhook.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.0"
+    "@openadminos/agent-sdk": "0.5.1"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-outlook/package.json
+++ b/packages/connector-outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-outlook",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "description": "Outlook connector for OpenAdminOS. Sends outbound notification email through Microsoft Graph using the active tenant's delegated MSAL token.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.0"
+    "@openadminos/agent-sdk": "0.5.1"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-signal/package.json
+++ b/packages/connector-signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-signal",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "description": "Signal connector for OpenAdminOS. Sends outbound notification messages through signal-cli or a local signal-cli REST bridge.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.0"
+    "@openadminos/agent-sdk": "0.5.1"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-slack/package.json
+++ b/packages/connector-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-slack",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "description": "Slack connector for OpenAdminOS. Sends outbound notification messages through a Slack bot token.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.0"
+    "@openadminos/agent-sdk": "0.5.1"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-teams/package.json
+++ b/packages/connector-teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-teams",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "description": "Microsoft Teams connector for OpenAdminOS. Posts channel and chat messages via Microsoft Graph using the active tenant's delegated MSAL token.",
@@ -24,7 +24,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.0"
+    "@openadminos/agent-sdk": "0.5.1"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-whatsapp-web/package.json
+++ b/packages/connector-whatsapp-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-whatsapp-web",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "description": "WhatsApp Web connector for OpenAdminOS. Sends outbound notification messages through a locally linked WhatsApp Web session.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.0",
+    "@openadminos/agent-sdk": "0.5.1",
     "baileys": "7.0.0-rc13",
     "pino": "^10.1.0",
     "qrcode": "^1.5.4"

--- a/packages/qa-graph/package.json
+++ b/packages/qa-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/qa-graph",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -14,7 +14,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.0",
+    "@openadminos/agent-sdk": "0.5.1",
     "ajv": "^8.17.1",
     "js-yaml": "^4.1.1"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/runtime",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -21,13 +21,13 @@
   },
   "dependencies": {
     "@azure/msal-node": "^5.2.1",
-    "@openadminos/agent-sdk": "0.5.0",
-    "@openadminos/connector-discord": "0.5.0",
-    "@openadminos/connector-outlook": "0.5.0",
-    "@openadminos/connector-signal": "0.5.0",
-    "@openadminos/connector-slack": "0.5.0",
-    "@openadminos/connector-teams": "0.5.0",
-    "@openadminos/connector-whatsapp-web": "0.5.0",
+    "@openadminos/agent-sdk": "0.5.1",
+    "@openadminos/connector-discord": "0.5.1",
+    "@openadminos/connector-outlook": "0.5.1",
+    "@openadminos/connector-signal": "0.5.1",
+    "@openadminos/connector-slack": "0.5.1",
+    "@openadminos/connector-teams": "0.5.1",
+    "@openadminos/connector-whatsapp-web": "0.5.1",
     "js-yaml": "^4.1.1"
   },
   "optionalDependencies": {

--- a/packages/runtime/src/agent-template.ts
+++ b/packages/runtime/src/agent-template.ts
@@ -677,6 +677,7 @@ export async function runAgentTemplateApply(
   }
 
   for (const action of plan.actions) {
+    ctx.signal?.throwIfAborted();
     const handler = ACTION_HANDLERS[action.kind];
     if (!handler) {
       failed.push({
@@ -701,6 +702,7 @@ export async function runAgentTemplateApply(
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      ctx.signal?.throwIfAborted();
       failed.push({ id: action.id, name: action.label, error: message });
       ctx.log("error", `Failed action "${action.label}": ${message}`);
     }

--- a/packages/runtime/src/cancellation.ts
+++ b/packages/runtime/src/cancellation.ts
@@ -1,0 +1,10 @@
+/** Stop waiting promptly without allowing a late result to resume the caller. */
+export function awaitWithSignal<T>(work: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return work;
+  return new Promise<T>((resolve, reject) => {
+    const abort = () => reject(signal.reason ?? new Error("Run cancelled by user."));
+    signal.addEventListener("abort", abort, { once: true });
+    if (signal.aborted) abort();
+    work.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
+  });
+}

--- a/packages/runtime/src/connectors.ts
+++ b/packages/runtime/src/connectors.ts
@@ -276,6 +276,7 @@ export interface ConnectorInvocationInfo {
 }
 
 export interface WrapConnectorOptions {
+  signal?: AbortSignal;
   runId: string;
   /**
    * Current step id at the moment the capability fires. The wrapper
@@ -352,6 +353,7 @@ interface InvokeCapabilityInput {
 }
 
 async function invokeCapability(input: InvokeCapabilityInput): Promise<unknown> {
+  input.options.signal?.throwIfAborted();
   if (!input.capabilityDescriptor) {
     throw new ConnectorValidationError(
       `Connector '${input.connectorId}' exposed method '${input.methodName}' without a matching capability descriptor. Invocation was blocked.`,
@@ -414,6 +416,7 @@ async function invokeCapability(input: InvokeCapabilityInput): Promise<unknown> 
 
   const started = Date.now();
   try {
+    input.options.signal?.throwIfAborted();
     const result = await input.method(...args);
     const { externalId, externalUrl } = extractExternalRefs(result);
     emitAudit(input.options, {

--- a/packages/runtime/src/graph-adapter.test.ts
+++ b/packages/runtime/src/graph-adapter.test.ts
@@ -395,3 +395,22 @@ describe("createGraphAdapter transient network faults", () => {
     assert.equal(calls.length, 0);
   });
 });
+
+describe("cancellation while acquiring a Graph token", () => {
+  it("rejects promptly and never dispatches a late token after cancellation", async () => {
+    const controller = new AbortController();
+    let finish!: (token: string) => void;
+    let fetchCount = 0;
+    const graph = createGraphAdapter({
+      signal: controller.signal,
+      tokenProvider: () => new Promise<string>((resolve) => { finish = resolve; }),
+      fetchImpl: async () => { fetchCount += 1; return new Response("{}"); },
+    });
+    const request = graph.request({ method: "PATCH", path: "/users/test", body: { accountEnabled: false } });
+    controller.abort(new Error("Cancelled test"));
+    await assert.rejects(request, /Cancelled test/);
+    finish("late-token");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(fetchCount, 0);
+  });
+});

--- a/packages/runtime/src/graph-adapter.ts
+++ b/packages/runtime/src/graph-adapter.ts
@@ -1,3 +1,4 @@
+import { awaitWithSignal } from "./cancellation.js";
 import type {
   GraphRequestInput as SdkGraphRequestInput,
   ManagedDeviceRecord,
@@ -18,6 +19,7 @@ export type GraphAdapterLogger = (
 ) => void;
 
 export interface GraphAdapterOptions {
+  signal?: AbortSignal;
   tokenProvider: () => Promise<string>;
   baseUrl?: string;
   fetchImpl?: typeof fetch;
@@ -106,6 +108,7 @@ export function createGraphAdapter(options: GraphAdapterOptions): RunGraphApi {
           method: "GET",
           url: nextLink,
           tokenProvider: options.tokenProvider,
+          signal: options.signal,
           fetchImpl,
           maxRetries,
           retryBackoffMs,
@@ -134,6 +137,7 @@ export function createGraphAdapter(options: GraphAdapterOptions): RunGraphApi {
         method: "POST",
         url,
         tokenProvider: options.tokenProvider,
+        signal: options.signal,
         fetchImpl,
         maxRetries,
         retryBackoffMs,
@@ -178,6 +182,7 @@ export function createGraphAdapter(options: GraphAdapterOptions): RunGraphApi {
         method,
         url,
         tokenProvider: options.tokenProvider,
+        signal: options.signal,
         fetchImpl,
         maxRetries,
         retryBackoffMs,
@@ -188,7 +193,7 @@ export function createGraphAdapter(options: GraphAdapterOptions): RunGraphApi {
         idempotent: method === "GET" || method === "PUT" || method === "DELETE",
         baseUrl,
         log: options.log,
-        ...(input.signal ? { signal: input.signal } : {}),
+        ...(input.signal ? { signal: options.signal ? AbortSignal.any([options.signal, input.signal]) : input.signal } : {}),
       });
     },
   };
@@ -269,7 +274,8 @@ async function graphRequest<T>(input: GraphRequestInput): Promise<T> {
     if (input.signal?.aborted) {
       throw new Error(GRAPH_REQUEST_CANCELLED);
     }
-    const token = await input.tokenProvider();
+    const token = await awaitWithSignal(input.tokenProvider(), input.signal);
+    if (input.signal?.aborted) throw new Error(GRAPH_REQUEST_CANCELLED);
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), input.timeoutMs);
     // Caller cancellation aborts the same controller the timeout uses;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -338,6 +338,7 @@ export type CreateGraphAdapter = (
 ) => RunGraphApi;
 
 export interface ExecuteRunInput {
+  signal?: AbortSignal;
   run: RunRecord;
   agent: AgentSummary;
   providerId: ProviderId;
@@ -406,6 +407,7 @@ async function createPhaseHandle(
   initialOverrides: Partial<RunRecord>,
   startupLog: string,
 ): Promise<PhaseHandle> {
+  input.signal?.throwIfAborted();
   const startedAt = new Date().toISOString();
   let working: RunRecord = {
     ...input.run,
@@ -447,7 +449,7 @@ async function createPhaseHandle(
       working = { ...working, tokens: mergeTokenUsage(working.tokens, usage) };
       void input.onProgress(working);
     },
-  });
+  }, input.signal);
 
   const logFn = (
     level: RunLogLevel,
@@ -490,6 +492,7 @@ async function createPhaseHandle(
     for (const entry of preflight.built) {
       wrappedAccessor[entry.id] = wrapConnector(entry.id, entry.instance, {
         runId: input.run.id,
+        signal: input.signal,
         currentStepId: () => currentStepId,
         ...(input.confirmCapability
           ? { confirmInvocation: input.confirmCapability }
@@ -512,6 +515,7 @@ async function createPhaseHandle(
   const graph = input.createGraph(logFn);
 
   const ctx: RunContext = {
+    signal: input.signal,
     agent: toAgentDefinition(input.agent),
     providerId: input.providerId,
     model: input.model,
@@ -525,6 +529,7 @@ async function createPhaseHandle(
       void input.onProgress(working);
     },
     step: async (label, detail, fn) => {
+      input.signal?.throwIfAborted();
       const stepId = `step_${working.steps.length + 1}_${Math.random()
         .toString(36)
         .slice(2, 8)}`;
@@ -549,6 +554,7 @@ async function createPhaseHandle(
       await input.onProgress(working);
 
       try {
+        input.signal?.throwIfAborted();
         const value = await fn();
         const stepFinishedAt = new Date().toISOString();
         working = {
@@ -628,7 +634,7 @@ export function mergeTokenUsage(
   return merged;
 }
 
-function wrapLlmWithThinking(base: RunLlmApi, hooks: ThinkingHooks): RunLlmApi {
+function wrapLlmWithThinking(base: RunLlmApi, hooks: ThinkingHooks, signal?: AbortSignal): RunLlmApi {
   const guardAvailable = () => {
     if (!base.available) {
       throw new Error(
@@ -657,6 +663,8 @@ function wrapLlmWithThinking(base: RunLlmApi, hooks: ThinkingHooks): RunLlmApi {
     },
     async *stream(options) {
       guardAvailable();
+      signal?.throwIfAborted();
+      options = { ...options, signal: signal && options.signal ? AbortSignal.any([signal, options.signal]) : signal ?? options.signal };
       const stepId = hooks.getCurrentStepId();
       const reset = () => {
         if (stepId) {
@@ -666,6 +674,7 @@ function wrapLlmWithThinking(base: RunLlmApi, hooks: ThinkingHooks): RunLlmApi {
 
       try {
         for await (const chunk of base.stream(options)) {
+          signal?.throwIfAborted();
           if (stepId) {
             hooks.updateStepThinking(stepId, () => ({
               text: chunk.accumulated,

--- a/packages/runtime/src/msal.test.ts
+++ b/packages/runtime/src/msal.test.ts
@@ -61,11 +61,12 @@ describe("interactive tenant sign-in listener", () => {
       acquireTokenInteractive: async (request: InteractiveRequest) => {
         const authorization = request.loopbackClient!.listenForAuthCode();
         let redirectUri: string | undefined;
-        for (let attempt = 0; attempt < 20 && !redirectUri; attempt += 1) {
+        const readyDeadline = Date.now() + 2_000;
+        while (!redirectUri && Date.now() < readyDeadline) {
           try {
             redirectUri = request.loopbackClient!.getRedirectUri();
           } catch {
-            await new Promise((resolve) => setTimeout(resolve, 1));
+            await new Promise((resolve) => setTimeout(resolve, 5));
           }
         }
         assert.ok(redirectUri);
@@ -85,5 +86,26 @@ describe("interactive tenant sign-in listener", () => {
       openBrowser: async () => undefined,
     });
     assert.equal(result.accessToken, "test-token");
+  });
+});
+
+describe("incremental sign-in lifecycle", () => {
+  it("uses a five-minute default even when the agent does not supply a timeout", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const client = { acquireTokenInteractive: () => new Promise(() => {}) } as unknown as PublicClientApplication;
+    const result = runInteractiveFlow({ client, openBrowser: async () => undefined });
+    const rejected = assert.rejects(result, TenantConnectTimeoutError);
+    t.mock.timers.tick(300_001);
+    await rejected;
+  });
+
+  it("cancels the complete MSAL wait and ignores a late successful result", async () => {
+    const controller = new AbortController();
+    let finish!: (result: AuthenticationResult) => void;
+    const client = { acquireTokenInteractive: () => new Promise<AuthenticationResult>((resolve) => { finish = resolve; }) } as unknown as PublicClientApplication;
+    const result = runInteractiveFlow({ client, signal: controller.signal, openBrowser: async () => undefined });
+    controller.abort();
+    await assert.rejects(result, TenantConnectCancelledError);
+    finish({ accessToken: "late-token" } as AuthenticationResult);
   });
 });

--- a/packages/runtime/src/msal.ts
+++ b/packages/runtime/src/msal.ts
@@ -1,3 +1,4 @@
+import { awaitWithSignal } from "./cancellation.js";
 import {
   AuthError,
   type AuthorizeResponse,
@@ -307,7 +308,7 @@ export class TenantConnectCancelledError extends Error {
 
 export class TenantConnectTimeoutError extends Error {
   constructor() {
-    super("Tenant sign-in timed out while waiting for Microsoft.");
+    super("Microsoft sign-in timed out. Run the agent again and complete sign-in, or reconnect the tenant in Settings.");
     this.name = "TenantConnectTimeoutError";
   }
 }
@@ -413,7 +414,9 @@ class AbortableLoopbackClient implements ILoopbackClient {
   closeServer(): void {
     this.cleanupWaiters();
     if (!this.server) return;
-    if (this.server.listening) this.server.close();
+    const server = this.server;
+    if (server.listening) server.close();
+    else server.once("listening", () => server.close());
     this.server.closeAllConnections?.();
     this.server.unref();
     this.server = undefined;
@@ -439,24 +442,37 @@ class AbortableLoopbackClient implements ILoopbackClient {
 export async function runInteractiveFlow(
   input: InteractiveFlowInput,
 ): Promise<AuthenticationResult> {
-  const scopes = input.scopes ?? DEFAULT_SCOPES;
-
+  if (input.signal?.aborted) throw new TenantConnectCancelledError();
+  const deadline = new AbortController();
+  const timeoutMs = input.timeoutMs && input.timeoutMs > 0 ? input.timeoutMs : 300_000;
+  const timer = setTimeout(() => deadline.abort(new TenantConnectTimeoutError()), timeoutMs);
+  timer.unref?.();
+  const signal = input.signal ? AbortSignal.any([input.signal, deadline.signal]) : deadline.signal;
+  const loopbackClient = new AbortableLoopbackClient(signal);
   const request: InteractiveRequest = {
-    scopes,
-    openBrowser: input.openBrowser,
+    scopes: input.scopes ?? DEFAULT_SCOPES,
+    openBrowser: async (url) => {
+      signal.throwIfAborted();
+      await input.openBrowser(url);
+    },
     successTemplate: SUCCESS_TEMPLATE,
     errorTemplate: ERROR_TEMPLATE,
-    loopbackClient: new AbortableLoopbackClient(input.signal, input.timeoutMs),
+    loopbackClient,
   };
-  if (input.redirectUri) {
-    request.redirectUri = input.redirectUri;
+  if (input.redirectUri) request.redirectUri = input.redirectUri;
+  try {
+    const result = await awaitWithSignal(input.client.acquireTokenInteractive(request), signal);
+    signal.throwIfAborted();
+    if (!result) throw new Error("MSAL returned no authentication result.");
+    return result;
+  } catch (error) {
+    if (input.signal?.aborted) throw new TenantConnectCancelledError();
+    if (deadline.signal.aborted) throw new TenantConnectTimeoutError();
+    throw error;
+  } finally {
+    clearTimeout(timer);
+    loopbackClient.closeServer();
   }
-
-  const result = await input.client.acquireTokenInteractive(request);
-  if (!result) {
-    throw new Error("MSAL returned no authentication result.");
-  }
-  return result;
 }
 
 export async function acquireTokenSilent(input: {

--- a/packages/runtime/src/write-plan.test.ts
+++ b/packages/runtime/src/write-plan.test.ts
@@ -995,3 +995,47 @@ async function brokerWritePlan(params: unknown) {
     params: params as WritePlan,
   });
 }
+
+describe("template execution cancellation", () => {
+  it("stops the apply loop after cancellation instead of treating it as an individual failure", async () => {
+    const fixture = makeWriteAgentFixture({ devices: [
+      managedDevice("device-1", "Laptop 1", "S1"), managedDevice("device-2", "Laptop 2", "S2"),
+    ] });
+    try {
+      const input = { agent: fixture.agent, providerId: "ollama" as const, llm: fixture.llm,
+        createGraph: () => fixture.graph, onProgress() {} };
+      const planned = await executePlan({ ...input, run: createQueuedRun({ agent: fixture.agent, providerId: "ollama" }) });
+      assert.ok(planned.plan);
+      const controller = new AbortController();
+      let calls = 0;
+      fixture.graph.retireManagedDevice = async () => {
+        calls += 1; controller.abort(new Error("Cancelled during first action"));
+        throw new Error("Request interrupted");
+      };
+      const stopped = await executeApply({ ...input, run: planned, plan: planned.plan, realWrites: true, signal: controller.signal });
+      assert.equal(calls, 1);
+      assert.equal(stopped.status, "failed"); // The host retains the user-cancelled terminal state.
+      assert.match(stopped.error ?? "", /Cancelled during first action/);
+    } finally { fixture.cleanup(); }
+  });
+
+  it("passes cancellation into LLM streaming during planning", async () => {
+    const fixture = makeWriteAgentFixture({ devices: [] });
+    const controller = new AbortController();
+    let received: AbortSignal | undefined;
+    fixture.llm.stream = async function* (options) {
+      received = options.signal;
+      controller.abort(new Error("Cancelled LLM"));
+      options.signal?.throwIfAborted();
+      yield { delta: "", accumulated: "", done: true, model: "test" };
+    };
+    try {
+      const run = await executePlan({ agent: fixture.agent, providerId: "ollama", llm: fixture.llm,
+        createGraph: () => fixture.graph, signal: controller.signal,
+        run: createQueuedRun({ agent: fixture.agent, providerId: "ollama" }), onProgress() {} });
+      assert.equal(received, controller.signal);
+      assert.equal(run.status, "failed");
+      assert.match(run.error ?? "", /Cancelled LLM/);
+    } finally { fixture.cleanup(); }
+  });
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openadminos-website",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openadminos-website",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@octokit/rest": "^21.1.1",
         "@t3-oss/env-nextjs": "^0.13.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openadminos-website",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Agent permission requests could wait indefinitely after the Microsoft sign-in browser was closed. Cancel run only changed stored status, so an approved write run could continue executing later actions while appearing cancelled.

This prepares v0.5.1 with shared lifecycle fixes across all 14 registry agents and the rollback/external-proposal apply paths:

- Bound the complete Microsoft interactive sign-in wait to five minutes, show sign-in instructions in the active step, and propagate cancellation through authentication, token waits, Graph calls, LLM calls, and execution boundaries.
- Stop subsequent template/system write actions after cancellation. Preserve outcomes for requests already dispatched without allowing stale snapshots to revive the run.
- Cancel pending connector confirmations and block later capability invocations.
- Refuse interactive authentication for scheduled runs and their Teams/Outlook notifications with actionable recovery instructions.
- Recover interrupted queued/running records at startup without replaying writes or removing pending approvals.
- Resolve provider information before transitioning a confirmed agent plan to running.
- Include the original audit, regression evidence, v0.5.1 version metadata, and user-facing release notes.

The system browser does not report closure through shell.openExternal. Closing it therefore leaves the explicit sign-in wait until Cancel run or timeout. Cancellation cannot undo remote writes already sent, and an external connector operation already dispatched can finish; its outcome remains recorded.

Validation:
- 380 backend tests and 93 renderer tests passed locally, including new lifecycle regressions.
- Typecheck, build, all 168 Graph QA checks, generated documentation, and release compatibility checks passed.
- Local Node 26 renderer tests used NODE_OPTIONS=--no-experimental-webstorage to let jsdom provide browser storage. CI uses Node 22.
- No live tenant sign-in or write was performed.

This PR is for review. No merge, tag, or GitHub Release has been created.
