### PR TITLE
release: restore approved v0.5.1 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,29 +12,7 @@ All notable changes to OpenAdminOS are recorded here. Format follows [Keep a Cha
 
 ### Fixed
 
-### Security
-
-## [0.5.2] - 2026-09-06
-
-### Added
-
-### Changed
-
-### Removed
-
-### Fixed
-
-- macOS release packaging now uses the generated temporary-keychain password when configuring signing-key access, while retaining each certificate's own import password. This corrects the electron-builder 26.15.3 signing failure without disabling signing, notarization, or artifact verification.
-- Includes the agent lifecycle fixes prepared for 0.5.1: five-minute Microsoft sign-in deadlines, explicit sign-in recovery instructions, execution cancellation that stops later approved actions, scheduled-run and notification authentication safeguards, and recovery of interrupted runs without replaying writes.
-
-### Upgrade notes
-
-- Version 0.5.1 was tagged but not published because macOS signing failed. Version 0.5.2 is the distributable update containing those fixes. The 0.5.1 tag is preserved unchanged.
-- Closing the system browser still requires Cancel run or the sign-in timeout. Requests already sent to Microsoft may have completed; cancellation does not undo those effects.
-
-### Fixed automation
-
-- Release automation explicitly dispatches the version tag, preventing a same-named development branch from being selected instead.
+- Restore the requested v0.5.1 release version and document the explicitly approved withdrawal of v0.5.2.
 
 ### Security
 
@@ -56,6 +34,18 @@ All notable changes to OpenAdminOS are recorded here. Format follows [Keep a Cha
 - Cancel run now interrupts authentication and provider/Graph work and prevents subsequent approved actions. Results from requests already sent remain in the run history; cancellation does not reverse remote changes that already happened.
 - Scheduled agents and their Teams/Outlook notifications return actionable sign-in instructions when credentials or permissions need attention, instead of opening an unattended browser and blocking later runs indefinitely.
 - Restarting the app marks interrupted runs failed with recovery instructions, preserving pending write approvals and avoiding automatic write retries. Provider discovery failures during confirmation leave the plan awaiting approval rather than stranded as running.
+
+### Release reliability
+
+- Corrected macOS signing-key access to use the temporary keychain password, retaining certificate import passwords, signing, notarization, and artifact verification.
+- Release automation selects the explicit version tag even when a development branch has the same name.
+
+### Upgrade and recovery notes
+
+- This is the corrected v0.5.1 release. Version v0.5.2 was published in error and is being withdrawn from public distribution with maintainer approval. Its tag and artifacts are retained for traceability.
+- The previously unpublished v0.5.1 tag is being moved to the corrected, CI-verified release commit with explicit maintainer approval.
+- Existing v0.5.2 installations will not automatically downgrade. Users who need the v0.5.1 version must install it manually; apt also requires an explicit downgrade. Both versions contain the lifecycle fixes.
+- Closing the system browser requires Cancel run or the five-minute sign-in timeout. Cancellation does not undo Microsoft requests already sent.
 
 ### Security
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openadminos/desktop",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.1",
   "description": "Open-source, local-first agents for Microsoft 365 admins.",
   "author": {
     "name": "OpenAdminOS",
@@ -32,9 +32,9 @@
     "@azure/msal-node": "^5.3.1",
     "@microsoft/mxc-sdk": "0.6.1",
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "@openadminos/agent-sdk": "0.5.2",
-    "@openadminos/connector-whatsapp-web": "0.5.2",
-    "@openadminos/runtime": "0.5.2",
+    "@openadminos/agent-sdk": "0.5.1",
+    "@openadminos/connector-whatsapp-web": "0.5.1",
+    "@openadminos/runtime": "0.5.1",
     "electron-updater": "^6.6.2",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1981,3 +1981,14 @@ For context: these exist or are in flight, and may interact with OpenAdminOS ove
 - **IntuneTUI** (deprecated): terminal-based Intune tool. The lesson from this project drove OpenAdminOS' decision to use a desktop GUI instead of a terminal: admins are not developer-y enough for TUIs as a primary surface.
 
 OpenAdminOS is the flagship community project. The others are either narrow paid products (TenantPDF) or instructive prior art.
+
+### Approved v0.5.1 release recovery (2026-09-06)
+
+The maintainer explicitly approved restoring package versions to 0.5.1 while
+retaining the lifecycle and signing fixes, moving the previously unpublished
+v0.5.1 tag to the corrected CI-verified merge commit, and withdrawing the
+mistaken v0.5.2 GitHub Release into draft while preserving its tag and assets.
+The corrected v0.5.1 becomes the latest public release and apt package.
+This is a one-time approved exception, not permission to move other tags or
+reuse v0.5.2 for different source. Installed v0.5.2 copies do not automatically
+downgrade; users requiring 0.5.1 must install it explicitly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openadminos",
-  "version": "0.5.2",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openadminos",
-      "version": "0.5.2",
+      "version": "0.5.1",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -55,15 +55,15 @@
     },
     "apps/desktop": {
       "name": "@openadminos/desktop",
-      "version": "0.5.2",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^5.3.1",
         "@microsoft/mxc-sdk": "0.6.1",
         "@modelcontextprotocol/sdk": "^1.30.0",
-        "@openadminos/agent-sdk": "0.5.2",
-        "@openadminos/connector-whatsapp-web": "0.5.2",
-        "@openadminos/runtime": "0.5.2",
+        "@openadminos/agent-sdk": "0.5.1",
+        "@openadminos/connector-whatsapp-web": "0.5.1",
+        "@openadminos/runtime": "0.5.1",
         "electron-updater": "^6.6.2",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -9785,13 +9785,13 @@
     },
     "packages/agent-sdk": {
       "name": "@openadminos/agent-sdk",
-      "version": "0.5.2"
+      "version": "0.5.1"
     },
     "packages/connector-discord": {
       "name": "@openadminos/connector-discord",
-      "version": "0.5.2",
+      "version": "0.5.1",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.2"
+        "@openadminos/agent-sdk": "0.5.1"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -9804,9 +9804,9 @@
     },
     "packages/connector-outlook": {
       "name": "@openadminos/connector-outlook",
-      "version": "0.5.2",
+      "version": "0.5.1",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.2"
+        "@openadminos/agent-sdk": "0.5.1"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -9819,9 +9819,9 @@
     },
     "packages/connector-signal": {
       "name": "@openadminos/connector-signal",
-      "version": "0.5.2",
+      "version": "0.5.1",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.2"
+        "@openadminos/agent-sdk": "0.5.1"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -9834,9 +9834,9 @@
     },
     "packages/connector-slack": {
       "name": "@openadminos/connector-slack",
-      "version": "0.5.2",
+      "version": "0.5.1",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.2"
+        "@openadminos/agent-sdk": "0.5.1"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -9849,9 +9849,9 @@
     },
     "packages/connector-teams": {
       "name": "@openadminos/connector-teams",
-      "version": "0.5.2",
+      "version": "0.5.1",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.2"
+        "@openadminos/agent-sdk": "0.5.1"
       },
       "devDependencies": {
         "@types/node": "^25.8.0",
@@ -9864,9 +9864,9 @@
     },
     "packages/connector-whatsapp-web": {
       "name": "@openadminos/connector-whatsapp-web",
-      "version": "0.5.2",
+      "version": "0.5.1",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.2",
+        "@openadminos/agent-sdk": "0.5.1",
         "baileys": "7.0.0-rc13",
         "pino": "^10.1.0",
         "qrcode": "^1.5.4"
@@ -9882,9 +9882,9 @@
     },
     "packages/qa-graph": {
       "name": "@openadminos/qa-graph",
-      "version": "0.5.2",
+      "version": "0.5.1",
       "dependencies": {
-        "@openadminos/agent-sdk": "0.5.2",
+        "@openadminos/agent-sdk": "0.5.1",
         "ajv": "^8.17.1",
         "js-yaml": "^4.1.1"
       },
@@ -9900,16 +9900,16 @@
     },
     "packages/runtime": {
       "name": "@openadminos/runtime",
-      "version": "0.5.2",
+      "version": "0.5.1",
       "dependencies": {
         "@azure/msal-node": "^5.2.1",
-        "@openadminos/agent-sdk": "0.5.2",
-        "@openadminos/connector-discord": "0.5.2",
-        "@openadminos/connector-outlook": "0.5.2",
-        "@openadminos/connector-signal": "0.5.2",
-        "@openadminos/connector-slack": "0.5.2",
-        "@openadminos/connector-teams": "0.5.2",
-        "@openadminos/connector-whatsapp-web": "0.5.2",
+        "@openadminos/agent-sdk": "0.5.1",
+        "@openadminos/connector-discord": "0.5.1",
+        "@openadminos/connector-outlook": "0.5.1",
+        "@openadminos/connector-signal": "0.5.1",
+        "@openadminos/connector-slack": "0.5.1",
+        "@openadminos/connector-teams": "0.5.1",
+        "@openadminos/connector-whatsapp-web": "0.5.1",
         "js-yaml": "^4.1.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openadminos",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.1",
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/agent-sdk",
-  "version": "0.5.2",
+  "version": "0.5.1",
   "type": "module",
   "description": "Shared TypeScript contracts for OpenAdminOS packages.",
   "main": "./dist/index.js",

--- a/packages/connector-discord/package.json
+++ b/packages/connector-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-discord",
-  "version": "0.5.2",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "description": "Discord connector for OpenAdminOS. Sends outbound notification messages through a Discord channel webhook.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.2"
+    "@openadminos/agent-sdk": "0.5.1"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-outlook/package.json
+++ b/packages/connector-outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-outlook",
-  "version": "0.5.2",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "description": "Outlook connector for OpenAdminOS. Sends outbound notification email through Microsoft Graph using the active tenant's delegated MSAL token.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.2"
+    "@openadminos/agent-sdk": "0.5.1"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-signal/package.json
+++ b/packages/connector-signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-signal",
-  "version": "0.5.2",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "description": "Signal connector for OpenAdminOS. Sends outbound notification messages through signal-cli or a local signal-cli REST bridge.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.2"
+    "@openadminos/agent-sdk": "0.5.1"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-slack/package.json
+++ b/packages/connector-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-slack",
-  "version": "0.5.2",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "description": "Slack connector for OpenAdminOS. Sends outbound notification messages through a Slack bot token.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.2"
+    "@openadminos/agent-sdk": "0.5.1"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-teams/package.json
+++ b/packages/connector-teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-teams",
-  "version": "0.5.2",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "description": "Microsoft Teams connector for OpenAdminOS. Posts channel and chat messages via Microsoft Graph using the active tenant's delegated MSAL token.",
@@ -24,7 +24,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.2"
+    "@openadminos/agent-sdk": "0.5.1"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/connector-whatsapp-web/package.json
+++ b/packages/connector-whatsapp-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/connector-whatsapp-web",
-  "version": "0.5.2",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "description": "WhatsApp Web connector for OpenAdminOS. Sends outbound notification messages through a locally linked WhatsApp Web session.",
@@ -21,7 +21,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.2",
+    "@openadminos/agent-sdk": "0.5.1",
     "baileys": "7.0.0-rc13",
     "pino": "^10.1.0",
     "qrcode": "^1.5.4"

--- a/packages/qa-graph/package.json
+++ b/packages/qa-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/qa-graph",
-  "version": "0.5.2",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -14,7 +14,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@openadminos/agent-sdk": "0.5.2",
+    "@openadminos/agent-sdk": "0.5.1",
     "ajv": "^8.17.1",
     "js-yaml": "^4.1.1"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openadminos/runtime",
-  "version": "0.5.2",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -21,13 +21,13 @@
   },
   "dependencies": {
     "@azure/msal-node": "^5.2.1",
-    "@openadminos/agent-sdk": "0.5.2",
-    "@openadminos/connector-discord": "0.5.2",
-    "@openadminos/connector-outlook": "0.5.2",
-    "@openadminos/connector-signal": "0.5.2",
-    "@openadminos/connector-slack": "0.5.2",
-    "@openadminos/connector-teams": "0.5.2",
-    "@openadminos/connector-whatsapp-web": "0.5.2",
+    "@openadminos/agent-sdk": "0.5.1",
+    "@openadminos/connector-discord": "0.5.1",
+    "@openadminos/connector-outlook": "0.5.1",
+    "@openadminos/connector-signal": "0.5.1",
+    "@openadminos/connector-slack": "0.5.1",
+    "@openadminos/connector-teams": "0.5.1",
+    "@openadminos/connector-whatsapp-web": "0.5.1",
     "js-yaml": "^4.1.1"
   },
   "optionalDependencies": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openadminos-website",
-  "version": "0.5.2",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openadminos-website",
-      "version": "0.5.2",
+      "version": "0.5.1",
       "dependencies": {
         "@octokit/rest": "^21.1.1",
         "@t3-oss/env-nextjs": "^0.13.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openadminos-website",
-  "version": "0.5.2",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Restore the maintainer-requested version 0.5.1 across all packages and lockfiles while retaining the lifecycle audit, cancellation fixes, macOS signing correction, and explicit tag dispatch.

Document the approved one-time recovery: move the unpublished v0.5.1 tag only after this merge passes CI, publish corrected installers, then withdraw the mistaken v0.5.2 release into draft while retaining its tag and assets. Existing v0.5.2 installations require a manual downgrade if users want 0.5.1.

Validation: release compatibility and generated documentation checks passed locally. Full PR CI must pass before merge.
