### PR TITLE
release: v0.5.2 macOS signing correction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -453,6 +453,9 @@ jobs:
           echo "::error::macOS PKG publishing requires CSC_INSTALLER_LINK and CSC_INSTALLER_KEY_PASSWORD for a Developer ID Installer certificate."
           exit 1
 
+      - name: Correct electron-builder macOS keychain password handling
+        run: node scripts/patch-macos-signing.mjs
+
       - name: Build .dmg + .pkg + .zip (signed + notarized when secrets present)
         # Arch is declared in package.json build.mac.target, so we only
         # pass --mac on the CLI; passing --arm64 here would be redundant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ All notable changes to OpenAdminOS are recorded here. Format follows [Keep a Cha
 
 ### Fixed
 
+### Security
+
+## [0.5.2] - 2026-09-06
+
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+
+- macOS release packaging now uses the generated temporary-keychain password when configuring signing-key access, while retaining each certificate's own import password. This corrects the electron-builder 26.15.3 signing failure without disabling signing, notarization, or artifact verification.
+- Includes the agent lifecycle fixes prepared for 0.5.1: five-minute Microsoft sign-in deadlines, explicit sign-in recovery instructions, execution cancellation that stops later approved actions, scheduled-run and notification authentication safeguards, and recovery of interrupted runs without replaying writes.
+
+### Upgrade notes
+
+- Version 0.5.1 was tagged but not published because macOS signing failed. Version 0.5.2 is the distributable update containing those fixes. The 0.5.1 tag is preserved unchanged.
+- Closing the system browser still requires Cancel run or the sign-in timeout. Requests already sent to Microsoft may have completed; cancellation does not undo those effects.
+
+### Fixed automation
+
 - Release automation explicitly dispatches the version tag, preventing a same-named development branch from being selected instead.
 
 ### Security

--- a/apps/desktop/electron/macos-signing-patch.test.ts
+++ b/apps/desktop/electron/macos-signing-patch.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { runInNewContext } from "node:vm";
+import { it } from "node:test";
+
+it("uses separate keychain and certificate passwords for both macOS signing certificates", async () => {
+  // Load the build-time helper without importing its CLI side effect.
+  const script = readFileSync(new URL("../../../scripts/patch-macos-signing.mjs", import.meta.url), "utf8");
+  const definition = script.slice(script.indexOf("export function patchMacSigning"), script.indexOf("\nif (process.argv[1]"))
+    .replace("export function", "function");
+  const patch = runInNewContext(`${definition}\npatchMacSigning`) as (source: string) => string;
+  const require = createRequire(import.meta.url);
+  const source = readFileSync(require.resolve("app-builder-lib/out/codeSign/macCodeSign.js"), "utf8");
+  const patched = patch(source);
+  assert.equal(patch(patched), patched);
+  assert.throws(() => patch("unexpected source"), /Unrecognized/);
+  const calls: string[][] = [];
+  const functions = patched.slice(patched.indexOf("async function createKeychain("), patched.indexOf("async function sign("));
+  const createKeychain = runInNewContext(`${functions}\ncreateKeychain`, {
+    process: { env: { TRAVIS: "true" } },
+    path: { join: (...parts: string[]) => parts.join("/") },
+    os_1: { tmpdir: () => "/test" },
+    crypto_1: { createHash: () => ({ update() { return this; }, digest: () => "temporary" }), randomBytes: () => ({ toString: () => "keychain-password" }) },
+    removeKeychain: async () => undefined,
+    listUserKeychains: async () => [],
+    codesign_1: { importCertificate: async (link: string) => link },
+    builder_util_1: { exec: async (_command: string, args: string[]) => { calls.push(args); } },
+  });
+  await createKeychain({ tmpDir: {}, currentDir: "/project", cscLink: "app.p12", cscKeyPassword: "app-password",
+    cscILink: "installer.p12", cscIKeyPassword: "installer-password" });
+  assert.equal(calls.find((args) => args[0] === "create-keychain")?.[2], "keychain-password");
+  assert.deepEqual(calls.filter((args) => args[0] === "import").map((args) => args[args.indexOf("-P") + 1]), ["app-password", "installer-password"]);
+  assert.deepEqual(calls.filter((args) => args[0] === "set-key-partition-list").map((args) => args[args.indexOf("-k") + 1]), ["keychain-password", "keychain-password"]);
+});

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openadminos/desktop",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Open-source, local-first agents for Microsoft 365 admins.",
   "author": {
     "name": "OpenAdminOS",
@@ -32,9 +32,9 @@
     "@azure/msal-node": "^5.3.1",
     "@microsoft/mxc-sdk": "0.6.1",
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "@openadminos/agent-sdk": "0.5.1",
-    "@openadminos/connector-whatsapp-web": "0.5.1",
-    "@openadminos/runtime": "0.5.1",
+    "@openadminos/agent-sdk": "0.5.2",
+    "@openadminos/connector-whatsapp-web": "0.5.2",
+    "@openadminos/runtime": "0.5.2",
     "electron-updater": "^6.6.2",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1423,6 +1423,14 @@ Electron window.
 
 ### Code signing
 
+The macOS release job applies a fail-closed workaround for app-builder-lib
+26.15.3 before packaging. The dependency creates a random-password temporary
+keychain but supplies certificate passwords to `set-key-partition-list`;
+`scripts/patch-macos-signing.mjs` threads the keychain password separately while
+preserving certificate import passwords. The helper rejects unknown versions or
+source shapes. Remove it only after verifying an upstream correction. Signing,
+notarization, and packaged-signature verification remain mandatory.
+
 Release workflow dispatch must use the fully qualified `refs/tags/vX.Y.Z` ref.
 A branch may have the same version name; an unqualified dispatch can select
 that branch and skip tag-only signing/publication. Verify the workflow head

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openadminos",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openadminos",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -55,15 +55,15 @@
     },
     "apps/desktop": {
       "name": "@openadminos/desktop",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^5.3.1",
         "@microsoft/mxc-sdk": "0.6.1",
         "@modelcontextprotocol/sdk": "^1.30.0",
-        "@openadminos/agent-sdk": "0.5.1",
-        "@openadminos/connector-whatsapp-web": "0.5.1",
-        "@openadminos/runtime": "0.5.1",
+        "@openadminos/agent-sdk": "0.5.2",
+        "@openadminos/connector-whatsapp-web": "0.5.2",
+        "@openadminos/runtime": "0.5.2",
         "electron-updater": "^6.6.2",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -9785,13 +9785,13 @@
     },
     "packages/agent-sdk": {
       "name": "@openadminos/agent-sdk",
-      "version": "0.5.1"
+      "version": "0.5.2"
     },
     "packages/connector-discord": {
       "name": "@openadminos/connector-discord",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.1"
+        "@openadminos/agent-sdk": "0.5.2"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -9804,9 +9804,9 @@
     },
     "packages/connector-outlook": {
       "name": "@openadminos/connector-outlook",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.1"
+        "@openadminos/agent-sdk": "0.5.2"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -9819,9 +9819,9 @@
     },
     "packages/connector-signal": {
       "name": "@openadminos/connector-signal",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.1"
+        "@openadminos/agent-sdk": "0.5.2"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -9834,9 +9834,9 @@
     },
     "packages/connector-slack": {
       "name": "@openadminos/connector-slack",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.1"
+        "@openadminos/agent-sdk": "0.5.2"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -9849,9 +9849,9 @@
     },
     "packages/connector-teams": {
       "name": "@openadminos/connector-teams",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.1"
+        "@openadminos/agent-sdk": "0.5.2"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -9864,9 +9864,9 @@
     },
     "packages/connector-whatsapp-web": {
       "name": "@openadminos/connector-whatsapp-web",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.1",
+        "@openadminos/agent-sdk": "0.5.2",
         "baileys": "7.0.0-rc13",
         "pino": "^10.1.0",
         "qrcode": "^1.5.4"
@@ -9882,9 +9882,9 @@
     },
     "packages/qa-graph": {
       "name": "@openadminos/qa-graph",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.1",
+        "@openadminos/agent-sdk": "0.5.2",
         "ajv": "^8.17.1",
         "js-yaml": "^4.1.1"
       },
@@ -9900,16 +9900,16 @@
     },
     "packages/runtime": {
       "name": "@openadminos/runtime",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@azure/msal-node": "^5.2.1",
-        "@openadminos/agent-sdk": "0.5.1",
-        "@openadminos/connector-discord": "0.5.1",
-        "@openadminos/connector-outlook": "0.5.1",
-        "@openadminos/connector-signal": "0.5.1",
-        "@openadminos/connector-slack": "0.5.1",
-        "@openadminos/connector-teams": "0.5.1",
-        "@openadminos/connector-whatsapp-web": "0.5.1",
+        "@openadminos/agent-sdk": "0.5.2",
+        "@openadminos/connector-discord": "0.5.2",
+        "@openadminos/connector-outlook": "0.5.2",
+        "@openadminos/connector-signal": "0.5.2",
+        "@openadminos/connector-slack": "0.5.2",
+        "@openadminos/connector-teams": "0.5.2",
+        "@openadminos/connector-whatsapp-web": "0.5.2",
         "js-yaml": "^4.1.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openadminos",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/agent-sdk",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "description": "Shared TypeScript contracts for OpenAdminOS packages.",
   "main": "./dist/index.js",

--- a/packages/connector-discord/package.json
+++ b/packages/connector-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-discord",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "description": "Discord connector for OpenAdminOS. Sends outbound notification messages through a Discord channel webhook.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.1"
+    "@openadminos/agent-sdk": "0.5.2"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-outlook/package.json
+++ b/packages/connector-outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-outlook",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "description": "Outlook connector for OpenAdminOS. Sends outbound notification email through Microsoft Graph using the active tenant's delegated MSAL token.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.1"
+    "@openadminos/agent-sdk": "0.5.2"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-signal/package.json
+++ b/packages/connector-signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-signal",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "description": "Signal connector for OpenAdminOS. Sends outbound notification messages through signal-cli or a local signal-cli REST bridge.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.1"
+    "@openadminos/agent-sdk": "0.5.2"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-slack/package.json
+++ b/packages/connector-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-slack",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "description": "Slack connector for OpenAdminOS. Sends outbound notification messages through a Slack bot token.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.1"
+    "@openadminos/agent-sdk": "0.5.2"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-teams/package.json
+++ b/packages/connector-teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-teams",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "description": "Microsoft Teams connector for OpenAdminOS. Posts channel and chat messages via Microsoft Graph using the active tenant's delegated MSAL token.",
@@ -24,7 +24,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.1"
+    "@openadminos/agent-sdk": "0.5.2"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-whatsapp-web/package.json
+++ b/packages/connector-whatsapp-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-whatsapp-web",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "description": "WhatsApp Web connector for OpenAdminOS. Sends outbound notification messages through a locally linked WhatsApp Web session.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.1",
+    "@openadminos/agent-sdk": "0.5.2",
     "baileys": "7.0.0-rc13",
     "pino": "^10.1.0",
     "qrcode": "^1.5.4"

--- a/packages/qa-graph/package.json
+++ b/packages/qa-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/qa-graph",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -14,7 +14,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.1",
+    "@openadminos/agent-sdk": "0.5.2",
     "ajv": "^8.17.1",
     "js-yaml": "^4.1.1"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/runtime",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -21,13 +21,13 @@
   },
   "dependencies": {
     "@azure/msal-node": "^5.2.1",
-    "@openadminos/agent-sdk": "0.5.1",
-    "@openadminos/connector-discord": "0.5.1",
-    "@openadminos/connector-outlook": "0.5.1",
-    "@openadminos/connector-signal": "0.5.1",
-    "@openadminos/connector-slack": "0.5.1",
-    "@openadminos/connector-teams": "0.5.1",
-    "@openadminos/connector-whatsapp-web": "0.5.1",
+    "@openadminos/agent-sdk": "0.5.2",
+    "@openadminos/connector-discord": "0.5.2",
+    "@openadminos/connector-outlook": "0.5.2",
+    "@openadminos/connector-signal": "0.5.2",
+    "@openadminos/connector-slack": "0.5.2",
+    "@openadminos/connector-teams": "0.5.2",
+    "@openadminos/connector-whatsapp-web": "0.5.2",
     "js-yaml": "^4.1.1"
   },
   "optionalDependencies": {

--- a/scripts/patch-macos-signing.mjs
+++ b/scripts/patch-macos-signing.mjs
@@ -1,0 +1,34 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+// app-builder-lib 26.15.3 creates a keychain with a random password, but
+// passes the certificate password to set-key-partition-list. Keep the
+// certificate import password intact and pass the keychain password separately.
+// Fail closed when upgrading the builder so this workaround is reviewed.
+export function patchMacSigning(source) {
+  const replacements = [
+    ["importCerts(keychainFile, certPaths, cscPasswords)", "importCerts(keychainFile, certPaths, cscPasswords, keychainPassword)"],
+    ["async function importCerts(keychainFile, paths, keyPasswords) {", "async function importCerts(keychainFile, paths, keyPasswords, keychainPassword) {"],
+    ['["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", password, keychainFile]', '["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", keychainPassword, keychainFile]'],
+  ];
+  if (replacements.every(([, after]) => source.includes(after))) return source;
+  for (const [before, after] of replacements) {
+    if (source.split(before).length !== 2) {
+      throw new Error("Unrecognized app-builder-lib signing code. Review the macOS signing workaround before building.");
+    }
+    source = source.replace(before, after);
+  }
+  return source;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const require = createRequire(import.meta.url);
+  const version = require("app-builder-lib/package.json").version;
+  if (version !== "26.15.3") throw new Error(`Review the macOS signing workaround for app-builder-lib ${version}.`);
+  const path = require.resolve("app-builder-lib/out/codeSign/macCodeSign.js");
+  const source = readFileSync(path, "utf8");
+  writeFileSync(path, patchMacSigning(source));
+  console.log("Applied macOS signing keychain-password correction for app-builder-lib 26.15.3.");
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openadminos-website",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openadminos-website",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@octokit/rest": "^21.1.1",
         "@t3-oss/env-nextjs": "^0.13.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openadminos-website",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
The v0.5.1 release passed source validation and Windows/Linux packaging, but macOS failed before signing because app-builder-lib 26.15.3 supplies a certificate password to `security set-key-partition-list` instead of the generated temporary-keychain password. Release publication was correctly blocked.

Prepare v0.5.2 with a narrowly guarded build-time correction that passes the keychain password separately while preserving both certificate import passwords. The helper fails closed on unknown builder versions/source shapes and is idempotent. Existing signing, notarization, and artifact checks remain enabled.

The original v0.5.1 tag remains unchanged. This patch release includes its agent lifecycle fixes plus the corrected explicit-tag workflow dispatch already merged in #78.

Validation:
- Regression test executes the installed builder's keychain functions with mocked security commands and distinct application, installer, and keychain passwords.
- Test verifies password separation, repeat application, and rejection of unknown source.
- Desktop test typecheck, documentation generation, and release compatibility checks passed locally.
- Real signing/notarization remains the post-merge release gate.
